### PR TITLE
feat: BaseTimeEntity 및 JPA Auditing 설정

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -8,4 +8,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
 }

--- a/cherrypic-batch/build.gradle
+++ b/cherrypic-batch/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     implementation project(':cherrypic-common')
 //    implementation 'org.springframework.boot:spring-boot-starter-batch'
 //    testImplementation 'org.springframework.batch:spring-batch-test'
+    runtimeOnly 'com.h2database:h2'
 }

--- a/cherrypic-domain/build.gradle
+++ b/cherrypic-domain/build.gradle
@@ -4,4 +4,5 @@ jar {
 
 dependencies {
     implementation project(':cherrypic-common')
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/common/config/JpaAuditingConfig.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/common/config/JpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package org.cherrypic.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {}

--- a/cherrypic-domain/src/main/java/org/cherrypic/common/model/BaseTimeEntity.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/common/model/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package org.cherrypic.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate private LocalDateTime updatedAt;
+}

--- a/cherrypic-domain/src/main/resources/application.yml
+++ b/cherrypic-domain/src/main/resources/application.yml
@@ -1,1 +1,0 @@
-spring.application.name=cherrypic-domain


### PR DESCRIPTION
## 🌱 관련 이슈
- close #13 

---
## 📌 작업 내용 및 특이사항
* JPA Auditing을 적용하여 엔티티의 생성일과 수정일을 자동으로 관리하도록 구성하였습니다.
* BaseTimeEntity를 정의하여 엔티티에서 생성일·수정일 필드를 공통적으로 상속받아 사용할 수 있도록 하였습니다.
