### PR TITLE
chore: Spring Security 설정

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -11,4 +11,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.cherrypic.helper.SpringEnvironmentHelper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,6 +32,22 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+    }
+
+    @Bean
+    @Order(1)
+    @Profile({"dev", "local"})
+    public SecurityFilterChain swaggerFilterChain(HttpSecurity http) throws Exception {
+        defaultFilterChain(http);
+
+        http.securityMatcher("/swagger-ui/**", "/v3/api-docs/**").httpBasic(withDefaults());
+
+        http.authorizeHttpRequests(
+                springEnvironmentHelper.isProdProfile() || springEnvironmentHelper.isDevProfile()
+                        ? auth -> auth.anyRequest().authenticated()
+                        : auth -> auth.anyRequest().permitAll());
+
+        return http.build();
     }
 
     @Bean

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
@@ -1,0 +1,74 @@
+package org.cherrypic.global.config.security;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.helper.SpringEnvironmentHelper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+
+    private void defaultFilterChain(HttpSecurity http) throws Exception {
+        http.httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        defaultFilterChain(http);
+
+        http.authorizeHttpRequests(
+                auth ->
+                        auth.requestMatchers("/cherrypic-actuator/**")
+                                .permitAll()
+                                .anyRequest()
+                                .authenticated());
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        if (springEnvironmentHelper.isProdProfile()) {
+            configuration.setAllowedOriginPatterns(List.of("https://cherrypic.today"));
+        }
+
+        if (springEnvironmentHelper.isDevProfile()) {
+            configuration.setAllowedOriginPatterns(
+                    List.of(
+                            "https://dev.cherrypic.today",
+                            "https://dev-api.cherrypic.today",
+                            "http://localhost:3000"));
+        }
+
+        configuration.setAllowedMethods(
+                List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #16 

---
## 📌 작업 내용 및 특이사항
* Spring Security 기본 설정을 추가하였습니다.
* Stateless 세션 정책과 CSRF, FormLogin, BasicAuth 비활성화를 적용하였습니다.
* CORS 정책을 환경별로 분기하여 설정하였습니다.
* dev, local 환경에서 Swagger 접근을 허용하는 SecurityFilterChain을 추가하였습니다.