### PR TITLE
feat: 현재 로그인한 회원 조회 유틸 추가

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
@@ -8,6 +8,9 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseErrorCode {
     ID_TOKEN_VERIFICATION_FAILED(401, "ID 토큰 검증에 실패했습니다."),
+
+    AUTH_NOT_EXIST(401, "인증 정보가 존재하지 않습니다."),
+    AUTH_NOT_PARSABLE(500, "인증 정보 파싱에 실패했습니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/exception/MemberErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/exception/MemberErrorCode.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.member.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+    MEMBER_NOT_FOUND(404, "회원을 찾을 수 없습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/exception/MemberException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/exception/MemberException.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.member.exception;
+
+import org.cherrypic.exception.BaseCustomException;
+
+public class MemberException extends BaseCustomException {
+    public MemberException(MemberErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/MemberUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/MemberUtil.java
@@ -1,0 +1,39 @@
+package org.cherrypic.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.exception.AuthErrorCode;
+import org.cherrypic.domain.auth.exception.AuthException;
+import org.cherrypic.domain.member.exception.MemberErrorCode;
+import org.cherrypic.domain.member.exception.MemberException;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.repository.MemberRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtil {
+
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentMember() {
+        return memberRepository
+                .findById(getCurrentMemberId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            throw new AuthException(AuthErrorCode.AUTH_NOT_EXIST);
+        }
+
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new AuthException(AuthErrorCode.AUTH_NOT_PARSABLE);
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #39 

---
## 📌 작업 내용 및 특이사항
* 현재 로그인한 회원 정보를 조회하는 유틸 클래스를 추가했습니다.
* SecurityContext에서 ID를 읽어 DB에서 회원을 조회하며, 인증 정보가 없을 경우 예외를 던집니다.
* 서비스 레이어에서 주입받아 사용하시면 됩니다.

---
## 📚 참고사항
* 추후 서비스 레이어 테스트에서 인증이 필요한 경우 아래와 같이 ```@BeforeEach```를 활용해 SecurityContext에 인증 정보를 미리 주입하시기 바랍니다.

```java
@Autowired private MemberRepository memberRepository;

private Member member;

@BeforeEach
void setUp() {
    Member member =
            Member.createMember(
                    "testNickname",
                    "testProfileImageUrl",
                    OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
    memberRepository.save(member);

    UserDetails userDetails =
            User.withUsername(member.getId().toString())
                    .password("")
                    .authorities(member.getRole().toString())
                    .build();

    UsernamePasswordAuthenticationToken token =
            new UsernamePasswordAuthenticationToken(
                    userDetails, null, userDetails.getAuthorities());

    SecurityContextHolder.getContext().setAuthentication(token);
}
```
