### PR TITLE
chore: Spring Boot Actuator 설정

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     implementation project(':cherrypic-common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }

--- a/cherrypic-api/src/main/resources/application.yml
+++ b/cherrypic-api/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+management:
+  endpoints:
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health
+      base-path: /cherrypic-actuator
+    access:
+      default: none
+  endpoint:
+    health:
+      access: unrestricted


### PR DESCRIPTION
## 🌱 관련 이슈
- close #7 

---
## 📌 작업 내용 및 특이사항
* /cherrypic-actuator/health로 헬스 체크를 할 수 있습니다.
* actuator 보안 설정을 추가하였습니다.
  * 기본적으로 모든 엔드포인트를 비활성화했습니다. (enabled-by-default는 deprecated로 인해 access-default)
  * health 엔드포인트만 활성화했습니다.
  * JMX 엔드포인트는 모두 비활성화하고, health 엔드포인트만 노출하도록 설정했습니다.
  * actuator 기본 경로를 /cherrypic-actuator/health로 변경하였습니다.