### PR TITLE
feat: OIDC 소셜 로그인 SDK 기반 구현

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -16,4 +16,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
 }

--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -18,4 +18,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     implementation 'org.springframework.security:spring-security-oauth2-jose'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
@@ -1,0 +1,37 @@
+package org.cherrypic.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
+import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.service.AuthService;
+import org.cherrypic.domain.auth.util.CookieUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Tag(name = "1-1. 인증 API", description = "인증 관련 API입니다.")
+public class AuthController {
+
+    private final AuthService authService;
+    private final CookieUtil cookieUtil;
+
+    @PostMapping("/social-login")
+    @Operation(summary = "소셜 로그인", description = "소셜 로그인을 진행합니다.")
+    public ResponseEntity<Void> memberSocialLogin(
+            @RequestParam(name = "oauthProvider") OauthProvider provider,
+            @Valid @RequestBody IdTokenRequest request) {
+        SocialLoginResponse response = authService.socialLoginMember(provider, request);
+
+        HttpHeaders headers =
+                cookieUtil.generateTokenCookies(response.accessToken(), response.refreshToken());
+
+        return ResponseEntity.noContent().headers(headers).build();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
@@ -6,7 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
-import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.enums.OauthProvider;
 import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.util.CookieUtil;
 import org.springframework.http.HttpHeaders;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/AccessTokenDto.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.auth.dto;
+
+import org.cherrypic.member.enums.MemberRole;
+
+public record AccessTokenDto(Long memberId, MemberRole role, String accessTokenValue) {
+    public static AccessTokenDto of(Long memberId, MemberRole role, String accessTokenValue) {
+        return new AccessTokenDto(memberId, role, accessTokenValue);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/RefreshTokenDto.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.auth.dto;
+
+public record RefreshTokenDto(Long memberId, String refreshTokenValue, Long ttl) {
+    public static RefreshTokenDto of(Long memberId, String refreshTokenValue, Long ttl) {
+        return new RefreshTokenDto(memberId, refreshTokenValue, ttl);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/request/IdTokenRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/request/IdTokenRequest.java
@@ -1,0 +1,8 @@
+package org.cherrypic.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record IdTokenRequest(
+        @NotBlank(message = "Id Token은 비워둘 수 없습니다.") @Schema(description = "Id Token")
+                String idToken) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/response/SocialLoginResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/response/SocialLoginResponse.java
@@ -1,0 +1,11 @@
+package org.cherrypic.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SocialLoginResponse(
+        @Schema(description = "Access Token") String accessToken,
+        @Schema(description = "Refresh Token") String refreshToken) {
+    public static SocialLoginResponse of(String accessToken, String refreshToken) {
+        return new SocialLoginResponse(accessToken, refreshToken);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/entity/OauthProvider.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/entity/OauthProvider.java
@@ -1,0 +1,6 @@
+package org.cherrypic.domain.auth.entity;
+
+public enum OauthProvider {
+    KAKAO,
+    APPLE
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/enums/OauthProvider.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/enums/OauthProvider.java
@@ -1,4 +1,4 @@
-package org.cherrypic.domain.auth.entity;
+package org.cherrypic.domain.auth.enums;
 
 public enum OauthProvider {
     KAKAO,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.auth.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+    ID_TOKEN_VERIFICATION_FAILED(401, "ID 토큰 검증에 실패했습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthException.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.auth.exception;
+
+import org.cherrypic.exception.BaseCustomException;
+
+public class AuthException extends BaseCustomException {
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/jwt/JwtUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/jwt/JwtUtil.java
@@ -1,0 +1,65 @@
+package org.cherrypic.domain.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.jwt.JwtProperties;
+import org.cherrypic.member.enums.MemberRole;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+
+    public String generateAccessToken(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.refreshTokenExpirationTime();
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
+    }
+
+    private String buildAccessToken(
+            Long memberId, MemberRole memberRole, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .claim("role", memberRole.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(Long memberId, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.auth.service;
+
+import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
+import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.entity.OauthProvider;
+
+public interface AuthService {
+    SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
@@ -2,7 +2,7 @@ package org.cherrypic.domain.auth.service;
 
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
-import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.enums.OauthProvider;
 
 public interface AuthService {
     SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,56 @@
+package org.cherrypic.domain.auth.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
+import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.member.repository.MemberRepository;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+    private final MemberRepository memberRepository;
+    private final IdTokenVerifier idTokenVerifier;
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    public SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request) {
+        OidcUser oidcUser = idTokenVerifier.getOidcUser(request.idToken(), provider);
+
+        Optional<Member> optionalMember = findByOidcUser(oidcUser);
+        Member member = optionalMember.orElseGet(() -> saveMember(oidcUser));
+
+        return getLoginResponse(member);
+    }
+
+    private SocialLoginResponse getLoginResponse(Member member) {
+        String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtTokenService.createRefreshToken(member.getId());
+        return SocialLoginResponse.of(accessToken, refreshToken);
+    }
+
+    private Member saveMember(OidcUser oidcUser) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+
+        Member member =
+                Member.createMember(oauthInfo, oidcUser.getNickName(), oidcUser.getPicture());
+        return memberRepository.save(member);
+    }
+
+    private Optional<Member> findByOidcUser(OidcUser oidcUser) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+        return memberRepository.findByOauthInfo(oauthInfo);
+    }
+
+    private OauthInfo extractOauthInfo(OidcUser oidcUser) {
+        return OauthInfo.createOauthInfo(oidcUser.getSubject(), oidcUser.getIssuer().toString());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
 import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.util.NicknameGenerator;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
@@ -20,6 +21,7 @@ public class AuthServiceImpl implements AuthService {
     private final MemberRepository memberRepository;
     private final IdTokenVerifier idTokenVerifier;
     private final JwtTokenService jwtTokenService;
+    private final NicknameGenerator nicknameGenerator;
 
     @Override
     public SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request) {
@@ -41,7 +43,8 @@ public class AuthServiceImpl implements AuthService {
         OauthInfo oauthInfo = extractOauthInfo(oidcUser);
 
         Member member =
-                Member.createMember(oauthInfo, oidcUser.getNickName(), oidcUser.getPicture());
+                Member.createMember(
+                        oauthInfo, nicknameGenerator.generateNickname(), oidcUser.getPicture());
         return memberRepository.save(member);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
-import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.enums.OauthProvider;
 import org.cherrypic.domain.auth.util.NicknameGenerator;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/IdTokenVerifier.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/IdTokenVerifier.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.auth.service;
 
+import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +21,15 @@ import org.springframework.stereotype.Component;
 public class IdTokenVerifier {
 
     private final OidcProperties oidcProperties;
+    private Map<OauthProvider, JwtDecoder> decoders;
 
-    private final Map<OauthProvider, JwtDecoder> decoders =
-            Map.of(
-                    OauthProvider.KAKAO, buildDecoder(oidcProperties.kakao().jwkSetUri()),
-                    OauthProvider.APPLE, buildDecoder(oidcProperties.apple().jwkSetUri()));
+    @PostConstruct
+    private void initDecoders() {
+        this.decoders =
+                Map.of(
+                        OauthProvider.KAKAO, buildDecoder(oidcProperties.kakao().jwkSetUri()),
+                        OauthProvider.APPLE, buildDecoder(oidcProperties.apple().jwkSetUri()));
+    }
 
     private JwtDecoder buildDecoder(String jwkSetUrl) {
         return NimbusJwtDecoder.withJwkSetUri(jwkSetUrl).build();

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/IdTokenVerifier.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/IdTokenVerifier.java
@@ -1,0 +1,88 @@
+package org.cherrypic.domain.auth.service;
+
+import java.time.Instant;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.exception.AuthErrorCode;
+import org.cherrypic.domain.auth.exception.AuthException;
+import org.cherrypic.oidc.OidcProperties;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IdTokenVerifier {
+
+    private final OidcProperties oidcProperties;
+
+    private final Map<OauthProvider, JwtDecoder> decoders =
+            Map.of(
+                    OauthProvider.KAKAO, buildDecoder(oidcProperties.kakao().jwkSetUri()),
+                    OauthProvider.APPLE, buildDecoder(oidcProperties.apple().jwkSetUri()));
+
+    private JwtDecoder buildDecoder(String jwkSetUrl) {
+        return NimbusJwtDecoder.withJwkSetUri(jwkSetUrl).build();
+    }
+
+    public OidcUser getOidcUser(String idToken, OauthProvider provider) {
+        Jwt jwt = getJwt(idToken, provider);
+        OidcIdToken oidcIdToken = getOidcIdToken(jwt);
+
+        String audience =
+                switch (provider) {
+                    case KAKAO -> oidcProperties.kakao().audience();
+                    case APPLE -> oidcProperties.apple().audience();
+                };
+
+        String issuer =
+                switch (provider) {
+                    case KAKAO -> oidcProperties.kakao().issuer();
+                    case APPLE -> oidcProperties.apple().issuer();
+                };
+
+        validateAudience(oidcIdToken, audience);
+        validateIssuer(oidcIdToken, issuer);
+        validateExpiresAt(oidcIdToken);
+
+        return new DefaultOidcUser(null, oidcIdToken);
+    }
+
+    private Jwt getJwt(String idToken, OauthProvider provider) {
+        return decoders.get(provider).decode(idToken);
+    }
+
+    private OidcIdToken getOidcIdToken(Jwt jwt) {
+        return new OidcIdToken(
+                jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+    }
+
+    private void validateAudience(OidcIdToken oidcIdToken, String targetAudience) {
+        String audience = oidcIdToken.getAudience().getFirst();
+
+        if (!targetAudience.equals(audience)) {
+            throw new AuthException(AuthErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateIssuer(OidcIdToken oidcIdToken, String targetIssuer) {
+        String issuer = oidcIdToken.getIssuer().toString();
+
+        if (!targetIssuer.equals(issuer)) {
+            throw new AuthException(AuthErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateExpiresAt(OidcIdToken oidcIdToken) {
+        Instant expiresAt = oidcIdToken.getExpiresAt();
+
+        if (expiresAt == null || expiresAt.isBefore(Instant.now())) {
+            throw new AuthException(AuthErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/IdTokenVerifier.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/IdTokenVerifier.java
@@ -4,7 +4,7 @@ import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.enums.OauthProvider;
 import org.cherrypic.domain.auth.exception.AuthErrorCode;
 import org.cherrypic.domain.auth.exception.AuthException;
 import org.cherrypic.oidc.OidcProperties;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
@@ -1,0 +1,33 @@
+package org.cherrypic.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.auth.entity.RefreshToken;
+import org.cherrypic.auth.repository.RefreshTokenRepository;
+import org.cherrypic.domain.auth.util.JwtUtil;
+import org.cherrypic.member.enums.MemberRole;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createAccessToken(Long memberId, MemberRole memberRole) {
+        return jwtUtil.generateAccessToken(memberId, memberRole);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String token = jwtUtil.generateRefreshToken(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(token)
+                        .ttl(jwtUtil.getRefreshTokenExpirationTime())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return token;
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/CookieUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/CookieUtil.java
@@ -1,0 +1,52 @@
+package org.cherrypic.domain.auth.util;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.helper.SpringEnvironmentHelper;
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtil {
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+
+    public HttpHeaders generateTokenCookies(String accessToken, String refreshToken) {
+        String sameSite = determineSameSitePolicy();
+
+        ResponseCookie accessTokenCookie =
+                ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .build();
+
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
+    private String determineSameSitePolicy() {
+        if (springEnvironmentHelper.isProdProfile()) {
+            return Cookie.SameSite.STRICT.attributeValue();
+        }
+
+        return Cookie.SameSite.NONE.attributeValue();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
@@ -1,4 +1,4 @@
-package org.cherrypic.domain.auth.jwt;
+package org.cherrypic.domain.auth.util;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/NicknameGenerator.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/NicknameGenerator.java
@@ -1,0 +1,32 @@
+package org.cherrypic.domain.auth.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NicknameGenerator {
+
+    private static final String[] PREFIX_NAMES = {
+        "귀여운", "졸린", "행복한", "멋진", "배고픈",
+        "활발한", "조용한", "용감한", "상냥한", "차분한",
+        "명랑한", "신나는", "엉뚱한", "불타는", "우아한",
+        "재빠른", "신비한", "웃긴", "똑똑한", "천재적인",
+        "수줍은", "반짝이는", "느긋한", "예민한", "호기심많은"
+    };
+
+    private static final String[] ANIMAL_NAMES = {
+        "사자", "호랑이", "토끼", "펭귄", "너구리",
+        "고양이", "강아지", "코끼리", "기린", "판다",
+        "올빼미", "햄스터", "하마", "여우", "고슴도치",
+        "수달", "공작", "앵무새", "두더지", "독수리",
+        "타조", "다람쥐", "카피바라", "알파카", "라마",
+        "북극곰", "늑대", "퓨마", "이구아나", "돌고래"
+    };
+
+    public String generateNickname() {
+        int animalIndex = ThreadLocalRandom.current().nextInt(ANIMAL_NAMES.length);
+        int prefixIndex = ThreadLocalRandom.current().nextInt(PREFIX_NAMES.length);
+
+        return PREFIX_NAMES[prefixIndex] + " " + ANIMAL_NAMES[animalIndex];
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
@@ -58,6 +58,8 @@ public class SecurityConfig {
                 auth ->
                         auth.requestMatchers("/cherrypic-actuator/**")
                                 .permitAll()
+                                .requestMatchers("/auth/**")
+                                .permitAll()
                                 .anyRequest()
                                 .authenticated());
 

--- a/cherrypic-api/src/main/resources/application-dev.yml
+++ b/cherrypic-api/src/main/resources/application-dev.yml
@@ -30,6 +30,13 @@ oidc:
     issuer: https://appleid.apple.com
     audience: ${APPLE_SERVICE_ID:}
 
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  issuer: ${JWT_ISSUER}
+
 spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/cherrypic-api/src/main/resources/application-dev.yml
+++ b/cherrypic-api/src/main/resources/application-dev.yml
@@ -20,6 +20,16 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
 
+oidc:
+  kakao:
+    jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
+    issuer: https://kauth.kakao.com
+    audience: ${KAKAO_NATIVE_APP_KEY:}
+  apple:
+    jwk-set-uri: https://appleid.apple.com/auth/keys
+    issuer: https://appleid.apple.com
+    audience: ${APPLE_SERVICE_ID:}
+
 spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/cherrypic-api/src/main/resources/application-local.yml
+++ b/cherrypic-api/src/main/resources/application-local.yml
@@ -30,6 +30,13 @@ oidc:
     issuer: https://appleid.apple.com
     audience: ${APPLE_SERVICE_ID:}
 
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  issuer: ${JWT_ISSUER}
+
 spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/cherrypic-api/src/main/resources/application-local.yml
+++ b/cherrypic-api/src/main/resources/application-local.yml
@@ -20,6 +20,16 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
 
+oidc:
+  kakao:
+    jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
+    issuer: https://kauth.kakao.com
+    audience: ${KAKAO_NATIVE_APP_KEY:}
+  apple:
+    jwk-set-uri: https://appleid.apple.com/auth/keys
+    issuer: https://appleid.apple.com
+    audience: ${APPLE_SERVICE_ID:}
+
 spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/cherrypic-api/src/main/resources/application-prod.yml
+++ b/cherrypic-api/src/main/resources/application-prod.yml
@@ -19,3 +19,13 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+
+oidc:
+  kakao:
+    jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
+    issuer: https://kauth.kakao.com
+    audience: ${KAKAO_NATIVE_APP_KEY:}
+  apple:
+    jwk-set-uri: https://appleid.apple.com/auth/keys
+    issuer: https://appleid.apple.com
+    audience: ${APPLE_SERVICE_ID:}

--- a/cherrypic-api/src/main/resources/application-prod.yml
+++ b/cherrypic-api/src/main/resources/application-prod.yml
@@ -29,3 +29,10 @@ oidc:
     jwk-set-uri: https://appleid.apple.com/auth/keys
     issuer: https://appleid.apple.com
     audience: ${APPLE_SERVICE_ID:}
+
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  issuer: ${JWT_ISSUER}

--- a/cherrypic-api/src/test/java/org/cherrypic/DatabaseCleaner.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/DatabaseCleaner.java
@@ -3,6 +3,7 @@ package org.cherrypic;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -39,10 +40,23 @@ public class DatabaseCleaner implements InitializingBean {
 
         for (String name : tableNames) {
             statement.executeUpdate(String.format("TRUNCATE TABLE %s", name));
-            statement.executeUpdate(
-                    String.format("ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1", name, name));
+            if (columnExists(conn, name, name)) {
+                statement.executeUpdate(
+                        String.format(
+                                "ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1", name, name));
+            }
         }
 
         statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    private boolean columnExists(Connection conn, String tableName, String columnName)
+            throws SQLException {
+        try (ResultSet rs =
+                conn.getMetaData()
+                        .getColumns(
+                                null, null, tableName.toUpperCase(), columnName.toUpperCase())) {
+            return rs.next();
+        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
@@ -1,0 +1,98 @@
+package org.cherrypic.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.domain.auth.controller.AuthController;
+import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
+import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.service.AuthService;
+import org.cherrypic.domain.auth.util.CookieUtil;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private AuthService authService;
+
+    @MockitoBean private CookieUtil cookieUtil;
+
+    @Nested
+    class 소셜_로그인할_때 {
+
+        @Test
+        void 유효한_ID_토큰이면_소셜_로그인에_성공한다() throws Exception {
+            // given
+            IdTokenRequest request = new IdTokenRequest("testIdTokenValue");
+
+            SocialLoginResponse response =
+                    new SocialLoginResponse("fake-access-token", "fake-refresh-token");
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.SET_COOKIE, "accessToken=fake-access-token");
+            headers.add(HttpHeaders.SET_COOKIE, "refreshToken=fake-refresh-token");
+
+            given(authService.socialLoginMember(eq(OauthProvider.KAKAO), any()))
+                    .willReturn(response);
+            given(cookieUtil.generateTokenCookies(response.accessToken(), response.refreshToken()))
+                    .willReturn(headers);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/auth/social-login")
+                                    .param("oauthProvider", "KAKAO")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(cookie().exists("accessToken"))
+                    .andExpect(cookie().exists("refreshToken"));
+        }
+
+        @Test
+        void ID_토큰이_blank이면_예외가_발생한다() throws Exception {
+            // given
+            IdTokenRequest request = new IdTokenRequest("");
+
+            SocialLoginResponse response =
+                    new SocialLoginResponse("fake-access-token", "fake-refresh-token");
+
+            given(authService.socialLoginMember(eq(OauthProvider.KAKAO), any()))
+                    .willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/auth/social-login")
+                                    .param("oauthProvider", "KAKAO")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("Id Token은 비워둘 수 없습니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.auth.controller.AuthController;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
-import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.enums.OauthProvider;
 import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.util.CookieUtil;
 import org.junit.jupiter.api.Nested;

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -41,7 +41,8 @@ public class AuthServiceTest extends IntegrationTest {
         @Test
         void 유효한_ID_토큰이면_소셜_로그인에_성공한다() {
             // given
-            given(idTokenVerifier.getOidcUser(anyString(), any())).willReturn(mockOidcUser());
+            given(idTokenVerifier.getOidcUser(anyString(), any()))
+                    .willReturn(mockOidcUser("kakao-sub-001", "https://kauth.kakao.com"));
             given(jwtTokenService.createAccessToken(anyLong(), any(MemberRole.class)))
                     .willReturn("fake-access-token");
             given(jwtTokenService.createRefreshToken(anyLong())).willReturn("fake-refresh-token");
@@ -61,7 +62,8 @@ public class AuthServiceTest extends IntegrationTest {
         @Test
         void 처음_로그인하는_회원이면_회원_정보를_저장한다() {
             // given
-            given(idTokenVerifier.getOidcUser(anyString(), any())).willReturn(mockOidcUser());
+            given(idTokenVerifier.getOidcUser(anyString(), any()))
+                    .willReturn(mockOidcUser("apple-sub-001", "https://appleid.apple.com"));
             given(jwtTokenService.createAccessToken(anyLong(), any(MemberRole.class)))
                     .willReturn("fake-access-token");
             given(jwtTokenService.createRefreshToken(anyLong())).willReturn("fake-refresh-token");
@@ -80,13 +82,13 @@ public class AuthServiceTest extends IntegrationTest {
                     () -> assertThat(member.getStatus()).isEqualTo(MemberStatus.NORMAL));
         }
 
-        private OidcUser mockOidcUser() {
+        private OidcUser mockOidcUser(String sub, String iss) {
             OidcIdToken idToken =
                     new OidcIdToken(
                             "fake-id-token",
                             Instant.now(),
                             Instant.now().plusSeconds(3600),
-                            Map.of("sub", "testOauthId", "iss", "https://test.oauth.provider"));
+                            Map.of("sub", sub, "iss", iss));
 
             return new DefaultOidcUser(List.of(), idToken);
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
-import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.enums.OauthProvider;
 import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.service.IdTokenVerifier;
 import org.cherrypic.domain.auth.service.JwtTokenService;

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -43,7 +43,7 @@ public class AuthServiceTest extends IntegrationTest {
         void setUp() {
             Member member =
                     Member.createMember(
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            OauthInfo.createOauthInfo("testOauthId", "https://test.oauth.provider"),
                             "testNickname",
                             "testProfileImageUrl");
             memberRepository.save(member);
@@ -75,7 +75,7 @@ public class AuthServiceTest extends IntegrationTest {
                             "fake-id-token",
                             Instant.now(),
                             Instant.now().plusSeconds(3600),
-                            Map.of("sub", "testOauthId", "iss", "testOauthProvider"));
+                            Map.of("sub", "testOauthId", "iss", "https://test.oauth.provider"));
 
             return new DefaultOidcUser(List.of(), idToken);
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -17,6 +17,7 @@ import org.cherrypic.domain.auth.service.JwtTokenService;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.enums.MemberRole;
+import org.cherrypic.member.enums.MemberStatus;
 import org.cherrypic.member.repository.MemberRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,6 +68,28 @@ public class AuthServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(response.accessToken()).isEqualTo("fake-access-token"),
                     () -> assertThat(response.refreshToken()).isEqualTo("fake-refresh-token"));
+        }
+
+        @Test
+        void 처음_로그인하는_회원이면_회원_정보를_저장한다() {
+            // given
+            given(idTokenVerifier.getOidcUser(anyString(), any())).willReturn(mockOidcUser());
+            given(jwtTokenService.createAccessToken(anyLong(), any(MemberRole.class)))
+                    .willReturn("fake-access-token");
+            given(jwtTokenService.createRefreshToken(anyLong())).willReturn("fake-refresh-token");
+
+            IdTokenRequest request = new IdTokenRequest("testIdTokenValue");
+
+            // when
+            authService.socialLoginMember(OauthProvider.KAKAO, request);
+
+            // then
+            Member member = memberRepository.findById(1L).get();
+            Assertions.assertAll(
+                    () -> assertThat(member.getId()).isEqualTo(1L),
+                    () -> assertThat(member.getNickname()).isNotNull(),
+                    () -> assertThat(member.getRole()).isEqualTo(MemberRole.USER),
+                    () -> assertThat(member.getStatus()).isEqualTo(MemberStatus.NORMAL));
         }
 
         private OidcUser mockOidcUser() {

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -15,12 +15,10 @@ import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.service.IdTokenVerifier;
 import org.cherrypic.domain.auth.service.JwtTokenService;
 import org.cherrypic.member.entity.Member;
-import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.enums.MemberRole;
 import org.cherrypic.member.enums.MemberStatus;
 import org.cherrypic.member.repository.MemberRepository;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,16 +37,6 @@ public class AuthServiceTest extends IntegrationTest {
 
     @Nested
     class 소셜_로그인할_때 {
-
-        @BeforeEach
-        void setUp() {
-            Member member =
-                    Member.createMember(
-                            OauthInfo.createOauthInfo("testOauthId", "https://test.oauth.provider"),
-                            "testNickname",
-                            "testProfileImageUrl");
-            memberRepository.save(member);
-        }
 
         @Test
         void 유효한_ID_토큰이면_소셜_로그인에_성공한다() {

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -1,0 +1,83 @@
+package org.cherrypic.auth.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
+import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.entity.OauthProvider;
+import org.cherrypic.domain.auth.service.AuthService;
+import org.cherrypic.domain.auth.service.IdTokenVerifier;
+import org.cherrypic.domain.auth.service.JwtTokenService;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.member.enums.MemberRole;
+import org.cherrypic.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public class AuthServiceTest extends IntegrationTest {
+
+    @Autowired private AuthService authService;
+    @Autowired private MemberRepository memberRepository;
+
+    @MockitoBean private JwtTokenService jwtTokenService;
+    @MockitoBean private IdTokenVerifier idTokenVerifier;
+
+    @Nested
+    class 소셜_로그인할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+        }
+
+        @Test
+        void 유효한_ID_토큰이면_소셜_로그인에_성공한다() {
+            // given
+            given(idTokenVerifier.getOidcUser(anyString(), any())).willReturn(mockOidcUser());
+            given(jwtTokenService.createAccessToken(anyLong(), any(MemberRole.class)))
+                    .willReturn("fake-access-token");
+            given(jwtTokenService.createRefreshToken(anyLong())).willReturn("fake-refresh-token");
+
+            IdTokenRequest request = new IdTokenRequest("testIdTokenValue");
+
+            // when
+            SocialLoginResponse response =
+                    authService.socialLoginMember(OauthProvider.KAKAO, request);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.accessToken()).isEqualTo("fake-access-token"),
+                    () -> assertThat(response.refreshToken()).isEqualTo("fake-refresh-token"));
+        }
+
+        private OidcUser mockOidcUser() {
+            OidcIdToken idToken =
+                    new OidcIdToken(
+                            "fake-id-token",
+                            Instant.now(),
+                            Instant.now().plusSeconds(3600),
+                            Map.of("sub", "testOauthId", "iss", "testOauthProvider"));
+
+            return new DefaultOidcUser(List.of(), idToken);
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/member/repository/MemberRepositoryTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,46 @@
+package org.cherrypic.member.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.Optional;
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberRepositoryTest extends IntegrationTest {
+
+    @Autowired private MemberRepository memberRepository;
+
+    @Nested
+    class OauthInfo로_회원_조회할_때 {
+
+        @Test
+        void 회원이_존재하면_조회에_성공한다() {
+            // given
+            OauthInfo oauthInfo = OauthInfo.createOauthInfo("testOauthId", "testOauthProvider");
+            Member member = Member.createMember(oauthInfo, "testNickname", "testProfileImageUrl");
+
+            memberRepository.save(member);
+
+            // when
+            Optional<Member> result = memberRepository.findByOauthInfo(oauthInfo);
+
+            // then
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        void 회원이_존재하지_않으면_조회에_실패한다() {
+            // when
+            Optional<Member> result =
+                    memberRepository.findByOauthInfo(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/cherrypic-api/src/test/resources/application-test.yml
+++ b/cherrypic-api/src/test/resources/application-test.yml
@@ -21,3 +21,10 @@ oidc:
     jwk-set-uri: https://appleid.apple.com/auth/keys
     issuer: https://appleid.apple.com
     audience: ${APPLE_SERVICE_ID:}
+
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  issuer: ${JWT_ISSUER}

--- a/cherrypic-api/src/test/resources/application-test.yml
+++ b/cherrypic-api/src/test/resources/application-test.yml
@@ -11,3 +11,13 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+
+oidc:
+  kakao:
+    jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
+    issuer: https://kauth.kakao.com
+    audience: ${KAKAO_NATIVE_APP_KEY:}
+  apple:
+    jwk-set-uri: https://appleid.apple.com/auth/keys
+    issuer: https://appleid.apple.com
+    audience: ${APPLE_SERVICE_ID:}

--- a/cherrypic-api/src/test/resources/application-test.yml
+++ b/cherrypic-api/src/test/resources/application-test.yml
@@ -1,7 +1,4 @@
 spring:
-  config:
-    activate:
-      on-profile: "test"
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
   flyway:

--- a/cherrypic-batch/src/test/java/org/cherrypic/CherrypicBatchApplicationTests.java
+++ b/cherrypic-batch/src/test/java/org/cherrypic/CherrypicBatchApplicationTests.java
@@ -2,8 +2,10 @@ package org.cherrypic;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CherrypicBatchApplicationTests {
 
     @Test

--- a/cherrypic-batch/src/test/resources/application-test.yml
+++ b/cherrypic-batch/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+  flyway:
+    enabled: false

--- a/cherrypic-domain/build.gradle
+++ b/cherrypic-domain/build.gradle
@@ -18,4 +18,6 @@ dependencies {
 
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/auth/entity/RefreshToken.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/auth/entity/RefreshToken.java
@@ -1,0 +1,30 @@
+package org.cherrypic.auth.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id private Long memberId;
+
+    private String token;
+
+    @TimeToLive private long ttl;
+
+    @Builder
+    private RefreshToken(Long memberId, String token, long ttl) {
+        this.memberId = memberId;
+        this.token = token;
+        this.ttl = ttl;
+    }
+
+    public void updateRefreshToken(String token, long ttl) {
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/auth/repository/RefreshTokenRepository.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package org.cherrypic.auth.repository;
+
+import org.cherrypic.auth.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -25,11 +25,11 @@ public class Member extends BaseTimeEntity {
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
     private Subscription subscription;
 
-    @NotNull private String nickname;
-
     @Embedded private OauthInfo oauthInfo;
 
-    @NotNull private String profile;
+    @NotNull private String nickname;
+
+    @NotNull private String profileImageUrl;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -49,4 +49,29 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorites> favorites = new ArrayList<>();
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Member(
+            OauthInfo oauthInfo,
+            String nickname,
+            String profileImageUrl,
+            MemberRole role,
+            MemberStatus status) {
+        this.oauthInfo = oauthInfo;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.role = role;
+        this.status = status;
+    }
+
+    public static Member createMember(
+            OauthInfo oauthInfo, String nickname, String profileImageUrl) {
+        return Member.builder()
+                .oauthInfo(oauthInfo)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .role(MemberRole.USER)
+                .status(MemberStatus.NORMAL)
+                .build();
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -39,7 +39,7 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
-    @NotNull private boolean appAlarm;
+    @NotNull private Boolean appAlarm = Boolean.FALSE;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -29,7 +29,7 @@ public class Member extends BaseTimeEntity {
 
     @NotNull private String nickname;
 
-    @NotNull private String profileImageUrl;
+    private String profileImageUrl;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/OauthInfo.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/OauthInfo.java
@@ -2,6 +2,7 @@ package org.cherrypic.member.entity;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,4 +13,14 @@ public class OauthInfo {
     @NotNull private String oauthId;
 
     private String oauthProvider;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OauthInfo(String oauthId, String oauthProvider) {
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+    }
+
+    public static OauthInfo createOauthInfo(String oauthId, String oauthProvider) {
+        return OauthInfo.builder().oauthId(oauthId).oauthProvider(oauthProvider).build();
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/repository/MemberRepository.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/repository/MemberRepository.java
@@ -1,6 +1,10 @@
 package org.cherrypic.member.repository;
 
+import java.util.Optional;
 import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {}
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+}

--- a/cherrypic-domain/src/main/resources/db/migration/V2__alter_member_table_rename_profile_column.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V2__alter_member_table_rename_profile_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member RENAME COLUMN profile TO profile_image_url;

--- a/cherrypic-domain/src/main/resources/db/migration/V3__alter_member_table_remove_not_null_from_profile_image_url_column.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V3__alter_member_table_remove_not_null_from_profile_image_url_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member MODIFY profile_image_url VARCHAR(255) NULL;

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/jwt/JwtProperties.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/jwt/JwtProperties.java
@@ -1,0 +1,19 @@
+package org.cherrypic.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String accessTokenSecret,
+        String refreshTokenSecret,
+        Long accessTokenExpirationTime,
+        Long refreshTokenExpirationTime,
+        String issuer) {
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/oidc/OidcProperties.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/oidc/OidcProperties.java
@@ -1,0 +1,10 @@
+package org.cherrypic.oidc;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oidc")
+public record OidcProperties(KAKAO kakao, Apple apple) {
+    public record KAKAO(String jwkSetUri, String issuer, String audience) {}
+
+    public record Apple(String jwkSetUri, String issuer, String audience) {}
+}

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/properties/PropertiesConfig.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/properties/PropertiesConfig.java
@@ -1,9 +1,10 @@
 package org.cherrypic.properties;
 
+import org.cherrypic.oidc.OidcProperties;
 import org.cherrypic.redis.RedisProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(RedisProperties.class)
+@EnableConfigurationProperties({RedisProperties.class, OidcProperties.class})
 public class PropertiesConfig {}

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/properties/PropertiesConfig.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/properties/PropertiesConfig.java
@@ -1,10 +1,11 @@
 package org.cherrypic.properties;
 
+import org.cherrypic.jwt.JwtProperties;
 import org.cherrypic.oidc.OidcProperties;
 import org.cherrypic.redis.RedisProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties({RedisProperties.class, OidcProperties.class})
+@EnableConfigurationProperties({RedisProperties.class, OidcProperties.class, JwtProperties.class})
 public class PropertiesConfig {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #32 

---
## 📌 작업 내용 및 특이사항
* Kakao와 Apple OIDC 기반 소셜 로그인 기능을 구현했습니다.
* ID 토큰을 통해 회원 정보를 식별하고, 기존 회원이 없을 경우 신규로 생성되도록 했습니다.
* 닉네임은 형용사+동물 이름 조합의 랜덤 닉네임으로 생성되며, Apple의 경우 프로필 이미지는 null로 저장되어 클라이언트에서 기본 이미지를 표시하도록 하려고 합니다.
* 소셜 로그인 성공 시 204 No Content 응답과 함께 Access/Refresh JWT를 생성한 뒤 쿠키로 발급하도록 구현했습니다.
* 인증이 필요 없는 경로(/auth/**)에 대해 PermitAll 설정을 추가했습니다.
* 다음과 같은 테스트를 추가했습니다:
  * AuthService 통합 테스트
  * AuthController 단위 테스트
  * MemberRepository 단위 테스트
