### PR TITLE
chore: SpringEnvironmentHelper 추가

### DIFF
--- a/cherrypic-common/src/main/java/org/cherrypic/helper/SpringEnvironmentHelper.java
+++ b/cherrypic-common/src/main/java/org/cherrypic/helper/SpringEnvironmentHelper.java
@@ -1,0 +1,37 @@
+package org.cherrypic.helper;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpringEnvironmentHelper {
+
+    private final Environment environment;
+
+    private static final String PROD = "prod";
+    private static final String DEV = "dev";
+    private static final String LOCAL = "local";
+
+    public String getCurrentProfile() {
+        return getActiveProfiles()
+                .filter(profile -> profile.equals(PROD) || profile.equals(DEV))
+                .findFirst()
+                .orElse(LOCAL);
+    }
+
+    public boolean isProdProfile() {
+        return getActiveProfiles().anyMatch(PROD::equals);
+    }
+
+    public boolean isDevProfile() {
+        return getActiveProfiles().anyMatch(DEV::equals);
+    }
+
+    private Stream<String> getActiveProfiles() {
+        return Arrays.stream(environment.getActiveProfiles());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #21 

---
## 📌 작업 내용 및 특이사항
* SpringEnvironmentHelper 클래스를 추가하여 현재 활성화된 Spring profile(prod, dev, local)을 조회할 수 있도록 하였습니다.
* isProdProfile, isDevProfile, getCurrentProfile 메서드를 통해 profile 조건 분기에 활용할 수 있습니다.
 
---
## 📚 참고사항
* SpringEnvironmentHelper는 SecurityConfig, SwaggerConfig 등 profile 분기에 따라 설정이 달라지는 클래스에서 활용할 예정입니다.