### PR TITLE
test: 테스트 격리

### DIFF
--- a/cherrypic-api/src/test/java/org/cherrypic/DatabaseCleaner.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/DatabaseCleaner.java
@@ -1,0 +1,48 @@
+package org.cherrypic;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+    }
+
+    private void extractTableNames(Connection conn) {
+        tableNames =
+                entityManager.getMetamodel().getEntities().stream()
+                        .map(e -> e.getName().replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase())
+                        .toList();
+    }
+
+    public void execute() {
+        entityManager.unwrap(Session.class).doWork(this::cleanTables);
+    }
+
+    private void cleanTables(Connection conn) throws SQLException {
+        Statement statement = conn.createStatement();
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
+
+        for (String name : tableNames) {
+            statement.executeUpdate(String.format("TRUNCATE TABLE %s", name));
+            statement.executeUpdate(
+                    String.format("ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1", name, name));
+        }
+
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/IntegrationTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/IntegrationTest.java
@@ -1,0 +1,18 @@
+package org.cherrypic;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class IntegrationTest {
+
+    @Autowired protected DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #36 

---
## 📌 작업 내용 및 특이사항
* 테스트 실행 전 데이터베이스 초기화를 위한 DatabaseCleaner를 구현하였습니다.
* TRUNCATE TABLE을 사용하여 모든 테이블의 데이터를 삭제하고, 기본 키 값을 1부터 다시 시작하도록 설정하였습니다.
* IntegrationTest를 상속받는 모든 통합 테스트에서 각 테스트 메서드 실행 전에 DatabaseCleaner가 동작하도록 구성하였습니다.
* 이를 통해 테스트 간 데이터 간섭 없이 독립적인 테스트 환경이 유지됩니다.

---
## 📚 참고사항

- @DirtiesContext를 사용하면 테스트마다 매번 컨텍스트가 재생성되므로 테스트 격리가 가능하지만 시간이 오래 걸린다는 단점이 있어
   적용하지 않았습니다.
- https://yeongkeedev.tistory.com/18
