### PR TITLE
feat: JWT 인증 필터 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
@@ -3,6 +3,7 @@ package org.cherrypic.domain.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.auth.entity.RefreshToken;
 import org.cherrypic.auth.repository.RefreshTokenRepository;
+import org.cherrypic.domain.auth.dto.AccessTokenDto;
 import org.cherrypic.domain.auth.util.JwtUtil;
 import org.cherrypic.member.enums.MemberRole;
 import org.springframework.stereotype.Service;
@@ -29,5 +30,13 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
 
         return token;
+    }
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/CookieUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/CookieUtil.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CookieUtil {
 
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
-    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private final SpringEnvironmentHelper springEnvironmentHelper;
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
@@ -1,10 +1,14 @@
 package org.cherrypic.domain.auth.util;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.dto.AccessTokenDto;
 import org.cherrypic.jwt.JwtProperties;
 import org.cherrypic.member.enums.MemberRole;
 import org.springframework.stereotype.Component;
@@ -12,6 +16,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class JwtUtil {
+
+    private static final String TOKEN_ROLE_NAME = "role";
 
     private final JwtProperties jwtProperties;
 
@@ -27,6 +33,29 @@ public class JwtUtil {
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
         return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public AccessTokenDto parseAccessToken(String accessTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(accessTokenValue, getAccessTokenKey());
+
+            return AccessTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    MemberRole.valueOf(claims.getBody().get(TOKEN_ROLE_NAME, String.class)),
+                    accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Jws<Claims> getClaims(String token, Key key) {
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
     }
 
     public long getRefreshTokenExpirationTime() {
@@ -46,7 +75,7 @@ public class JwtUtil {
         return Jwts.builder()
                 .setIssuer(jwtProperties.issuer())
                 .setSubject(memberId.toString())
-                .claim("role", memberRole.name())
+                .claim(TOKEN_ROLE_NAME, memberRole.name())
                 .setIssuedAt(issuedAt)
                 .setExpiration(expiredAt)
                 .signWith(getAccessTokenKey())

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
@@ -4,6 +4,8 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.service.JwtTokenService;
+import org.cherrypic.global.security.JwtAuthenticationFilter;
 import org.cherrypic.helper.SpringEnvironmentHelper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +16,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -24,6 +27,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final SpringEnvironmentHelper springEnvironmentHelper;
+    private final JwtTokenService jwtTokenService;
 
     private void defaultFilterChain(HttpSecurity http) throws Exception {
         http.httpBasic(AbstractHttpConfigurer::disable)
@@ -63,6 +67,10 @@ public class SecurityConfig {
                                 .anyRequest()
                                 .authenticated());
 
+        http.addFilterBefore(
+                jwtAuthenticationFilter(jwtTokenService),
+                UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 
@@ -90,5 +98,10 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtTokenService jwtTokenService) {
+        return new JwtAuthenticationFilter(jwtTokenService);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/swagger/SwaggerConfig.java
@@ -1,10 +1,7 @@
 package org.cherrypic.global.config.swagger;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +23,7 @@ public class SwaggerConfig {
                                 .title("CherryPic Server API")
                                 .description("CherryPic Server API 명세서입니다.")
                                 .version("v0.0.1"))
-                .servers(initializeSwaggerServers())
-                .components(authSetting())
-                .addSecurityItem(securityRequirement());
+                .servers(initializeSwaggerServers());
     }
 
     private List<Server> initializeSwaggerServers() {
@@ -41,23 +36,5 @@ public class SwaggerConfig {
             case "dev" -> "https://dev-api.cherrypic.today";
             default -> "http://localhost:8080";
         };
-    }
-
-    private Components authSetting() {
-        return new Components()
-                .addSecuritySchemes(
-                        "accessToken",
-                        new SecurityScheme()
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
-                                .in(SecurityScheme.In.HEADER)
-                                .name("Authorization"));
-    }
-
-    private SecurityRequirement securityRequirement() {
-        SecurityRequirement securityRequirement = new SecurityRequirement();
-        securityRequirement.addList("accessToken");
-        return securityRequirement;
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/security/JwtAuthenticationFilter.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package org.cherrypic.global.security;
+
+import static org.cherrypic.domain.auth.util.CookieUtil.ACCESS_TOKEN_COOKIE_NAME;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.dto.AccessTokenDto;
+import org.cherrypic.domain.auth.service.JwtTokenService;
+import org.cherrypic.member.enums.MemberRole;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessTokenValue = extractAccessTokenFromCookie(request);
+
+        if (accessTokenValue != null) {
+            AccessTokenDto accessTokenDto = jwtTokenService.retrieveAccessToken(accessTokenValue);
+
+            // AT가 유효하면 통과
+            if (accessTokenDto != null) {
+                setAuthenticationToken(accessTokenDto.memberId(), accessTokenDto.role());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToken(Long memberId, MemberRole memberRole) {
+        UserDetails userDetails =
+                User.withUsername(memberId.toString())
+                        .password("")
+                        .authorities(memberRole.toString())
+                        .build();
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private String extractAccessTokenFromCookie(HttpServletRequest request) {
+        return Optional.ofNullable(WebUtils.getCookie(request, ACCESS_TOKEN_COOKIE_NAME))
+                .map(Cookie::getValue)
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #34 

---
## 📌 작업 내용 및 특이사항
* JWT Access Token을 쿠키에서 추출하여 인증하는 필터를 구현했습니다.
* 토큰이 유효한 경우, 사용자 정보를 기반으로 SecurityContext에 인증 정보를 설정하도록 했습니다.
* JwtAuthenticationFilter를 SecurityConfig에 등록하여 인증 필터 체인에 적용했습니다.
* 기존 Swagger에서 사용하던 Authorization 헤더 기반 JWT 설정을 제거했습니다.
* Access Token을 헤더가 아닌 쿠키에서 읽도록 방식이 변경됨에 따라 Swagger 설정도 이를 반영했습니다.