### PR TITLE
feat: 이벤트 생성 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -1,11 +1,11 @@
 package org.cherrypic.domain.album.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.cherrypic.exception.BaseErrorCode;
 
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
 public enum AlbumErrorCode implements BaseErrorCode {
     ALBUM_NOT_FOUND(404, "엘범이 존재하지 않습니다."),
     ;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.album.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlbumErrorCode implements BaseErrorCode {
+    ALBUM_NOT_FOUND(404, "엘범이 존재하지 않습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum AlbumErrorCode implements BaseErrorCode {
-    ALBUM_NOT_FOUND(404, "엘범이 존재하지 않습니다."),
+    ALBUM_NOT_FOUND(404, "앨범이 존재하지 않습니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumException.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.album.exception;
+
+import org.cherrypic.exception.BaseCustomException;
+
+public class AlbumException extends BaseCustomException {
+    public AlbumException(AlbumErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -1,0 +1,32 @@
+package org.cherrypic.domain.event.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.dto.EventCreateResponse;
+import org.cherrypic.domain.event.service.EventService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/events")
+@RequiredArgsConstructor
+@Tag(name = "4. 이벤트 API", description = "이벤트 관련 API입니다.")
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping
+    @Operation(summary = "이벤트 생성", description = "새로운 이벤트를 생성합니다.")
+    public ResponseEntity<EventCreateResponse> eventCreate(
+            @Valid @RequestBody EventCreateRequest request) {
+        EventCreateResponse response = eventService.createEvent(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
@@ -11,4 +11,5 @@ public record EventCreateRequest(
         @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")
                 @Max(100)
                 @Schema(description = "이벤트의 이름", example = "일본 여행")
-                String title) {}
+                String title,
+        @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
@@ -1,0 +1,14 @@
+package org.cherrypic.domain.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+
+public record EventCreateRequest(
+        @NotBlank(message = "엘범 ID는 비워둘 수 없습니다.")
+                @Schema(description = "이벤트가 속한 엘범의 ID", example = "1L")
+                Long albumId,
+        @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")
+                @Max(100)
+                @Schema(description = "이벤트의 이름", example = "일본 여행")
+                String title) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 
 public record EventCreateRequest(
         @NotNull(message = "엘범 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이벤트가 속한 엘범의 ID", example = "1L")
+                @Schema(description = "이벤트가 속한 엘범의 ID", example = "1")
                 Long albumId,
         @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")
                 @Size(max = 100, message = "이벤트 이름은 최대 100자까지 가능합니다.")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record EventCreateRequest(
-        @NotNull(message = "엘범 ID는 비워둘 수 없습니다.")
+        @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
                 @Schema(description = "이벤트가 속한 엘범의 ID", example = "1")
                 Long albumId,
         @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
@@ -1,15 +1,16 @@
 package org.cherrypic.domain.event.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record EventCreateRequest(
-        @NotBlank(message = "엘범 ID는 비워둘 수 없습니다.")
+        @NotNull(message = "엘범 ID는 비워둘 수 없습니다.")
                 @Schema(description = "이벤트가 속한 엘범의 ID", example = "1L")
                 Long albumId,
         @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")
-                @Max(100)
+                @Size(max = 100, message = "이벤트 이름은 최대 100자까지 가능합니다.")
                 @Schema(description = "이벤트의 이름", example = "일본 여행")
                 String title,
         @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
@@ -1,0 +1,14 @@
+package org.cherrypic.domain.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.event.entity.Event;
+
+public record EventCreateResponse(
+        @Schema(description = "엘범 ID", example = "1L") Long albumId,
+        @Schema(description = "이벤트 ID", example = "1L") Long eventId,
+        @Schema(description = "이벤트 제목", example = "일본 여행") String eventTitle) {
+    public static EventCreateResponse from(Event event, Album album) {
+        return new EventCreateResponse(album.getId(), event.getId(), event.getName());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.event.entity.Event;
 
 public record EventCreateResponse(
-        @Schema(description = "이벤트 ID", example = "1L") Long eventId,
-        @Schema(description = "이벤트 제목", example = "일본 여행") String eventTitle,
+        @Schema(description = "이벤트 ID", example = "1") Long eventId,
+        @Schema(description = "이벤트 제목", example = "일본 여행") String title,
         @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {
     public static EventCreateResponse from(Event event) {
         return new EventCreateResponse(event.getId(), event.getTitle(), event.getCoverUrl());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
@@ -1,16 +1,13 @@
 package org.cherrypic.domain.event.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.cherrypic.album.entity.Album;
 import org.cherrypic.event.entity.Event;
 
 public record EventCreateResponse(
-        @Schema(description = "엘범 ID", example = "1L") Long albumId,
         @Schema(description = "이벤트 ID", example = "1L") Long eventId,
         @Schema(description = "이벤트 제목", example = "일본 여행") String eventTitle,
-        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl) {
-    public static EventCreateResponse from(Event event, Album album) {
-        return new EventCreateResponse(
-                album.getId(), event.getId(), event.getTitle(), event.getCoverUrl());
+        @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {
+    public static EventCreateResponse from(Event event) {
+        return new EventCreateResponse(event.getId(), event.getTitle(), event.getCoverUrl());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateResponse.java
@@ -7,8 +7,10 @@ import org.cherrypic.event.entity.Event;
 public record EventCreateResponse(
         @Schema(description = "엘범 ID", example = "1L") Long albumId,
         @Schema(description = "이벤트 ID", example = "1L") Long eventId,
-        @Schema(description = "이벤트 제목", example = "일본 여행") String eventTitle) {
+        @Schema(description = "이벤트 제목", example = "일본 여행") String eventTitle,
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl) {
     public static EventCreateResponse from(Event event, Album album) {
-        return new EventCreateResponse(album.getId(), event.getId(), event.getName());
+        return new EventCreateResponse(
+                album.getId(), event.getId(), event.getTitle(), event.getCoverUrl());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
-    NOT_ALBUM_PARTICIPANT(400, "사용자가 소속되지 않은 엘범에서 이벤트를 만들 수 없습니다.");
+    NOT_ALBUM_PARTICIPANT(403, "참여하지 않은 엘범에는 이벤트를 생성할 권한이 없습니다");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -1,0 +1,14 @@
+package org.cherrypic.domain.event.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum EventErrorCode implements BaseErrorCode {
+    NOT_ALBUM_PARTICIPANT(400, "사용자가 소속되지 않은 엘범에서 이벤트를 만들 수 없습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
-    NOT_ALBUM_PARTICIPANT(403, "참여하지 않은 엘범에는 이벤트를 생성할 권한이 없습니다");
+    NOT_ALBUM_PARTICIPANT(403, "참여하지 않은 앨범에는 이벤트를 생성할 권한이 없습니다");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventException.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.event.exception;
+
+import org.cherrypic.exception.BaseCustomException;
+
+public class EventException extends BaseCustomException {
+    public EventException(EventErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.event.service;
+
+import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.dto.EventCreateResponse;
+
+public interface EventService {
+
+    EventCreateResponse createEvent(EventCreateRequest request);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
@@ -4,6 +4,5 @@ import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventCreateResponse;
 
 public interface EventService {
-
     EventCreateResponse createEvent(EventCreateRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -35,7 +35,7 @@ public class EventServiceImpl implements EventService {
         final Album currentAlbum = getAlbumById(request.albumId());
         validateAlbumParticipant(currentMember, currentAlbum);
 
-        Event event = Event.createEvent(currentAlbum, request.title());
+        Event event = Event.createEvent(currentAlbum, request.title(), request.coverUrl());
         eventRepository.save(event);
 
         return EventCreateResponse.from(event, currentAlbum);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -30,26 +30,24 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventCreateResponse createEvent(EventCreateRequest request) {
-
         final Member currentMember = memberUtil.getCurrentMember();
-        final Album currentAlbum = getAlbumById(request.albumId());
-        validateAlbumParticipant(currentMember, currentAlbum);
+        final Album album = getAlbumById(request.albumId());
+        validateAlbumParticipant(currentMember, album);
 
-        Event event = Event.createEvent(currentAlbum, request.title(), request.coverUrl());
+        Event event = Event.createEvent(album, request.title(), request.coverUrl());
         eventRepository.save(event);
 
-        return EventCreateResponse.from(event, currentAlbum);
+        return EventCreateResponse.from(event);
     }
 
-    private Album getAlbumById(Long id) {
+    private Album getAlbumById(Long albumId) {
         return albumRepository
-                .findById(id)
+                .findById(albumId)
                 .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
     }
 
-    private void validateAlbumParticipant(Member participant, Album currentAlbum) {
-        if (!participantRepository.existsByMemberIdAndAlbumId(
-                participant.getId(), currentAlbum.getId())) {
+    private void validateAlbumParticipant(Member member, Album album) {
+        if (!participantRepository.existsByMemberIdAndAlbumId(member.getId(), album.getId())) {
             throw new EventException(EventErrorCode.NOT_ALBUM_PARTICIPANT);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -1,0 +1,56 @@
+package org.cherrypic.domain.event.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.repository.AlbumRepository;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.exception.AlbumException;
+import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.dto.EventCreateResponse;
+import org.cherrypic.domain.event.exception.EventErrorCode;
+import org.cherrypic.domain.event.exception.EventException;
+import org.cherrypic.event.entity.Event;
+import org.cherrypic.event.repository.EventRepository;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.repository.ParticipantRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EventServiceImpl implements EventService {
+
+    private final MemberUtil memberUtil;
+
+    private final AlbumRepository albumRepository;
+    private final ParticipantRepository participantRepository;
+    private final EventRepository eventRepository;
+
+    @Override
+    public EventCreateResponse createEvent(EventCreateRequest request) {
+
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album currentAlbum = getAlbumById(request.albumId());
+        validateAlbumParticipant(currentMember, currentAlbum);
+
+        Event event = Event.createEvent(currentAlbum, request.title());
+        eventRepository.save(event);
+
+        return EventCreateResponse.from(event, currentAlbum);
+    }
+
+    private Album getAlbumById(Long id) {
+        return albumRepository
+                .findById(id)
+                .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+
+    private void validateAlbumParticipant(Member participant, Album currentAlbum) {
+        if (!participantRepository.existsByMemberIdAndAlbumId(
+                participant.getId(), currentAlbum.getId())) {
+            throw new EventException(EventErrorCode.NOT_ALBUM_PARTICIPANT);
+        }
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/TransactionUtil.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/TransactionUtil.java
@@ -1,0 +1,14 @@
+package org.cherrypic.global.util;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionUtil {
+
+    @Transactional
+    public <T> T getResult(Supplier<T> transactionalTask) {
+        return transactionalTask.get();
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -1,0 +1,3 @@
+package org.cherrypic.event.controller;
+
+public class EventControllerTest {}

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -42,7 +42,7 @@ public class EventControllerTest {
             // given
             EventCreateRequest request = new EventCreateRequest(1L, "Test Event", "Test CoverURL");
             EventCreateResponse response =
-                    new EventCreateResponse(1L, 1L, "Test Event", "Test CoverURL");
+                    new EventCreateResponse(1L, "Test Event", "Test CoverURL");
 
             given(eventService.createEvent(request)).willReturn(response);
 
@@ -56,7 +56,6 @@ public class EventControllerTest {
             perform.andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
-                    .andExpect(jsonPath("$.data.albumId").value(1))
                     .andExpect(jsonPath("$.data.eventId").value(1))
                     .andExpect(jsonPath("$.data.eventTitle").value("Test Event"))
                     .andExpect(jsonPath("$.data.coverUrl").value("Test CoverURL"));

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -57,7 +57,7 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
                     .andExpect(jsonPath("$.data.eventId").value(1))
-                    .andExpect(jsonPath("$.data.eventTitle").value("Test Event"))
+                    .andExpect(jsonPath("$.data.title").value("Test Event"))
                     .andExpect(jsonPath("$.data.coverUrl").value("Test CoverURL"));
         }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -40,9 +40,8 @@ public class EventControllerTest {
         @Test
         void 유효한_요청이면_이벤트_생성_정보를_반환한다() throws Exception {
             // given
-            EventCreateRequest request = new EventCreateRequest(1L, "Test Event", "Test CoverURL");
-            EventCreateResponse response =
-                    new EventCreateResponse(1L, "Test Event", "Test CoverURL");
+            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+            EventCreateResponse response = new EventCreateResponse(1L, "testTitle", "testCoverUrl");
 
             given(eventService.createEvent(request)).willReturn(response);
 
@@ -57,8 +56,8 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
                     .andExpect(jsonPath("$.data.eventId").value(1))
-                    .andExpect(jsonPath("$.data.title").value("Test Event"))
-                    .andExpect(jsonPath("$.data.coverUrl").value("Test CoverURL"));
+                    .andExpect(jsonPath("$.data.title").value("testTitle"))
+                    .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"));
         }
 
         @NullSource
@@ -66,7 +65,7 @@ public class EventControllerTest {
         void 엘범_ID가_null이면_에러가_발생한다(Long albumId) throws Exception {
             // given
             EventCreateRequest request =
-                    new EventCreateRequest(albumId, "Test Event", "Test CoverURL");
+                    new EventCreateRequest(albumId, "testTitle", "testCoverUrl");
 
             // when & then
             ResultActions perform =
@@ -88,7 +87,7 @@ public class EventControllerTest {
         @ValueSource(strings = {" "})
         void 이벤트_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
             // given
-            EventCreateRequest request = new EventCreateRequest(1L, title, "Test CoverURL");
+            EventCreateRequest request = new EventCreateRequest(1L, title, "testCoverUrl");
 
             // when & then
             ResultActions perform =
@@ -108,7 +107,7 @@ public class EventControllerTest {
         void 이벤트_이름이_100자를_넘어가면_에러가_발생한다() throws Exception {
             // given
             EventCreateRequest request =
-                    new EventCreateRequest(1L, "a".repeat(101), "Test CoverURL");
+                    new EventCreateRequest(1L, "t".repeat(101), "testCoverUrl");
 
             // when & then
             ResultActions perform =

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -35,7 +35,7 @@ public class EventControllerTest {
     @MockitoBean private EventService eventService;
 
     @Nested
-    class 이벤트를_만들_때 {
+    class 이벤트를_생성할_때 {
 
         @Test
         void 유효한_요청이면_이벤트_생성_정보를_반환한다() throws Exception {
@@ -60,9 +60,9 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"));
         }
 
-        @NullSource
         @ParameterizedTest
-        void 엘범_ID가_null이면_에러가_발생한다(Long albumId) throws Exception {
+        @NullSource
+        void 엘범_ID가_null이면_예외가_발생한다(Long albumId) throws Exception {
             // given
             EventCreateRequest request =
                     new EventCreateRequest(albumId, "testTitle", "testCoverUrl");
@@ -104,7 +104,7 @@ public class EventControllerTest {
         }
 
         @Test
-        void 이벤트_이름이_100자를_넘어가면_에러가_발생한다() throws Exception {
+        void 이벤트_이름이_100자를_넘어가면_예외가_발생한다() throws Exception {
             // given
             EventCreateRequest request =
                     new EventCreateRequest(1L, "t".repeat(101), "testCoverUrl");

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -1,3 +1,128 @@
 package org.cherrypic.event.controller;
 
-public class EventControllerTest {}
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.domain.event.controller.EventController;
+import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.dto.EventCreateResponse;
+import org.cherrypic.domain.event.service.EventService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(EventController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class EventControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private EventService eventService;
+
+    @Nested
+    class 이벤트를_만들_때 {
+
+        @Test
+        void 유효한_요청이면_이벤트_생성_정보를_반환한다() throws Exception {
+            // given
+            EventCreateRequest request = new EventCreateRequest(1L, "Test Event", "Test CoverURL");
+            EventCreateResponse response =
+                    new EventCreateResponse(1L, 1L, "Test Event", "Test CoverURL");
+
+            given(eventService.createEvent(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
+                    .andExpect(jsonPath("$.data.albumId").value(1))
+                    .andExpect(jsonPath("$.data.eventId").value(1))
+                    .andExpect(jsonPath("$.data.eventTitle").value("Test Event"))
+                    .andExpect(jsonPath("$.data.coverUrl").value("Test CoverURL"));
+        }
+
+        @NullSource
+        @ParameterizedTest
+        void 엘범_ID가_null이면_에러가_발생한다(Long albumId) throws Exception {
+            // given
+            EventCreateRequest request =
+                    new EventCreateRequest(albumId, "Test Event", "Test CoverURL");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("엘범 ID는 비워둘 수 없습니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 이벤트_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
+            // given
+            EventCreateRequest request = new EventCreateRequest(1L, title, "Test CoverURL");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이벤트 이름은 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 이벤트_이름이_100자를_넘어가면_에러가_발생한다() throws Exception {
+            // given
+            EventCreateRequest request =
+                    new EventCreateRequest(1L, "a".repeat(101), "Test CoverURL");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이벤트 이름은 최대 100자까지 가능합니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -62,7 +62,7 @@ public class EventControllerTest {
 
         @ParameterizedTest
         @NullSource
-        void 엘범_ID가_null이면_예외가_발생한다(Long albumId) throws Exception {
+        void 앨범_ID가_null이면_예외가_발생한다(Long albumId) throws Exception {
             // given
             EventCreateRequest request =
                     new EventCreateRequest(albumId, "testTitle", "testCoverUrl");
@@ -78,7 +78,7 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("엘범 ID는 비워둘 수 없습니다."));
+                    .andExpect(jsonPath("$.data.message").value("앨범 ID는 비워둘 수 없습니다."));
         }
 
         @ParameterizedTest

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -71,7 +71,6 @@ public class EventServiceTest extends IntegrationTest {
             Participant participant =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
             participantRepository.save(participant);
-            album1.addParticipant(participant);
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -41,7 +41,7 @@ public class EventServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        Member member =
+        member =
                 Member.createMember(
                         OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
                         "testNickname",
@@ -69,10 +69,7 @@ public class EventServiceTest extends IntegrationTest {
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant =
-                    Participant.createParticipant(
-                            memberRepository.findById(1L).orElseThrow(),
-                            album1,
-                            ParticipantRole.HOST);
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
             participantRepository.save(participant);
             album1.addParticipant(participant);
         }
@@ -97,7 +94,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 엘범에_속하지_않은_사용자가_이벤트를_생성하면_예외가_발생한다() {
+        void 앨범에_속하지_않은_사용자가_이벤트를_생성하면_예외가_발생한다() {
 
             // given
             EventCreateRequest request = new EventCreateRequest(2L, "testEvent", "tesCoverUrl");
@@ -105,7 +102,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.createEvent(request))
                     .isInstanceOf(EventException.class)
-                    .hasMessageContaining("참여하지 않은 엘범에는 이벤트를 생성할 권한이 없습니다");
+                    .hasMessageContaining("참여하지 않은 앨범에는 이벤트를 생성할 권한이 없습니다");
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -99,7 +99,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.createEvent(request))
                     .isInstanceOf(EventException.class)
-                    .hasMessageContaining(EventErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+                    .hasMessage(EventErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -6,8 +6,10 @@ import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.repository.AlbumRepository;
-import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
-import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.service.EventService;
+import org.cherrypic.event.entity.Event;
+import org.cherrypic.event.repository.EventRepository;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
@@ -26,7 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 public class EventServiceTest extends IntegrationTest {
 
-    @Autowired private AlbumService albumService;
+    @Autowired private EventService eventService;
+    @Autowired private EventRepository eventRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
 
@@ -54,28 +57,35 @@ public class EventServiceTest extends IntegrationTest {
     @Nested
     class 이벤트를_생성할_때 {
 
+        @BeforeEach
+        void setUp() {
+            Album album = Album.createAlbum("Test Album", "Test URL", AlbumType.SHARED);
+            albumRepository.save(album);
+            Participant participant =
+                    Participant.createParticipant(
+                            memberRepository.findById(1L).orElseThrow(),
+                            album,
+                            ParticipantRole.HOST);
+            album.addParticipant(participant);
+        }
+
         @Test
-        void 유효한_요청이면_엘범이_생성된다() {
+        void 유효한_요청이면_이벤트가_생성된다() {
 
             // given
-            AlbumCreateRequest request =
-                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumType.SHARED);
+            EventCreateRequest request = new EventCreateRequest(1L, "Test Event", "Test CoverURL");
 
             // when
-            albumService.createAlbum(request);
+            eventService.createEvent(request);
 
             // then
-            Album album = albumRepository.findById(1L).orElseThrow();
-            Participant participant = album.getParticipants().get(0);
+            Event event = eventRepository.findById(1L).orElseThrow();
 
             Assertions.assertAll(
-                    () -> assertThat(album.getId()).isEqualTo(1L),
-                    () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
-                    () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
-                    () -> assertThat(album.getType()).isEqualTo(AlbumType.SHARED),
-                    () -> assertThat(participant.getId()).isEqualTo(1L),
-                    () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
-                    () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST));
+                    () -> assertThat(event.getId()).isEqualTo(1L),
+                    () -> assertThat(event.getAlbum().getId()).isEqualTo(1L),
+                    () -> assertThat(event.getTitle()).isEqualTo("Test Event"),
+                    () -> assertThat(event.getCoverUrl()).isEqualTo("Test CoverURL"));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -9,6 +9,7 @@ import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.service.EventService;
 import org.cherrypic.event.entity.Event;
@@ -98,7 +99,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.createEvent(request))
                     .isInstanceOf(EventException.class)
-                    .hasMessageContaining("참여하지 않은 앨범에는 이벤트를 생성할 권한이 없습니다");
+                    .hasMessageContaining(EventErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -1,12 +1,15 @@
 package org.cherrypic.event.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.service.EventService;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.event.repository.EventRepository;
@@ -59,14 +62,16 @@ public class EventServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            Album album = Album.createAlbum("Test Album", "Test URL", AlbumType.SHARED);
-            albumRepository.save(album);
+            Album album1 = Album.createAlbum("Test Album1", "Test URL 1", AlbumType.SHARED);
+            Album album2 = Album.createAlbum("Test Album2", "Test URL 2", AlbumType.SHARED);
+            albumRepository.saveAll(List.of(album1, album2));
+
             Participant participant =
                     Participant.createParticipant(
                             memberRepository.findById(1L).orElseThrow(),
-                            album,
+                            album1,
                             ParticipantRole.HOST);
-            album.addParticipant(participant);
+            album1.addParticipant(participant);
         }
 
         @Test
@@ -86,6 +91,18 @@ public class EventServiceTest extends IntegrationTest {
                     () -> assertThat(event.getAlbum().getId()).isEqualTo(1L),
                     () -> assertThat(event.getTitle()).isEqualTo("Test Event"),
                     () -> assertThat(event.getCoverUrl()).isEqualTo("Test CoverURL"));
+        }
+
+        @Test
+        void 엘범에_속하지_않은_사용자는_이벤트를_생성할_수_없다() {
+
+            // given
+            EventCreateRequest request = new EventCreateRequest(2L, "Test Event", "Test CoverURL");
+
+            // when & then
+            assertThatThrownBy(() -> eventService.createEvent(request))
+                    .isInstanceOf(EventException.class)
+                    .hasMessageContaining("사용자가 소속되지 않은 엘범에서 이벤트를 만들 수 없습니다.");
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -76,7 +76,6 @@ public class EventServiceTest extends IntegrationTest {
 
         @Test
         void 유효한_요청이면_이벤트가_생성된다() {
-
             // given
             EventCreateRequest request = new EventCreateRequest(1L, "testEvent", "testCoverUrl");
 
@@ -85,7 +84,6 @@ public class EventServiceTest extends IntegrationTest {
 
             // then
             Event event = eventRepository.findById(1L).orElseThrow();
-
             Assertions.assertAll(
                     () -> assertThat(event.getId()).isEqualTo(1L),
                     () -> assertThat(event.getAlbum().getId()).isEqualTo(1L),
@@ -95,7 +93,6 @@ public class EventServiceTest extends IntegrationTest {
 
         @Test
         void 앨범에_속하지_않은_사용자가_이벤트를_생성하면_예외가_발생한다() {
-
             // given
             EventCreateRequest request = new EventCreateRequest(2L, "testEvent", "tesCoverUrl");
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -102,7 +102,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.createEvent(request))
                     .isInstanceOf(EventException.class)
-                    .hasMessageContaining("사용자가 소속되지 않은 엘범에서 이벤트를 만들 수 없습니다.");
+                    .hasMessageContaining("참여하지 않은 엘범에는 이벤트를 생성할 권한이 없습니다");
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -1,0 +1,81 @@
+package org.cherrypic.event.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumType;
+import org.cherrypic.album.repository.AlbumRepository;
+import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.member.repository.MemberRepository;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.transaction.annotation.Transactional;
+
+public class EventServiceTest extends IntegrationTest {
+
+    @Autowired private AlbumService albumService;
+    @Autowired private AlbumRepository albumRepository;
+    @Autowired private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        Member member =
+                Member.createMember(
+                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                        "testNickname",
+                        "testProfileImageUrl");
+        memberRepository.save(member);
+
+        UserDetails userDetails =
+                User.withUsername(member.getId().toString())
+                        .password("")
+                        .authorities(member.getRole().name())
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @Transactional
+    @Nested
+    class 이벤트를_생성할_때 {
+
+        @Test
+        void 유효한_요청이면_엘범이_생성된다() {
+
+            // given
+            AlbumCreateRequest request =
+                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumType.SHARED);
+
+            // when
+            albumService.createAlbum(request);
+
+            // then
+            Album album = albumRepository.findById(1L).orElseThrow();
+            Participant participant = album.getParticipants().get(0);
+
+            Assertions.assertAll(
+                    () -> assertThat(album.getId()).isEqualTo(1L),
+                    () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
+                    () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
+                    () -> assertThat(album.getType()).isEqualTo(AlbumType.SHARED),
+                    () -> assertThat(participant.getId()).isEqualTo(1L),
+                    () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
+                    () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -62,8 +62,8 @@ public class EventServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            Album album1 = Album.createAlbum("Test Album1", "Test URL 1", AlbumType.SHARED);
-            Album album2 = Album.createAlbum("Test Album2", "Test URL 2", AlbumType.SHARED);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.SHARED);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.SHARED);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant =
@@ -78,7 +78,7 @@ public class EventServiceTest extends IntegrationTest {
         void 유효한_요청이면_이벤트가_생성된다() {
 
             // given
-            EventCreateRequest request = new EventCreateRequest(1L, "Test Event", "Test CoverURL");
+            EventCreateRequest request = new EventCreateRequest(1L, "testEvent", "testCoverUrl");
 
             // when
             eventService.createEvent(request);
@@ -89,15 +89,15 @@ public class EventServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(event.getId()).isEqualTo(1L),
                     () -> assertThat(event.getAlbum().getId()).isEqualTo(1L),
-                    () -> assertThat(event.getTitle()).isEqualTo("Test Event"),
-                    () -> assertThat(event.getCoverUrl()).isEqualTo("Test CoverURL"));
+                    () -> assertThat(event.getTitle()).isEqualTo("testEvent"),
+                    () -> assertThat(event.getCoverUrl()).isEqualTo("testCoverUrl"));
         }
 
         @Test
         void 엘범에_속하지_않은_사용자는_이벤트를_생성할_수_없다() {
 
             // given
-            EventCreateRequest request = new EventCreateRequest(2L, "Test Event", "Test CoverURL");
+            EventCreateRequest request = new EventCreateRequest(2L, "testEvent", "tesCoverUrl");
 
             // when & then
             assertThatThrownBy(() -> eventService.createEvent(request))

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -18,6 +18,7 @@ import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.participant.repository.ParticipantRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -27,7 +28,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.transaction.annotation.Transactional;
 
 public class EventServiceTest extends IntegrationTest {
 
@@ -35,6 +35,9 @@ public class EventServiceTest extends IntegrationTest {
     @Autowired private EventRepository eventRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private ParticipantRepository participantRepository;
+
+    private Member member;
 
     @BeforeEach
     void setUp() {
@@ -56,7 +59,6 @@ public class EventServiceTest extends IntegrationTest {
         SecurityContextHolder.getContext().setAuthentication(token);
     }
 
-    @Transactional
     @Nested
     class 이벤트를_생성할_때 {
 
@@ -71,6 +73,7 @@ public class EventServiceTest extends IntegrationTest {
                             memberRepository.findById(1L).orElseThrow(),
                             album1,
                             ParticipantRole.HOST);
+            participantRepository.save(participant);
             album1.addParticipant(participant);
         }
 
@@ -94,7 +97,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 엘범에_속하지_않은_사용자는_이벤트를_생성할_수_없다() {
+        void 엘범에_속하지_않은_사용자가_이벤트를_생성하면_예외가_발생한다() {
 
             // given
             EventCreateRequest request = new EventCreateRequest(2L, "testEvent", "tesCoverUrl");

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -26,7 +26,7 @@ public class Album extends BaseTimeEntity {
 
     @NotNull private String title;
 
-    @NotNull private String coverUrl;
+    private String coverUrl;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -24,18 +24,20 @@ public class Event extends BaseTimeEntity {
     @JoinColumn(name = "album_id")
     private Album album;
 
-    @NotNull private String name;
+    @NotNull private String title;
+
+    @NotNull private String coverUrl;
 
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventImage> eventImages = new ArrayList<>();
 
     @Builder
-    private Event(Album album, String name) {
+    private Event(Album album, String name, String coverUrl) {
         this.album = album;
-        this.name = name;
+        this.title = name;
     }
 
-    public static Event createEvent(Album album, String name) {
-        return Event.builder().album(album).name(name).build();
+    public static Event createEvent(Album album, String name, String coverUrl) {
+        return Event.builder().album(album).name(name).coverUrl(coverUrl).build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -26,19 +26,19 @@ public class Event extends BaseTimeEntity {
 
     @NotNull private String title;
 
-    @NotNull private String coverUrl;
+    private String coverUrl;
 
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventImage> eventImages = new ArrayList<>();
 
     @Builder
-    private Event(Album album, String name, String coverUrl) {
+    private Event(Album album, String title, String coverUrl) {
         this.album = album;
-        this.title = name;
+        this.title = title;
         this.coverUrl = coverUrl;
     }
 
     public static Event createEvent(Album album, String name, String coverUrl) {
-        return Event.builder().album(album).name(name).coverUrl(coverUrl).build();
+        return Event.builder().album(album).title(name).coverUrl(coverUrl).build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -35,6 +35,7 @@ public class Event extends BaseTimeEntity {
     private Event(Album album, String name, String coverUrl) {
         this.album = album;
         this.title = name;
+        this.coverUrl = coverUrl;
     }
 
     public static Event createEvent(Album album, String name, String coverUrl) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
@@ -27,4 +28,14 @@ public class Event extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventImage> eventImages = new ArrayList<>();
+
+    @Builder
+    private Event(Album album, String name) {
+        this.album = album;
+        this.name = name;
+    }
+
+    public static Event createEvent(Album album, String name) {
+        return Event.builder().album(album).name(name).build();
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -38,7 +38,7 @@ public class Event extends BaseTimeEntity {
         this.coverUrl = coverUrl;
     }
 
-    public static Event createEvent(Album album, String name, String coverUrl) {
-        return Event.builder().album(album).title(name).coverUrl(coverUrl).build();
+    public static Event createEvent(Album album, String title, String coverUrl) {
+        return Event.builder().album(album).title(title).coverUrl(coverUrl).build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/repository/ParticipantRepository.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/repository/ParticipantRepository.java
@@ -3,4 +3,6 @@ package org.cherrypic.participant.repository;
 import org.cherrypic.participant.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ParticipantRepository extends JpaRepository<Participant, Long> {}
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    boolean existsByMemberIdAndAlbumId(Long memberId, Long albumId);
+}

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -37,7 +37,8 @@ CREATE TABLE album (
 CREATE TABLE event (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        album_id BIGINT NOT NULL,
-                       name VARCHAR(100) NOT NULL,
+                       title VARCHAR(100) NOT NULL,
+                       cover_url VARCHAR(255) NOT NULL,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,
                        CONSTRAINT fk_event_album FOREIGN KEY (album_id) REFERENCES album (id)

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -27,7 +27,7 @@ CREATE TABLE subscription (
 CREATE TABLE album (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        title VARCHAR(50) NOT NULL,
-                       cover_url VARCHAR(255) NOT NULL,
+                       cover_url VARCHAR(255),
                        type VARCHAR(20) NOT NULL CHECK (type IN ('PRIVATE','SHARED','MANAGED_SHARED')),
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
@@ -38,7 +38,7 @@ CREATE TABLE event (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        album_id BIGINT NOT NULL,
                        title VARCHAR(100) NOT NULL,
-                       cover_url VARCHAR(255) NOT NULL,
+                       cover_url VARCHAR(255),
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,
                        CONSTRAINT fk_event_album FOREIGN KEY (album_id) REFERENCES album (id)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #56 

---
## 📌 작업 내용 및 특이사항
- 이벤트를 생성할 수 있는 API를 추가했습니다.
- 엘범 ID와 이벤트 제목을 입력값으로 받으며, 응답으로 생성된 이벤트 정보를 반환합니다.
- 엘범에 속한 멤버만 이벤트를 생성할 수 있도록 구현했습니다. 
- 이벤트도 커버 사진을 추가하자는 수정사항이 있어서 엔티티가 수정되었습니다.
- 이벤트의 이름 길이는 우선 100으로 생각하고 있습니다. ( 수정이 필요하면 나중에 수정 ) 

---
## 📚 참고사항
- 사용자의 권한을 확인하고 이벤트 생성을 제제할까에 대한 부분을 고민중입니다. 