### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
@@ -56,7 +56,6 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> memberLogout() {
         authService.logoutMember();
-
         return ResponseEntity.noContent().headers(cookieUtil.deleteTokenCookies()).build();
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/controller/AuthController.java
@@ -49,4 +49,14 @@ public class AuthController {
 
         return ResponseEntity.noContent().headers(headers).build();
     }
+
+    @Operation(
+            summary = "회원 로그아웃",
+            description = "로그아웃 시, 쿠키에 저장된 accessToken과 refreshToken이 만료 처리됩니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout() {
+        authService.logoutMember();
+
+        return ResponseEntity.noContent().headers(cookieUtil.deleteTokenCookies()).build();
+    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthService.java
@@ -9,4 +9,6 @@ public interface AuthService {
     SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request);
 
     TokenReissueResponse reissueToken(String refreshTokenValue);
+
+    void logoutMember();
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/service/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package org.cherrypic.domain.auth.service;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.auth.repository.RefreshTokenRepository;
 import org.cherrypic.domain.auth.dto.AccessTokenDto;
 import org.cherrypic.domain.auth.dto.RefreshTokenDto;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
@@ -13,6 +14,7 @@ import org.cherrypic.domain.auth.exception.AuthException;
 import org.cherrypic.domain.auth.util.NicknameGenerator;
 import org.cherrypic.domain.member.exception.MemberErrorCode;
 import org.cherrypic.domain.member.exception.MemberException;
+import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
@@ -25,7 +27,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AuthServiceImpl implements AuthService {
 
+    private final MemberUtil memberUtil;
     private final MemberRepository memberRepository;
+
+    private final RefreshTokenRepository refreshTokenRepository;
     private final IdTokenVerifier idTokenVerifier;
     private final JwtTokenService jwtTokenService;
     private final NicknameGenerator nicknameGenerator;
@@ -56,6 +61,15 @@ public class AuthServiceImpl implements AuthService {
 
         return TokenReissueResponse.of(
                 newAccessTokenDto.tokenValue(), newRefreshTokenDto.tokenValue());
+    }
+
+    @Override
+    public void logoutMember() {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        refreshTokenRepository
+                .findById(currentMember.getId())
+                .ifPresent(refreshTokenRepository::delete);
     }
 
     private SocialLoginResponse getLoginResponse(Member member) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/CookieUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/auth/util/CookieUtil.java
@@ -42,6 +42,34 @@ public class CookieUtil {
         return headers;
     }
 
+    public HttpHeaders deleteTokenCookies() {
+        String sameSite = determineSameSitePolicy();
+
+        ResponseCookie accessTokenCookie =
+                ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .build();
+
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
     private String determineSameSitePolicy() {
         if (springEnvironmentHelper.isProdProfile()) {
             return Cookie.SameSite.STRICT.attributeValue();

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/security/SecurityConfig.java
@@ -90,7 +90,9 @@ public class SecurityConfig {
                 auth ->
                         auth.requestMatchers("/cherrypic-actuator/**")
                                 .permitAll()
-                                .requestMatchers("/auth/**")
+                                .requestMatchers("/auth/social-login")
+                                .permitAll()
+                                .requestMatchers("/auth/reissue")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
@@ -120,10 +120,7 @@ class AuthControllerTest {
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            post("/auth/reissue")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .cookie(refreshTokenCookie));
+                    mockMvc.perform(post("/auth/reissue").cookie(refreshTokenCookie));
 
             perform.andExpect(status().isNoContent())
                     .andExpect(cookie().exists("accessToken"))
@@ -140,10 +137,7 @@ class AuthControllerTest {
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            post("/auth/reissue")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .cookie(refreshTokenCookie));
+                    mockMvc.perform(post("/auth/reissue").cookie(refreshTokenCookie));
 
             perform.andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.success").value(false))

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package org.cherrypic.auth.controller;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -16,6 +17,7 @@ import org.cherrypic.domain.auth.exception.AuthErrorCode;
 import org.cherrypic.domain.auth.exception.AuthException;
 import org.cherrypic.domain.auth.service.AuthService;
 import org.cherrypic.domain.auth.util.CookieUtil;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -148,6 +150,38 @@ class AuthControllerTest {
                     .andExpect(
                             jsonPath("$.data.message")
                                     .value(AuthErrorCode.INVALID_REFRESH_TOKEN.getMessage()));
+        }
+    }
+
+    @Nested
+    class 로그아웃할_때 {
+
+        @Test
+        void 로그아웃하면_엑세스_토큰과_리프레시_토큰_쿠키가_만료_처리된다() throws Exception {
+            // given
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.SET_COOKIE, "accessToken=; Max-Age=0");
+            headers.add(HttpHeaders.SET_COOKIE, "refreshToken=; Max-Age=0");
+
+            willDoNothing().given(authService).logoutMember();
+            given(cookieUtil.deleteTokenCookies()).willReturn(headers);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/auth/logout"));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(
+                            header().stringValues(
+                                            HttpHeaders.SET_COOKIE,
+                                            Matchers.hasItems(
+                                                    Matchers.allOf(
+                                                            Matchers.containsString("accessToken="),
+                                                            Matchers.containsString("Max-Age=0")),
+                                                    Matchers.allOf(
+                                                            Matchers.containsString(
+                                                                    "refreshToken="),
+                                                            Matchers.containsString(
+                                                                    "Max-Age=0")))));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/auth/service/AuthServiceTest.java
@@ -11,6 +11,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.cherrypic.IntegrationTest;
+import org.cherrypic.auth.entity.RefreshToken;
+import org.cherrypic.auth.repository.RefreshTokenRepository;
 import org.cherrypic.domain.auth.dto.AccessTokenDto;
 import org.cherrypic.domain.auth.dto.RefreshTokenDto;
 import org.cherrypic.domain.auth.dto.request.IdTokenRequest;
@@ -32,6 +34,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -41,6 +47,7 @@ public class AuthServiceTest extends IntegrationTest {
 
     @Autowired private AuthService authService;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private RefreshTokenRepository refreshTokenRepository;
 
     @MockitoBean private JwtTokenService jwtTokenService;
     @MockitoBean private IdTokenVerifier idTokenVerifier;
@@ -147,6 +154,44 @@ public class AuthServiceTest extends IntegrationTest {
                     .isInstanceOf(AuthException.class)
                     .hasMessage(AuthErrorCode.INVALID_REFRESH_TOKEN.getMessage());
             verify(jwtTokenService, times(1)).retrieveRefreshToken(anyString());
+        }
+    }
+
+    @Nested
+    class 로그아웃할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+
+            UserDetails userDetails =
+                    User.withUsername(member.getId().toString())
+                            .password("")
+                            .authorities(member.getRole().name())
+                            .build();
+            UsernamePasswordAuthenticationToken token =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(token);
+        }
+
+        @Test
+        void 로그아웃하면_Redis에_저장된_리프레시_토큰이_삭제된다() {
+            // given
+            RefreshToken refreshToken =
+                    RefreshToken.builder().memberId(1L).token("testRefreshToken").build();
+            refreshTokenRepository.save(refreshToken);
+
+            // when
+            authService.logoutMember();
+
+            // then
+            assertThat(refreshTokenRepository.findById(1L).isEmpty());
         }
     }
 }

--- a/cherrypic-api/src/test/resources/application-test.yml
+++ b/cherrypic-api/src/test/resources/application-test.yml
@@ -5,7 +5,7 @@ spring:
     enabled: false
   data:
     redis:
-      host: ${REDIS_HOST}
+      host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #50 

---
## 📌 작업 내용 및 특이사항
* 로그아웃 시 Redis에 저장된 리프레시 토큰을 삭제하도록 구현했습니다.
* accessToken과 refreshToken 쿠키를 빈 문자열과 Max-Age=0으로 설정하여 만료 처리했습니다.
* 로그아웃 요청은 인증이 필요한 요청이므로, /auth/logout 경로에 인증이 필요하도록 Spring Security 설정을 수정했습니다.
