### PR TITLE
chore: Swagger 설정

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -10,4 +10,5 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/SwaggerConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package org.cherrypic.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +24,26 @@ public class SwaggerConfig {
                         new Info()
                                 .title("CherryPic Server API")
                                 .description("CherryPic Server API 명세서입니다.")
-                                .version("v0.0.1"));
+                                .version("v0.0.1"))
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList("accessToken");
+        return securityRequirement;
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/SwaggerConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package org.cherrypic.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder().group("v1").pathsToMatch("/**").build();
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("CherryPic Server API")
+                                .description("CherryPic Server API 명세서입니다.")
+                                .version("v0.0.1"));
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
@@ -5,17 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-
-    @Bean
-    public GroupedOpenApi publicApi() {
-        return GroupedOpenApi.builder().group("v1").pathsToMatch("/**").build();
-    }
 
     @Bean
     public OpenAPI openAPI() {

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package org.cherrypic.global.config;
+package org.cherrypic.global.config.swagger;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
@@ -5,11 +5,18 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.helper.SpringEnvironmentHelper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
+
+    private final SpringEnvironmentHelper springEnvironmentHelper;
 
     @Bean
     public OpenAPI openAPI() {
@@ -19,8 +26,21 @@ public class SwaggerConfig {
                                 .title("CherryPic Server API")
                                 .description("CherryPic Server API 명세서입니다.")
                                 .version("v0.0.1"))
+                .servers(initializeSwaggerServers())
                 .components(authSetting())
                 .addSecurityItem(securityRequirement());
+    }
+
+    private List<Server> initializeSwaggerServers() {
+        return List.of(new Server().url(resolveServerUrlByProfile()));
+    }
+
+    private String resolveServerUrlByProfile() {
+        return switch (springEnvironmentHelper.getCurrentProfile()) {
+            case "prod" -> "https://api.cherrypic.today";
+            case "dev" -> "https://dev-api.cherrypic.today";
+            default -> "http://localhost:8080";
+        };
     }
 
     private Components authSetting() {

--- a/cherrypic-api/src/main/resources/application.yml
+++ b/cherrypic-api/src/main/resources/application.yml
@@ -12,3 +12,12 @@ management:
   endpoint:
     health:
       access: unrestricted
+
+spring-doc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter : method
+    path: /swagger-ui
+    doc-expansion : none


### PR DESCRIPTION
## 🌱 관련 이슈
- close #11 

---
## 📌 작업 내용 및 특이사항
* Swagger(SpringDoc OpenAPI)를 설정하였습니다.
  * SwaggerConfig를 추가하여 API 그룹, 기본 정보(title, description, version)를 정의하였습니다.
  * JWT Bearer 인증 스키마를 적용하여 Swagger UI에서 Authorization 헤더에 액세스 토큰을 입력하면 이후 요청에 자동으로 포함되도록 구성하였습니다.
* Swagger UI 옵션을 application.yml에 정의하였습니다.
  * 기본 consume/produce 미디어 타입을 application/json으로 설정하였습니다.
  * UI 정렬(tags-sorter: alpha, operations-sorter: method), 경로(path: /swagger-ui), 초기 상태(doc-expansion: none)를 설정하였습니다.

---
## 📚 참고사항
* Swagger 보안(ID/PW) 설정은 추후 별도 이슈로 진행할 예정입니다.