### PR TITLE
feat: 이미지 업로드용 S3 Presigned URL 발급 기능 구현

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -22,4 +22,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -1,0 +1,29 @@
+package org.cherrypic.domain.image.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.service.ImageService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "2. 이미지 API", description = "이미지 관련 API입니다.")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping("/members/me/upload-url")
+    @Operation(
+            summary = "회원 프로필 이미지 Presigned URL 생성",
+            description = "회원 프로필 이미지 업로드를 위한 Presigned URL을 생성합니다.")
+    public PresignedUrlResponse memberProfileImageUploadUrlCreate(
+            @Valid @RequestBody MemberProfileImageUploadRequest request) {
+        return imageService.createMemberProfileImageUploadUrl(request);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.cherrypic.domain.image.enums.ImageFileExtension;
+
+public record MemberProfileImageUploadRequest(
+        @NotNull(message = "이미지 파일의 확장자는 비워둘 수 없습니다.")
+                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
+                ImageFileExtension imageFileExtension) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 
 public record MemberProfileImageUploadRequest(
-        @NotNull(message = "이미지 파일의 확장자는 비워둘 수 없습니다.")
+        @NotNull(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
                 @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,5 @@
+package org.cherrypic.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PresignedUrlResponse(@Schema(description = "Presigned URL") String presignedUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.image.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageFileExtension {
+    PNG("png"),
+    JPG("jpg"),
+    JPEG("jpeg"),
+    ;
+
+    private final String extension;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
@@ -1,5 +1,7 @@
 package org.cherrypic.domain.image.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,4 +14,12 @@ public enum ImageFileExtension {
     ;
 
     private final String extension;
+
+    @JsonCreator
+    public static ImageFileExtension from(String extension) {
+        return Stream.of(values())
+                .filter(e -> e.name().equalsIgnoreCase(extension))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageType.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageType.java
@@ -1,0 +1,16 @@
+package org.cherrypic.domain.image.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageType {
+    MEMBER_PROFILE("member_profile"),
+    ALBUM_COVER("album_cover"),
+    ALBUM_IMAGE("album_image"),
+    EVENT_IMAGE("event_image"),
+    ;
+
+    private final String type;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageType.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageType.java
@@ -6,11 +6,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ImageType {
-    MEMBER_PROFILE("member_profile"),
-    ALBUM_COVER("album_cover"),
-    ALBUM_IMAGE("album_image"),
-    EVENT_IMAGE("event_image"),
+    MEMBER_PROFILE("member-profile", "회원 프로필 사진"),
+    ALBUM_COVER("album-cover", "앨범 커버"),
+    ALBUM_IMAGE("album-image", "앨범 사진"),
+    EVENT_IMAGE("event-image", "이벤트 사진"),
     ;
 
     private final String type;
+    private final String description;
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -1,0 +1,8 @@
+package org.cherrypic.domain.image.service;
+
+import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+
+public interface ImageService {
+    PresignedUrlResponse createMemberProfileImageUploadUrl(MemberProfileImageUploadRequest request);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -1,0 +1,96 @@
+package org.cherrypic.domain.image.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.domain.image.enums.ImageType;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.helper.SpringEnvironmentHelper;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.s3.S3Properties;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+
+    private final MemberUtil memberUtil;
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+    private final AmazonS3 amazonS3;
+    private final S3Properties s3Properties;
+
+    @Override
+    public PresignedUrlResponse createMemberProfileImageUploadUrl(
+            MemberProfileImageUploadRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        String imageKey = generateUUID();
+        String fileName =
+                createFileName(
+                        ImageType.MEMBER_PROFILE,
+                        currentMember.getId(),
+                        imageKey,
+                        request.imageFileExtension());
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                generatePresignedUrlRequest(
+                        s3Properties.bucket(),
+                        fileName,
+                        request.imageFileExtension().getExtension());
+
+        String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+
+        return new PresignedUrlResponse(presignedUrl);
+    }
+
+    private String generateUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String createFileName(
+            ImageType imageType,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension imageFileExtension) {
+        return springEnvironmentHelper.getCurrentProfile()
+                + "/"
+                + imageType.getType()
+                + "/"
+                + targetId
+                + "/"
+                + imageKey
+                + "."
+                + imageFileExtension.getExtension();
+    }
+
+    private GeneratePresignedUrlRequest generatePresignedUrlRequest(
+            String bucket, String fileName, String imageFileExtension) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
+                        .withKey(fileName)
+                        .withContentType("image/" + imageFileExtension)
+                        .withExpiration(getPresignedUrlExpiration());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        return generatePresignedUrlRequest;
+    }
+
+    private Date getPresignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += TimeUnit.MINUTES.toMillis(1);
+        expiration.setTime(expTimeMillis);
+
+        return expiration;
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -33,26 +33,22 @@ public class ImageServiceImpl implements ImageService {
             MemberProfileImageUploadRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        String imageKey = generateUUID();
-        String fileName =
-                createFileName(
-                        ImageType.MEMBER_PROFILE,
-                        currentMember.getId(),
-                        imageKey,
-                        request.imageFileExtension());
+        return createPresignedUrl(
+                ImageType.MEMBER_PROFILE, currentMember.getId(), request.imageFileExtension());
+    }
+
+    private PresignedUrlResponse createPresignedUrl(
+            ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
+        String imageKey = UUID.randomUUID().toString();
+        String fileName = createFileName(imageType, targetId, imageKey, imageFileExtension);
+
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 generatePresignedUrlRequest(
-                        s3Properties.bucket(),
-                        fileName,
-                        request.imageFileExtension().getExtension());
+                        s3Properties.bucket(), fileName, imageFileExtension.getExtension());
 
         String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
 
         return new PresignedUrlResponse(presignedUrl);
-    }
-
-    private String generateUUID() {
-        return UUID.randomUUID().toString();
     }
 
     private String createFileName(

--- a/cherrypic-api/src/main/resources/application-dev.yml
+++ b/cherrypic-api/src/main/resources/application-dev.yml
@@ -37,6 +37,14 @@ jwt:
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
   issuer: ${JWT_ISSUER}
 
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${S3_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
+
 swagger:
   username: ${SWAGGER_USERNAME}
   password: ${SWAGGER_PASSWORD}

--- a/cherrypic-api/src/main/resources/application-local.yml
+++ b/cherrypic-api/src/main/resources/application-local.yml
@@ -37,6 +37,14 @@ jwt:
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
   issuer: ${JWT_ISSUER}
 
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${S3_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
+
 spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/cherrypic-api/src/main/resources/application-prod.yml
+++ b/cherrypic-api/src/main/resources/application-prod.yml
@@ -36,3 +36,11 @@ jwt:
   access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
   issuer: ${JWT_ISSUER}
+
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${S3_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -13,6 +13,10 @@ import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.service.ImageService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -57,14 +61,14 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.data.presignedUrl").isNotEmpty());
         }
 
-        @Test
-        void 이미지_파일_확장자가_null이면_예외가_발생한다() throws Exception {
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {"JPEG1", "PDF", "TXT"})
+        void 이미지_파일_확장자가_null_또는_지원하지_않는_형식이면_예외가_발생한다(String extension) throws Exception {
             // given
-            MemberProfileImageUploadRequest request = new MemberProfileImageUploadRequest(null);
-
-            PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
-
-            given(imageService.createMemberProfileImageUploadUrl(request)).willReturn(response);
+            MemberProfileImageUploadRequest request =
+                    new MemberProfileImageUploadRequest(ImageFileExtension.from(extension));
 
             // when & then
             ResultActions perform =
@@ -77,7 +81,9 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("이미지 파일의 확장자는 비워둘 수 없습니다."));
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -1,0 +1,83 @@
+package org.cherrypic.image.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.domain.image.controller.ImageController;
+import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.domain.image.service.ImageService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(ImageController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ImageControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private ImageService imageService;
+
+    @Nested
+    class Presigned_URL_생성할_때 {
+
+        @Test
+        void 정상적인_회원_프로필_이미지_업로드_요청이면_Presigned_URL을_반환한다() throws Exception {
+            // given
+            MemberProfileImageUploadRequest request =
+                    new MemberProfileImageUploadRequest(ImageFileExtension.JPEG);
+
+            PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
+
+            given(imageService.createMemberProfileImageUploadUrl(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/members/me/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.presignedUrl").isNotEmpty());
+        }
+
+        @Test
+        void 이미지_파일_확장자가_null이면_예외가_발생한다() throws Exception {
+            // given
+            MemberProfileImageUploadRequest request = new MemberProfileImageUploadRequest(null);
+
+            PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
+
+            given(imageService.createMemberProfileImageUploadUrl(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/members/me/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이미지 파일의 확장자는 비워둘 수 없습니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -53,7 +53,7 @@ class ImageControllerTest {
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
                     .andExpect(jsonPath("$.data.presignedUrl").isNotEmpty());
         }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -36,10 +36,10 @@ class ImageControllerTest {
     @MockitoBean private ImageService imageService;
 
     @Nested
-    class Presigned_URL_생성할_때 {
+    class Presigned_URL을_생성할_때 {
 
         @Test
-        void 정상적인_회원_프로필_이미지_업로드_요청이면_Presigned_URL을_반환한다() throws Exception {
+        void 유효한_요청이면_회원_프로필_이미지용_Presigned_URL을_반환한다() throws Exception {
             // given
             MemberProfileImageUploadRequest request =
                     new MemberProfileImageUploadRequest(ImageFileExtension.JPEG);

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -1,0 +1,66 @@
+package org.cherrypic.image.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.domain.image.service.ImageService;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+class ImageServiceTest extends IntegrationTest {
+
+    @Autowired private ImageService imageService;
+    @Autowired private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        Member member =
+                Member.createMember(
+                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                        "testNickname",
+                        "testProfileImageUrl");
+        memberRepository.save(member);
+
+        UserDetails userDetails =
+                User.withUsername(member.getId().toString())
+                        .password("")
+                        .authorities(member.getRole().name())
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @Nested
+    class Presigned_URL_생성할_때 {
+
+        @Test
+        void 회원_프로필_이미지_Presigned_URL을_정상적으로_생성한다() {
+            // given
+            MemberProfileImageUploadRequest request =
+                    new MemberProfileImageUploadRequest(ImageFileExtension.JPEG);
+
+            // when
+            PresignedUrlResponse response = imageService.createMemberProfileImageUploadUrl(request);
+
+            // then
+            assertThat(response.presignedUrl())
+                    .containsPattern(
+                            String.format(
+                                    "/%s/%s/%d/[\\w\\-]+\\.jpeg", "local", "member_profile", 1));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -45,10 +45,10 @@ class ImageServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class Presigned_URL_생성할_때 {
+    class Presigned_URL을_생성할_때 {
 
         @Test
-        void 회원_프로필_이미지_Presigned_URL을_정상적으로_생성한다() {
+        void 유효한_요청이면_회원_프로필_이미지용_Presigned_URL을_생성한다() {
             // given
             MemberProfileImageUploadRequest request =
                     new MemberProfileImageUploadRequest(ImageFileExtension.JPEG);

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -60,7 +60,7 @@ class ImageServiceTest extends IntegrationTest {
             assertThat(response.presignedUrl())
                     .containsPattern(
                             String.format(
-                                    "/%s/%s/%d/[\\w\\-]+\\.jpeg", "local", "member_profile", 1));
+                                    "/%s/%s/%d/[\\w\\-]+\\.jpeg", "local", "member-profile", 1));
         }
     }
 }

--- a/cherrypic-api/src/test/resources/application-test.yml
+++ b/cherrypic-api/src/test/resources/application-test.yml
@@ -25,3 +25,11 @@ jwt:
   access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
   issuer: ${JWT_ISSUER}
+
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${S3_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}

--- a/cherrypic-infrastructure/build.gradle
+++ b/cherrypic-infrastructure/build.gradle
@@ -8,4 +8,6 @@ jar {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 }

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/aws/AwsProperties.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/aws/AwsProperties.java
@@ -1,0 +1,6 @@
+package org.cherrypic.aws;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("aws")
+public record AwsProperties(String accessKeyId, String secretAccessKey, String region) {}

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/properties/PropertiesConfig.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/properties/PropertiesConfig.java
@@ -1,11 +1,19 @@
 package org.cherrypic.properties;
 
+import org.cherrypic.aws.AwsProperties;
 import org.cherrypic.jwt.JwtProperties;
 import org.cherrypic.oidc.OidcProperties;
 import org.cherrypic.redis.RedisProperties;
+import org.cherrypic.s3.S3Properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties({RedisProperties.class, OidcProperties.class, JwtProperties.class})
+@EnableConfigurationProperties({
+    RedisProperties.class,
+    OidcProperties.class,
+    JwtProperties.class,
+    AwsProperties.class,
+    S3Properties.class
+})
 public class PropertiesConfig {}

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/s3/S3Config.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/s3/S3Config.java
@@ -1,0 +1,34 @@
+package org.cherrypic.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.aws.AwsProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final AwsProperties awsProperties;
+    private final S3Properties s3Properties;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        BasicAWSCredentials credentials =
+                new BasicAWSCredentials(
+                        awsProperties.accessKeyId(), awsProperties.secretAccessKey());
+        AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+                new AwsClientBuilder.EndpointConfiguration(
+                        s3Properties.endpoint(), awsProperties.region());
+
+        return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(endpointConfiguration)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/s3/S3Properties.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/s3/S3Properties.java
@@ -1,0 +1,6 @@
+package org.cherrypic.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("aws.s3")
+public record S3Properties(String bucket, String endpoint) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #52 

---
## 📌 작업 내용 및 특이사항
* AwsProperties, S3Properties 정의 및 설정 분리
  * 공통 AWS 설정(access-key-id, secret-access-key, region)과 S3 전용 설정(bucket, endpoint)을 분리하였습니다.
* S3 Presigned URL 생성을 위한 S3Config 구성하였습니다.
* 회원 프로필 이미지 업로드용 Presigned URL 발급 API를 추가하였습니다.
* Presigned URL 생성을 위한 요청/응답 DTO 및 관련 enum(ImageType, ImageFileExtension)을 정의하였습니다.
* S3에 저장될 경로를 {spring_profile}/{image_type}/{target_id}/{uuid}.{ext} 형식으로 구성하였습니다.
* 이후 앨범 커버, 앨범 이미지, 이벤트 이미지 등 도메인별 Presigned URL 발급 및 업로드 완료 처리 API를 추가할 예정입니다.

---
## 📚 참고사항
* 이미지 업로드는 Presigned URL 발급 → 클라이언트가 S3에 업로드 → 이후 처리(API 호출 또는 도메인 생성 요청) 의 흐름으로 동작합니다.
* 예를 들어,
  * 회원 프로필 이미지는 S3 업로드 후, 업로드 완료 API를 호출하여 DB에 반영합니다.
  * 앨범 커버 이미지는 S3 업로드 후, 앨범 생성 요청 시 해당 URL을 포함하여 서버에 전달합니다.
* 이처럼 업로드 완료 처리 방식은 도메인에 따라 다르게 동작하며, 직접적인 이미지 업로드는 클라이언트가 담당하고, 백엔드는 Presigned URL 발급 및 메타데이터 저장을 담당합니다.
