### PR TITLE
chore: 개발 서버 Swagger 보안 설정

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.auth.service.JwtTokenService;
 import org.cherrypic.global.security.JwtAuthenticationFilter;
 import org.cherrypic.helper.SpringEnvironmentHelper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -15,6 +16,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -29,6 +35,12 @@ public class SecurityConfig {
     private final SpringEnvironmentHelper springEnvironmentHelper;
     private final JwtTokenService jwtTokenService;
 
+    @Value("${swagger.username}")
+    private String swaggerUsername;
+
+    @Value("${swagger.password}")
+    private String swaggerPassword;
+
     private void defaultFilterChain(HttpSecurity http) throws Exception {
         http.httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -36,6 +48,22 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager inMemoryUserDetailsManager() {
+        UserDetails user =
+                User.withUsername(swaggerUsername)
+                        .password(passwordEncoder().encode(swaggerPassword))
+                        .roles("SWAGGER")
+                        .build();
+
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean
@@ -47,9 +75,9 @@ public class SecurityConfig {
         http.securityMatcher("/swagger-ui/**", "/v3/api-docs/**").httpBasic(withDefaults());
 
         http.authorizeHttpRequests(
-                springEnvironmentHelper.isProdProfile() || springEnvironmentHelper.isDevProfile()
-                        ? auth -> auth.anyRequest().authenticated()
-                        : auth -> auth.anyRequest().permitAll());
+                (springEnvironmentHelper.isDevProfile())
+                        ? authorize -> authorize.anyRequest().authenticated()
+                        : authorize -> authorize.anyRequest().permitAll());
 
         return http.build();
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
@@ -35,10 +35,10 @@ public class SecurityConfig {
     private final SpringEnvironmentHelper springEnvironmentHelper;
     private final JwtTokenService jwtTokenService;
 
-    @Value("${swagger.username}")
+    @Value("${swagger.username:default}")
     private String swaggerUsername;
 
-    @Value("${swagger.password}")
+    @Value("${swagger.password:default}")
     private String swaggerPassword;
 
     private void defaultFilterChain(HttpSecurity http) throws Exception {

--- a/cherrypic-api/src/main/resources/application-dev.yml
+++ b/cherrypic-api/src/main/resources/application-dev.yml
@@ -37,6 +37,10 @@ jwt:
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
   issuer: ${JWT_ISSUER}
 
+swagger:
+  username: ${SWAGGER_USERNAME}
+  password: ${SWAGGER_PASSWORD}
+
 spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json


### PR DESCRIPTION
## 🌱 관련 이슈
- close #41 

---
## 📌 작업 내용 및 특이사항
* 개발 서버에서 Swagger UI 접근 시 인증을 요구하도록 설정했습니다.  
* httpBasic 인증을 적용하고 계정 정보는 환경 변수로 주입받도록 구성했습니다.  
* /swagger-ui 경로에만 인증 필터를 적용했습니다.  