### PR TITLE
feat: 회원 정보 조회 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package org.cherrypic.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.member.service.MemberService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+@Tag(name = "1-2. 회원 API", description = "회원 관련 API입니다.")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    @Operation(summary = "회원 정보 조회", description = "로그인한 회원 정보를 조회합니다.")
+    public MemberInfoResponse memberInfo() {
+        return memberService.getMemberInfo();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/MemberInfoResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,29 @@
+package org.cherrypic.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.enums.MemberRole;
+import org.cherrypic.member.enums.MemberStatus;
+
+public record MemberInfoResponse(
+        @Schema(description = "회원 아이디", example = "1") Long memberId,
+        @Schema(description = "소셜 로그인 제공자", example = "https://kauth.kakao.com")
+                String oauthProvider,
+        @Schema(description = "회원 닉네임", example = "최현태") String nickname,
+        @Schema(
+                        description = "회원 프로필 사진",
+                        example =
+                                "http://k.kakaocdn.net/dn/ceTrU6/btsL0V0mhKO/DGqAZKAK/img_110x110.jpg")
+                String profileImageUrl,
+        @Schema(description = "회원 상태", example = "NORMAL") MemberStatus status,
+        @Schema(description = "회원 역할", example = "ROLE_USER") MemberRole role) {
+    public static MemberInfoResponse from(Member member) {
+        return new MemberInfoResponse(
+                member.getId(),
+                member.getOauthInfo().getOauthProvider(),
+                member.getNickname(),
+                member.getProfileImageUrl(),
+                member.getStatus(),
+                member.getRole());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.member.service;
+
+import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+
+public interface MemberService {
+    MemberInfoResponse getMemberInfo();
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,24 @@
+package org.cherrypic.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberUtil memberUtil;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMemberInfo() {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        return MemberInfoResponse.from(currentMember);
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -1,0 +1,62 @@
+package org.cherrypic.member.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.domain.member.controller.MemberController;
+import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.member.service.MemberService;
+import org.cherrypic.member.enums.MemberRole;
+import org.cherrypic.member.enums.MemberStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MemberControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private MemberService memberService;
+
+    @Test
+    void 회원_정보를_조회한다() throws Exception {
+        // given
+        MemberInfoResponse response =
+                new MemberInfoResponse(
+                        1L,
+                        "https://kauth.kakao.com",
+                        "testNickname",
+                        "testProfileImageUrl",
+                        MemberStatus.NORMAL,
+                        MemberRole.USER);
+
+        given(memberService.getMemberInfo()).willReturn(response);
+
+        // when & then
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/members/me")
+                                .param("oauthProvider", "KAKAO")
+                                .contentType(MediaType.APPLICATION_JSON));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.memberId").value(1))
+                .andExpect(jsonPath("$.data.oauthProvider").value("https://kauth.kakao.com"))
+                .andExpect(jsonPath("$.data.nickname").value("testNickname"))
+                .andExpect(jsonPath("$.data.profileImageUrl").value("testProfileImageUrl"))
+                .andExpect(jsonPath("$.data.status").value("NORMAL"))
+                .andExpect(jsonPath("$.data.role").value("USER"));
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -24,11 +24,9 @@ class MemberServiceTest extends IntegrationTest {
     @Autowired private MemberService memberService;
     @Autowired private MemberRepository memberRepository;
 
-    private Member member;
-
     @BeforeEach
     void setUp() {
-        member =
+        Member member =
                 Member.createMember(
                         OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
                         "testNickname",

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -1,0 +1,63 @@
+package org.cherrypic.member.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.member.service.MemberService;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.member.enums.MemberRole;
+import org.cherrypic.member.enums.MemberStatus;
+import org.cherrypic.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+class MemberServiceTest extends IntegrationTest {
+
+    @Autowired private MemberService memberService;
+    @Autowired private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member =
+                Member.createMember(
+                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                        "testNickname",
+                        "testProfileImageUrl");
+        memberRepository.save(member);
+
+        UserDetails userDetails =
+                User.withUsername(member.getId().toString())
+                        .password("")
+                        .authorities(member.getRole().name())
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @Test
+    void 회원_정보를_조회한다() {
+        // when
+        MemberInfoResponse response = memberService.getMemberInfo();
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(response.memberId()).isEqualTo(1L),
+                () -> assertThat(response.oauthProvider()).isEqualTo("testOauthProvider"),
+                () -> assertThat(response.nickname()).isEqualTo("testNickname"),
+                () -> assertThat(response.profileImageUrl()).isEqualTo("testProfileImageUrl"),
+                () -> assertThat(response.role()).isEqualTo(MemberRole.USER),
+                () -> assertThat(response.status()).isEqualTo(MemberStatus.NORMAL));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #45 

---
## 📌 작업 내용 및 특이사항
* 로그인한 회원 정보 조회 기능을 구현하였습니다.
* 조회 API의 경우 서비스 레이어에서 Transactional(readOnly = true) 어노테이션을 추가하였습니다.
* Response DTO의 경우 정적 팩토리 메서드 from을 적용하였습니다.

---
## 📚 참고사항
* 인증이 필요한 테스트의 경우, `SecurityContextHolder`에 로그인한 회원 정보를 미리 세팅해야 합니다.
* 아래와 같은 방식으로 테스트용 회원을 등록하고, 인증 정보를 context에 주입해 주세요.

```java
@BeforeEach
void setUp() {
    Member member =
            Member.createMember(
                    OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
                    "testNickname",
                    "testProfileImageUrl");
    memberRepository.save(member);

    UserDetails userDetails =
            User.withUsername(member.getId().toString())
                    .password("")
                    .authorities(member.getRole().name())
                    .build();
    UsernamePasswordAuthenticationToken token =
            new UsernamePasswordAuthenticationToken(
                    userDetails, null, userDetails.getAuthorities());
    SecurityContextHolder.getContext().setAuthentication(token);
}