### PR TITLE
feat: JWT 토큰 재발급 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.dto.response.TokenReissueResponse;
 import org.cherrypic.domain.auth.enums.OauthProvider;
 import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.util.CookieUtil;
@@ -28,6 +29,20 @@ public class AuthController {
             @RequestParam(name = "oauthProvider") OauthProvider provider,
             @Valid @RequestBody IdTokenRequest request) {
         SocialLoginResponse response = authService.socialLoginMember(provider, request);
+
+        HttpHeaders headers =
+                cookieUtil.generateTokenCookies(response.accessToken(), response.refreshToken());
+
+        return ResponseEntity.noContent().headers(headers).build();
+    }
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "엑세스 토큰이 만료되었을 경우, 리프레시 토큰을 이용해 엑세스 및 리프레시 토큰을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<Void> tokenReissue(
+            @CookieValue("refreshToken") String refreshTokenValue) {
+        TokenReissueResponse response = authService.reissueToken(refreshTokenValue);
 
         HttpHeaders headers =
                 cookieUtil.generateTokenCookies(response.accessToken(), response.refreshToken());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/AccessTokenDto.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/AccessTokenDto.java
@@ -2,8 +2,8 @@ package org.cherrypic.domain.auth.dto;
 
 import org.cherrypic.member.enums.MemberRole;
 
-public record AccessTokenDto(Long memberId, MemberRole role, String accessTokenValue) {
-    public static AccessTokenDto of(Long memberId, MemberRole role, String accessTokenValue) {
-        return new AccessTokenDto(memberId, role, accessTokenValue);
+public record AccessTokenDto(Long memberId, MemberRole role, String tokenValue) {
+    public static AccessTokenDto of(Long memberId, MemberRole role, String tokenValue) {
+        return new AccessTokenDto(memberId, role, tokenValue);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/RefreshTokenDto.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/RefreshTokenDto.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.auth.dto;
 
-public record RefreshTokenDto(Long memberId, String refreshTokenValue, Long ttl) {
-    public static RefreshTokenDto of(Long memberId, String refreshTokenValue, Long ttl) {
-        return new RefreshTokenDto(memberId, refreshTokenValue, ttl);
+public record RefreshTokenDto(Long memberId, String tokenValue, Long ttl) {
+    public static RefreshTokenDto of(Long memberId, String tokenValue, Long ttl) {
+        return new RefreshTokenDto(memberId, tokenValue, ttl);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/response/TokenReissueResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/dto/response/TokenReissueResponse.java
@@ -1,0 +1,11 @@
+package org.cherrypic.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenReissueResponse(
+        @Schema(description = "Access Token") String accessToken,
+        @Schema(description = "Refresh Token") String refreshToken) {
+    public static TokenReissueResponse of(String accessToken, String refreshToken) {
+        return new TokenReissueResponse(accessToken, refreshToken);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
@@ -13,7 +13,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     AUTH_NOT_PARSABLE(500, "인증 정보 파싱에 실패했습니다."),
 
     REFRESH_TOKEN_NOT_FOUND(401, "리프레시 토큰이 존재하지 않습니다."),
-    EXPIRED_REFRESH_TOKEN(401, "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
+    INVALID_REFRESH_TOKEN(401, "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/exception/AuthErrorCode.java
@@ -11,6 +11,9 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     AUTH_NOT_EXIST(401, "인증 정보가 존재하지 않습니다."),
     AUTH_NOT_PARSABLE(500, "인증 정보 파싱에 실패했습니다."),
+
+    REFRESH_TOKEN_NOT_FOUND(401, "리프레시 토큰이 존재하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(401, "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
@@ -2,8 +2,11 @@ package org.cherrypic.domain.auth.service;
 
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.dto.response.TokenReissueResponse;
 import org.cherrypic.domain.auth.enums.OauthProvider;
 
 public interface AuthService {
     SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request);
+
+    TokenReissueResponse reissueToken(String refreshTokenValue);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
@@ -46,7 +46,7 @@ public class AuthServiceImpl implements AuthService {
                 jwtTokenService.retrieveRefreshToken(refreshTokenValue);
 
         if (oldRefreshTokenDto == null) {
-            throw new AuthException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         RefreshTokenDto newRefreshTokenDto =

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
@@ -2,10 +2,17 @@ package org.cherrypic.domain.auth.service;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.auth.dto.AccessTokenDto;
+import org.cherrypic.domain.auth.dto.RefreshTokenDto;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.dto.response.TokenReissueResponse;
 import org.cherrypic.domain.auth.enums.OauthProvider;
+import org.cherrypic.domain.auth.exception.AuthErrorCode;
+import org.cherrypic.domain.auth.exception.AuthException;
 import org.cherrypic.domain.auth.util.NicknameGenerator;
+import org.cherrypic.domain.member.exception.MemberErrorCode;
+import org.cherrypic.domain.member.exception.MemberException;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
@@ -33,6 +40,24 @@ public class AuthServiceImpl implements AuthService {
         return getLoginResponse(member);
     }
 
+    @Override
+    public TokenReissueResponse reissueToken(String refreshTokenValue) {
+        RefreshTokenDto oldRefreshTokenDto =
+                jwtTokenService.retrieveRefreshToken(refreshTokenValue);
+
+        if (oldRefreshTokenDto == null) {
+            throw new AuthException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        RefreshTokenDto newRefreshTokenDto =
+                jwtTokenService.reissueRefreshToken(oldRefreshTokenDto);
+        AccessTokenDto newAccessTokenDto =
+                jwtTokenService.reissueAccessToken(getMember(newRefreshTokenDto));
+
+        return TokenReissueResponse.of(
+                newAccessTokenDto.tokenValue(), newRefreshTokenDto.tokenValue());
+    }
+
     private SocialLoginResponse getLoginResponse(Member member) {
         String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
         String refreshToken = jwtTokenService.createRefreshToken(member.getId());
@@ -55,5 +80,11 @@ public class AuthServiceImpl implements AuthService {
 
     private OauthInfo extractOauthInfo(OidcUser oidcUser) {
         return OauthInfo.createOauthInfo(oidcUser.getSubject(), oidcUser.getIssuer().toString());
+    }
+
+    private Member getMember(RefreshTokenDto refreshTokenDto) {
+        return memberRepository
+                .findById(refreshTokenDto.memberId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
@@ -1,9 +1,11 @@
 package org.cherrypic.domain.auth.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.auth.entity.RefreshToken;
 import org.cherrypic.auth.repository.RefreshTokenRepository;
 import org.cherrypic.domain.auth.dto.AccessTokenDto;
+import org.cherrypic.domain.auth.dto.RefreshTokenDto;
 import org.cherrypic.domain.auth.util.JwtUtil;
 import org.cherrypic.member.enums.MemberRole;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,28 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
 
         return token;
+    }
+
+    public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {
+        RefreshTokenDto refreshTokenDto;
+        try {
+            refreshTokenDto = jwtUtil.parseRefreshToken(refreshTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+
+        Optional<RefreshToken> refreshToken =
+                refreshTokenRepository.findById(refreshTokenDto.memberId());
+
+        if (refreshToken.isEmpty()) {
+            return null;
+        }
+
+        if (!refreshTokenDto.tokenValue().equals(refreshToken.get().getToken())) {
+            return null;
+        }
+
+        return refreshTokenDto;
     }
 
     public AccessTokenDto retrieveAccessToken(String accessTokenValue) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/JwtTokenService.java
@@ -6,7 +6,10 @@ import org.cherrypic.auth.entity.RefreshToken;
 import org.cherrypic.auth.repository.RefreshTokenRepository;
 import org.cherrypic.domain.auth.dto.AccessTokenDto;
 import org.cherrypic.domain.auth.dto.RefreshTokenDto;
+import org.cherrypic.domain.auth.exception.AuthErrorCode;
+import org.cherrypic.domain.auth.exception.AuthException;
 import org.cherrypic.domain.auth.util.JwtUtil;
+import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.enums.MemberRole;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +35,26 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
 
         return token;
+    }
+
+    public AccessTokenDto reissueAccessToken(Member member) {
+        return jwtUtil.generateAccessTokenDto(member.getId(), member.getRole());
+    }
+
+    public RefreshTokenDto reissueRefreshToken(RefreshTokenDto oldRefreshTokenDto) {
+        RefreshToken refreshToken =
+                refreshTokenRepository
+                        .findById(oldRefreshTokenDto.memberId())
+                        .orElseThrow(
+                                () -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        RefreshTokenDto newRefreshTokenDto =
+                jwtUtil.generateRefreshTokenDto(refreshToken.getMemberId());
+        refreshToken.updateRefreshToken(newRefreshTokenDto.tokenValue(), newRefreshTokenDto.ttl());
+
+        refreshTokenRepository.save(refreshToken);
+
+        return newRefreshTokenDto;
     }
 
     public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
@@ -29,11 +29,28 @@ public class JwtUtil {
         return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
     }
 
+    public AccessTokenDto generateAccessTokenDto(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String accessTokenValue = buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+        return AccessTokenDto.of(memberId, memberRole, accessTokenValue);
+    }
+
     public String generateRefreshToken(Long memberId) {
         Date issuedAt = new Date();
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
         return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        String refreshTokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return RefreshTokenDto.of(
+                memberId, refreshTokenValue, jwtProperties.refreshTokenExpirationTime());
     }
 
     public AccessTokenDto parseAccessToken(String accessTokenValue) throws ExpiredJwtException {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/JwtUtil.java
@@ -9,6 +9,7 @@ import java.security.Key;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.auth.dto.AccessTokenDto;
+import org.cherrypic.domain.auth.dto.RefreshTokenDto;
 import org.cherrypic.jwt.JwtProperties;
 import org.cherrypic.member.enums.MemberRole;
 import org.springframework.stereotype.Component;
@@ -43,6 +44,21 @@ public class JwtUtil {
                     Long.parseLong(claims.getBody().getSubject()),
                     MemberRole.valueOf(claims.getBody().get(TOKEN_ROLE_NAME, String.class)),
                     accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto parseRefreshToken(String refreshTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(refreshTokenValue, getRefreshTokenKey());
+
+            return RefreshTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    refreshTokenValue,
+                    jwtProperties.refreshTokenExpirationTime());
         } catch (ExpiredJwtException e) {
             throw e;
         } catch (Exception e) {

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
@@ -134,7 +134,7 @@ class AuthControllerTest {
         void 만료된_리프레시_토큰이면_예외가_발생한다() throws Exception {
             // given
             given(authService.reissueToken(anyString()))
-                    .willThrow(new AuthException(AuthErrorCode.EXPIRED_REFRESH_TOKEN));
+                    .willThrow(new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN));
 
             Cookie refreshTokenCookie = new Cookie("refreshToken", "invalidRefreshToken");
 
@@ -150,10 +150,10 @@ class AuthControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()))
                     .andExpect(
                             jsonPath("$.data.code")
-                                    .value(AuthErrorCode.EXPIRED_REFRESH_TOKEN.name()))
+                                    .value(AuthErrorCode.INVALID_REFRESH_TOKEN.name()))
                     .andExpect(
                             jsonPath("$.data.message")
-                                    .value(AuthErrorCode.EXPIRED_REFRESH_TOKEN.getMessage()));
+                                    .value(AuthErrorCode.INVALID_REFRESH_TOKEN.getMessage()));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
@@ -1,16 +1,19 @@
 package org.cherrypic.auth.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.cherrypic.domain.auth.controller.AuthController;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.dto.response.TokenReissueResponse;
 import org.cherrypic.domain.auth.enums.OauthProvider;
+import org.cherrypic.domain.auth.exception.AuthErrorCode;
+import org.cherrypic.domain.auth.exception.AuthException;
 import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.util.CookieUtil;
 import org.junit.jupiter.api.Nested;
@@ -93,6 +96,64 @@ class AuthControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("Id Token은 비워둘 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 토큰_재발급할_때 {
+
+        @Test
+        void 유효한_리프레시_토큰이면_새로운_토큰을_반환한다() throws Exception {
+            // given
+            TokenReissueResponse response =
+                    TokenReissueResponse.of("fake-access-token", "fake-refresh-token");
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.SET_COOKIE, "accessToken=fake-access-token");
+            headers.add(HttpHeaders.SET_COOKIE, "refreshToken=fake-refresh-token");
+
+            given(authService.reissueToken(anyString())).willReturn(response);
+            given(cookieUtil.generateTokenCookies(response.accessToken(), response.refreshToken()))
+                    .willReturn(headers);
+
+            Cookie refreshTokenCookie = new Cookie("refreshToken", "testRefreshTokenValue");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/auth/reissue")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .cookie(refreshTokenCookie));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(cookie().exists("accessToken"))
+                    .andExpect(cookie().exists("refreshToken"));
+        }
+
+        @Test
+        void 만료된_리프레시_토큰이면_예외가_발생한다() throws Exception {
+            // given
+            given(authService.reissueToken(anyString()))
+                    .willThrow(new AuthException(AuthErrorCode.EXPIRED_REFRESH_TOKEN));
+
+            Cookie refreshTokenCookie = new Cookie("refreshToken", "invalidRefreshToken");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/auth/reissue")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .cookie(refreshTokenCookie));
+
+            perform.andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()))
+                    .andExpect(
+                            jsonPath("$.data.code")
+                                    .value(AuthErrorCode.EXPIRED_REFRESH_TOKEN.name()))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(AuthErrorCode.EXPIRED_REFRESH_TOKEN.getMessage()));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -1,24 +1,34 @@
 package org.cherrypic.auth.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.cherrypic.IntegrationTest;
+import org.cherrypic.domain.auth.dto.AccessTokenDto;
+import org.cherrypic.domain.auth.dto.RefreshTokenDto;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
 import org.cherrypic.domain.auth.dto.response.SocialLoginResponse;
+import org.cherrypic.domain.auth.dto.response.TokenReissueResponse;
 import org.cherrypic.domain.auth.enums.OauthProvider;
+import org.cherrypic.domain.auth.exception.AuthErrorCode;
+import org.cherrypic.domain.auth.exception.AuthException;
 import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.service.IdTokenVerifier;
 import org.cherrypic.domain.auth.service.JwtTokenService;
 import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.enums.MemberRole;
 import org.cherrypic.member.enums.MemberStatus;
 import org.cherrypic.member.repository.MemberRepository;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,6 +101,52 @@ public class AuthServiceTest extends IntegrationTest {
                             Map.of("sub", sub, "iss", iss));
 
             return new DefaultOidcUser(List.of(), idToken);
+        }
+    }
+
+    @Nested
+    class 토큰_재발급할_때 {
+
+        @BeforeEach
+        void setUp() {
+            memberRepository.save(
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl"));
+        }
+
+        @Test
+        void 유효한_리프레시_토큰이면_새로운_토큰을_반환한다() {
+            // given
+            RefreshTokenDto oldRefreshTokenDto =
+                    RefreshTokenDto.of(1L, "fake-old-register-token", 604800L);
+            RefreshTokenDto newRefreshTokenDto =
+                    RefreshTokenDto.of(1L, "fake-new-refresh-token", 604800L);
+            AccessTokenDto newAccessTokenDto =
+                    AccessTokenDto.of(1L, MemberRole.USER, "fake-new-access-token");
+
+            given(jwtTokenService.retrieveRefreshToken(anyString())).willReturn(oldRefreshTokenDto);
+            given(jwtTokenService.reissueRefreshToken(oldRefreshTokenDto))
+                    .willReturn(newRefreshTokenDto);
+            given(jwtTokenService.reissueAccessToken(any())).willReturn(newAccessTokenDto);
+
+            // when
+            TokenReissueResponse response = authService.reissueToken("testRefreshTokenValue");
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.accessToken()).isEqualTo("fake-new-access-token"),
+                    () -> assertThat(response.refreshToken()).isEqualTo("fake-new-refresh-token"));
+        }
+
+        @Test
+        void 만료된_리프레시_토큰이면_예외가_발생한다() {
+            // given
+            assertThatThrownBy(() -> authService.reissueToken("testRefreshTokenValue"))
+                    .isInstanceOf(AuthException.class)
+                    .hasMessage(AuthErrorCode.EXPIRED_REFRESH_TOKEN.getMessage());
+            verify(jwtTokenService, times(1)).retrieveRefreshToken(anyString());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -145,7 +145,7 @@ public class AuthServiceTest extends IntegrationTest {
             // given
             assertThatThrownBy(() -> authService.reissueToken("testRefreshTokenValue"))
                     .isInstanceOf(AuthException.class)
-                    .hasMessage(AuthErrorCode.EXPIRED_REFRESH_TOKEN.getMessage());
+                    .hasMessage(AuthErrorCode.INVALID_REFRESH_TOKEN.getMessage());
             verify(jwtTokenService, times(1)).retrieveRefreshToken(anyString());
         }
     }

--- a/cherrypic-common/src/main/java/org/cherrypic/exception/BaseCustomException.java
+++ b/cherrypic-common/src/main/java/org/cherrypic/exception/BaseCustomException.java
@@ -1,11 +1,14 @@
 package org.cherrypic.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class BaseCustomException extends RuntimeException {
 
     private final BaseErrorCode errorCode;
+
+    public BaseCustomException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #43 

---
## 📌 작업 내용 및 특이사항
- Refresh Token을 이용한 Access Token 재발급 로직을 구현했습니다.  
- 토큰 검증 시 Redis에 저장된 토큰과 일치하는지 확인하여 유효성을 체크합니다.  
- 토큰 재발급 시 새로운 Refresh Token도 함께 발급하고, 쿠키에 저장되도록 처리했습니다.