### PR TITLE
feat: 앨범 유료 플랜 결제 준비 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
@@ -2,12 +2,8 @@ package org.cherrypic.domain.album.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import org.cherrypic.album.enums.AlbumType;
 
 public record AlbumCreateRequest(
         @NotBlank(message = "앨범 이름은 비워둘 수 없습니다.") @Schema(description = "앨범 이름", example = "연인 앨범")
                 String title,
-        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @NotNull(message = "앨범 유형은 비워둘 수 없습니다.") @Schema(description = "앨범 유형", example = "SHARED")
-                AlbumType type) {}
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
@@ -2,15 +2,12 @@ package org.cherrypic.domain.album.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumType;
 
 public record AlbumCreateResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
-        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @Schema(description = "앨범 유형", example = "SHARED") AlbumType type) {
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl) {
     public static AlbumCreateResponse from(Album album) {
-        return new AlbumCreateResponse(
-                album.getId(), album.getTitle(), album.getCoverUrl(), album.getType());
+        return new AlbumCreateResponse(album.getId(), album.getTitle(), album.getCoverUrl());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -24,7 +24,7 @@ public class AlbumServiceImpl implements AlbumService {
     public AlbumCreateResponse createAlbum(AlbumCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        Album album = Album.createAlbum(request.title(), request.coverUrl(), request.type());
+        Album album = Album.createAlbum(request.title(), request.coverUrl());
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.HOST);
         album.addParticipant(participant);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
@@ -1,0 +1,27 @@
+package org.cherrypic.domain.payment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.payment.dto.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.PaymentReadyResponse;
+import org.cherrypic.domain.payment.service.PaymentService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+@Tag(name = "5. 결제 API", description = "결제 관련 API입니다.")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/ready")
+    @Operation(
+            summary = "앨범 구독 플랜 결제 준비",
+            description = "사용자가 선택한 앨범 구독 플랜(PRO 또는 PREMIUM)에 대해 결제 요청에 필요한 정보를 생성합니다.")
+    public PaymentReadyResponse paymentPrepare(@Valid @RequestBody PaymentReadyRequest request) {
+        return paymentService.preparePayment(request);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
@@ -20,7 +20,7 @@ public class PaymentController {
     @PostMapping("/ready")
     @Operation(
             summary = "앨범 구독 플랜 결제 준비",
-            description = "사용자가 선택한 앨범 구독 플랜(PRO 또는 PREMIUM)에 대해 결제 요청에 필요한 정보를 생성합니다.")
+            description = "사용자가 선택한 앨범 구독 플랜에 대해 결제 요청에 필요한 정보를 생성합니다.")
     public PaymentReadyResponse paymentPrepare(@Valid @RequestBody PaymentReadyRequest request) {
         return paymentService.preparePayment(request);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/PaymentReadyRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/PaymentReadyRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.cherrypic.album.enums.AlbumPlan;
+
+public record PaymentReadyRequest(
+        @NotNull(message = "앨범 구독 플랜은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다.")
+                @Schema(description = "앨범 구독 플랜", defaultValue = "PRO")
+                AlbumPlan plan) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/PaymentReadyResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/PaymentReadyResponse.java
@@ -1,0 +1,16 @@
+package org.cherrypic.domain.payment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.album.enums.AlbumPlan;
+
+public record PaymentReadyResponse(
+        @Schema(description = "앨범 구독 플랜", defaultValue = "PRO") AlbumPlan plan,
+        @Schema(description = "구독 플랜 가격", example = "3900") int price,
+        @Schema(description = "결제 요청 고유 ID", example = "album_20250723_pro_1_c4f1a2b3d5e6")
+                String merchantUid,
+        @Schema(description = "구매자 이름", example = "최현태") String buyerName) {
+    public static PaymentReadyResponse of(
+            AlbumPlan plan, int price, String merchantUid, String buyerName) {
+        return new PaymentReadyResponse(plan, price, merchantUid, buyerName);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.payment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentErrorCode implements BaseErrorCode {
+    UNSUPPORTED_PAYMENT_PLAN(400, "해당 플랜은 유료 결제가 필요하지 않습니다. PRO 또는 PREMIUM 플랜만 결제가 가능합니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentException.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.payment.exception;
+
+import org.cherrypic.exception.BaseCustomException;
+
+public class PaymentException extends BaseCustomException {
+    public PaymentException(PaymentErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentService.java
@@ -1,0 +1,8 @@
+package org.cherrypic.domain.payment.service;
+
+import org.cherrypic.domain.payment.dto.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.PaymentReadyResponse;
+
+public interface PaymentService {
+    PaymentReadyResponse preparePayment(PaymentReadyRequest request);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -1,0 +1,52 @@
+package org.cherrypic.domain.payment.service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.payment.dto.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.PaymentReadyResponse;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
+import org.cherrypic.domain.payment.exception.PaymentException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.payment.entity.Payment;
+import org.cherrypic.payment.repository.PaymentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentServiceImpl implements PaymentService {
+
+    private final MemberUtil memberUtil;
+    private final PaymentRepository paymentRepository;
+
+    @Override
+    public PaymentReadyResponse preparePayment(PaymentReadyRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        AlbumPlan plan = request.plan();
+        if (plan.equals(AlbumPlan.BASIC)) {
+            throw new PaymentException(PaymentErrorCode.UNSUPPORTED_PAYMENT_PLAN);
+        }
+
+        int price = plan.getPrice();
+        String merchantUid = generateMerchantUid(currentMember.getId(), plan);
+        String buyerName = currentMember.getNickname();
+
+        Payment payment = Payment.createPayment(currentMember, merchantUid, price);
+        paymentRepository.save(payment);
+
+        return PaymentReadyResponse.of(plan, price, merchantUid, buyerName);
+    }
+
+    private String generateMerchantUid(Long memberId, AlbumPlan plan) {
+        String date = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+        String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+
+        return String.format("album_%s_%s_%d_%s", date, plan.name().toLowerCase(), memberId, uuid);
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
@@ -41,11 +40,9 @@ class AlbumControllerTest {
         @Test
         void 유효한_요청이면_앨범_생성_정보를_반환한다() throws Exception {
             // given
-            AlbumCreateRequest request =
-                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumType.PRIVATE);
+            AlbumCreateRequest request = new AlbumCreateRequest("testTitle", "testCoverUrl");
 
-            AlbumCreateResponse response =
-                    new AlbumCreateResponse(1L, "testTitle", "testCoverUrl", AlbumType.PRIVATE);
+            AlbumCreateResponse response = new AlbumCreateResponse(1L, "testTitle", "testCoverUrl");
 
             given(albumService.createAlbum(request)).willReturn(response);
 
@@ -61,8 +58,7 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
                     .andExpect(jsonPath("$.data.albumId").value(1))
                     .andExpect(jsonPath("$.data.title").value("testTitle"))
-                    .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"))
-                    .andExpect(jsonPath("$.data.type").value("PRIVATE"));
+                    .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"));
         }
 
         @ParameterizedTest
@@ -71,8 +67,7 @@ class AlbumControllerTest {
         @ValueSource(strings = {" "})
         void 앨범_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
             // given
-            AlbumCreateRequest request =
-                    new AlbumCreateRequest(title, "testCoverUrl", AlbumType.PRIVATE);
+            AlbumCreateRequest request = new AlbumCreateRequest(title, "testCoverUrl");
 
             // when & then
             ResultActions perform =
@@ -86,26 +81,6 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("앨범 이름은 비워둘 수 없습니다."));
-        }
-
-        @ParameterizedTest
-        @NullSource
-        void 앨범_유형이_null이면_예외가_발생한다(AlbumType type) throws Exception {
-            // given
-            AlbumCreateRequest request = new AlbumCreateRequest("testTitle", "testCoverUrl", type);
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("앨범 유형은 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.service.AlbumService;
@@ -58,8 +57,7 @@ class AlbumServiceTest extends IntegrationTest {
         void 유효한_요청이면_앨범과_HOST_참여자가_생성된다() {
 
             // given
-            AlbumCreateRequest request =
-                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumType.SHARED);
+            AlbumCreateRequest request = new AlbumCreateRequest("testTitle", "testCoverUrl");
 
             // when
             albumService.createAlbum(request);
@@ -72,7 +70,6 @@ class AlbumServiceTest extends IntegrationTest {
                     () -> assertThat(album.getId()).isEqualTo(1L),
                     () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
                     () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
-                    () -> assertThat(album.getType()).isEqualTo(AlbumType.SHARED),
                     () -> assertThat(participant.getId()).isEqualTo(1L),
                     () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
                     () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST));

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -65,8 +64,8 @@ public class EventServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.SHARED);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.SHARED);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1");
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2");
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant =

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -38,7 +38,7 @@ class PaymentControllerTest {
     @MockitoBean private PaymentService paymentService;
 
     @Nested
-    class 앨범_구독_결제_준비_요청_시 {
+    class 앨범_유료_플랜_결제_준비_요청_시 {
 
         @Test
         void 유효한_요청이면_결제_준비_정보를_반환한다() throws Exception {
@@ -73,7 +73,7 @@ class PaymentControllerTest {
         @NullSource
         @EmptySource
         @ValueSource(strings = {" ", "PROO", "PREMIUMM"})
-        void 앨범_구독_플랜이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String plan) throws Exception {
+        void 앨범_플랜이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String plan) throws Exception {
             // given
             PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.from(plan));
 
@@ -94,7 +94,7 @@ class PaymentControllerTest {
         }
 
         @Test
-        void 앨범_구독_플랜이_BASIC이면_예외가_발생한다() throws Exception {
+        void 앨범_플랜이_BASIC이면_예외가_발생한다() throws Exception {
             // given
             PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.BASIC);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,121 @@
+package org.cherrypic.payment.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.payment.controller.PaymentController;
+import org.cherrypic.domain.payment.dto.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.PaymentReadyResponse;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
+import org.cherrypic.domain.payment.exception.PaymentException;
+import org.cherrypic.domain.payment.service.PaymentService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(PaymentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PaymentControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private PaymentService paymentService;
+
+    @Nested
+    class 앨범_구독_결제_준비_요청_시 {
+
+        @Test
+        void 유효한_요청이면_결제_준비_정보를_반환한다() throws Exception {
+            // given
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO);
+
+            PaymentReadyResponse response =
+                    new PaymentReadyResponse(
+                            AlbumPlan.PRO, 3900, "album_20250723_pro_1_a5c5dd8beaa6", "상냥한 너구리");
+
+            given(paymentService.preparePayment(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/payments/ready")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.plan").value("PRO"))
+                    .andExpect(jsonPath("$.data.price").value("3900"))
+                    .andExpect(
+                            jsonPath("$.data.merchantUid")
+                                    .value("album_20250723_pro_1_a5c5dd8beaa6"))
+                    .andExpect(jsonPath("$.data.buyerName").value("상냥한 너구리"));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" ", "PROO", "PREMIUMM"})
+        void 앨범_구독_플랜이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String plan) throws Exception {
+            // given
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.from(plan));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/payments/ready")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("앨범 구독 플랜은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다."));
+        }
+
+        @Test
+        void 앨범_구독_플랜이_BASIC이면_예외가_발생한다() throws Exception {
+            // given
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.BASIC);
+
+            given(paymentService.preparePayment(request))
+                    .willThrow(new PaymentException(PaymentErrorCode.UNSUPPORTED_PAYMENT_PLAN));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/payments/ready")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("UNSUPPORTED_PAYMENT_PLAN"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(
+                                            "해당 플랜은 유료 결제가 필요하지 않습니다. PRO 또는 PREMIUM 플랜만 결제가 가능합니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -1,0 +1,87 @@
+package org.cherrypic.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.payment.dto.PaymentReadyRequest;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
+import org.cherrypic.domain.payment.exception.PaymentException;
+import org.cherrypic.domain.payment.service.PaymentService;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.member.repository.MemberRepository;
+import org.cherrypic.payment.entity.Payment;
+import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class PaymentServiceTest extends IntegrationTest {
+
+    @Autowired private PaymentService paymentService;
+    @Autowired PaymentRepository paymentRepository;
+    @Autowired private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        Member member =
+                Member.createMember(
+                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                        "testNickname",
+                        "testProfileImageUrl");
+        memberRepository.save(member);
+
+        UserDetails userDetails =
+                User.withUsername(member.getId().toString())
+                        .password("")
+                        .authorities(member.getRole().name())
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @Nested
+    class 앨범_구독_결제를_준비할_때 {
+
+        @Test
+        void 유효한_요청이면_결제_준비_정보를_생성한다() {
+            // given
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO);
+
+            // when
+            paymentService.preparePayment(request);
+
+            // then
+            Payment payment = paymentRepository.findById(1L).orElseThrow();
+            Assertions.assertAll(
+                    () -> assertThat(payment.getId()).isEqualTo(1L),
+                    () -> assertThat(payment.getMember().getId()).isEqualTo(1L),
+                    () -> assertThat(payment.getMerchantUid()).startsWith("album_"),
+                    () -> assertThat(payment.getMerchantUid()).contains("pro"),
+                    () -> assertThat(payment.getAmount()).isEqualTo(3900),
+                    () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY));
+        }
+
+        @Test
+        void 앨범_플랜이_BASIC이면_예외가_발생한다() {
+            // given
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.BASIC);
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.preparePayment(request))
+                    .isInstanceOf(PaymentException.class)
+                    .hasMessage(PaymentErrorCode.UNSUPPORTED_PAYMENT_PLAN.getMessage());
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -52,7 +52,7 @@ public class PaymentServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 앨범_구독_결제를_준비할_때 {
+    class 앨범_유료_플랜_결제를_준비할_때 {
 
         @Test
         void 유효한_요청이면_결제_준비_정보를_생성한다() {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -8,7 +8,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.favorites.entity.Favorites;
@@ -28,10 +27,6 @@ public class Album extends BaseTimeEntity {
 
     private String coverUrl;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private AlbumType type;
-
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorites> favorites = new ArrayList<>();
 
@@ -45,14 +40,13 @@ public class Album extends BaseTimeEntity {
     private List<Participant> participants = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Album(String title, String coverUrl, AlbumType type) {
+    private Album(String title, String coverUrl) {
         this.title = title;
         this.coverUrl = coverUrl;
-        this.type = type;
     }
 
-    public static Album createAlbum(String title, String coverUrl, AlbumType type) {
-        return Album.builder().title(title).coverUrl(coverUrl).type(type).build();
+    public static Album createAlbum(String title, String coverUrl) {
+        return Album.builder().title(title).coverUrl(coverUrl).build();
     }
 
     public void addParticipant(Participant participant) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -14,6 +14,7 @@ import org.cherrypic.event.entity.Event;
 import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.payment.entity.Payment;
 
 @Getter
 @Entity
@@ -31,6 +32,9 @@ public class Album extends BaseTimeEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     private AlbumPlan plan;
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Payment> payments = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorites> favorites = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -29,7 +29,6 @@ public class Album extends BaseTimeEntity {
 
     private String coverUrl;
 
-    @NotNull
     @Enumerated(EnumType.STRING)
     private AlbumPlan plan;
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.favorites.entity.Favorites;
@@ -26,6 +27,10 @@ public class Album extends BaseTimeEntity {
     @NotNull private String title;
 
     private String coverUrl;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AlbumPlan plan;
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorites> favorites = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
@@ -1,7 +1,25 @@
 package org.cherrypic.album.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum AlbumPlan {
-    BASIC,
-    PRO,
-    PREMIUM
+    BASIC(0),
+    PRO(3900),
+    PREMIUM(7900),
+    ;
+
+    private final int price;
+
+    @JsonCreator
+    public static AlbumPlan from(String plan) {
+        return Stream.of(values())
+                .filter(p -> p.name().equalsIgnoreCase(plan))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
@@ -1,0 +1,7 @@
+package org.cherrypic.album.enums;
+
+public enum AlbumPlan {
+    BASIC,
+    PRO,
+    PREMIUM
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumType.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumType.java
@@ -1,7 +1,0 @@
-package org.cherrypic.album.enums;
-
-public enum AlbumType {
-    PRIVATE,
-    SHARED,
-    MANAGED_SHARED
-}

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.payment.enums.PaymentStatus;
@@ -22,6 +23,10 @@ public class Payment extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id")
+    private Album album;
 
     @NotNull private String merchantUid;
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
@@ -41,4 +42,21 @@ public class Payment extends BaseTimeEntity {
     private PaymentStatus status;
 
     private LocalDateTime paidAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Payment(Member member, String merchantUid, int amount, PaymentStatus status) {
+        this.member = member;
+        this.merchantUid = merchantUid;
+        this.amount = amount;
+        this.status = status;
+    }
+
+    public static Payment createPayment(Member member, String merchantUid, int amount) {
+        return Payment.builder()
+                .member(member)
+                .merchantUid(merchantUid)
+                .amount(amount)
+                .status(PaymentStatus.READY)
+                .build();
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -36,6 +36,7 @@ public class Payment extends BaseTimeEntity {
 
     @NotNull private int amount;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
-import org.cherrypic.subscription.enums.SubscriptionType;
 
 @Getter
 @Entity
@@ -22,10 +21,6 @@ public class Subscription {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", unique = true)
     private Member member;
-
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private SubscriptionType type;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/enums/SubscriptionType.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/enums/SubscriptionType.java
@@ -1,7 +1,0 @@
-package org.cherrypic.subscription.enums;
-
-public enum SubscriptionType {
-    BASIC,
-    PLUS,
-    PRO;
-}

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -15,7 +15,6 @@ CREATE TABLE member (
 CREATE TABLE subscription (
                               id BIGINT AUTO_INCREMENT PRIMARY KEY,
                               member_id BIGINT UNIQUE NOT NULL,
-                              type VARCHAR(255) NOT NULL CHECK (type IN ('BASIC','PLUS','PRO')),
                               status VARCHAR(255) NOT NULL CHECK (status IN ('ACTIVE','CANCELLED','EXPIRED')),
                               start_at DATETIME(6),
                               end_at DATETIME(6),
@@ -28,6 +27,7 @@ CREATE TABLE album (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        title VARCHAR(50) NOT NULL,
                        cover_url VARCHAR(255),
+                       plan VARCHAR(255) NOT NULL CHECK (plan IN ('BASIC','PRO','PREMIUM')),
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
 );

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -28,7 +28,6 @@ CREATE TABLE album (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        title VARCHAR(50) NOT NULL,
                        cover_url VARCHAR(255),
-                       type VARCHAR(20) NOT NULL CHECK (type IN ('PRIVATE','SHARED','MANAGED_SHARED')),
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
 );

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -32,6 +32,22 @@ CREATE TABLE album (
                        updated_at DATETIME(6) NOT NULL
 );
 
+CREATE TABLE payment (
+                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         member_id BIGINT NOT NULL,
+                         album_id BIGINT,
+                         merchant_uid VARCHAR(255) NOT NULL,
+                         imp_uid VARCHAR(255),
+                         pg_provider VARCHAR(255),
+                         amount INT NOT NULL,
+                         status VARCHAR(255) NOT NULL CHECK (status IN ('READY','PAID','FAILED','CANCELLED')),
+                         paid_at DATETIME,
+                         created_at DATETIME(6) NOT NULL,
+                         updated_at DATETIME(6) NOT NULL,
+                         CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id),
+                         CONSTRAINT fk_payment_album FOREIGN KEY (album_id) REFERENCES album (id)
+);
+
 
 CREATE TABLE event (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -85,19 +101,4 @@ CREATE TABLE participant (
                              updated_at DATETIME(6) NOT NULL,
                              CONSTRAINT fk_participant_member FOREIGN KEY (member_id) REFERENCES member (id),
                              CONSTRAINT fk_participant_album FOREIGN KEY (album_id) REFERENCES album (id)
-);
-
-
-CREATE TABLE payment (
-                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                         member_id BIGINT NOT NULL ,
-                         merchant_uid VARCHAR(255) NOT NULL,
-                         imp_uid VARCHAR(255),
-                         pg_provider VARCHAR(255),
-                         amount INT NOT NULL,
-                         status VARCHAR(255) NOT NULL CHECK (status IN ('READY','PAID','FAILED','CANCELLED')),
-                         paid_at DATETIME,
-                         created_at DATETIME(6) NOT NULL,
-                         updated_at DATETIME(6) NOT NULL,
-                         CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id)
 );

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -27,7 +27,7 @@ CREATE TABLE album (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        title VARCHAR(50) NOT NULL,
                        cover_url VARCHAR(255),
-                       plan VARCHAR(255) NOT NULL CHECK (plan IN ('BASIC','PRO','PREMIUM')),
+                       plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
 );


### PR DESCRIPTION
## 🌱 관련 이슈
- close #60 

---
## 📌 작업 내용 및 특이사항
* 앨범 유료 플랜 결제 준비 API를 구현했습니다.
  * 사용자가 선택한 유료 플랜(PRO, PREMIUM)에 대해 결제 요청에 필요한 정보를 생성하여 응답하도록 했습니다.
  * 결제 준비 과정에서 Payment 엔티티를 생성하고 저장합니다.
  * 포트원 결제 요청에 필요한 고유 주문번호(merchantUid)는 날짜, 플랜명, 사용자 ID를 기반으로 생성했습니다.
* 앨범 구독 플랜 관련 Enum을 재정의했습니다.
  * 기존에 Subscription 테이블에 존재하던 구독 플랜(SubscriptionPlan)을 제거하고, 앨범 도메인에서 관리하도록 AlbumPlan Enum으로 분리했습니다.
  * BASIC 플랜은 무료이므로, 결제 준비 요청 시 예외가 발생하도록 처리했습니다
*기존 AlbumType Enum은 불필요하다고 판단하여 제거했습니다.
* Payment와 Album 간 연관관계를 설정했습니다.
  * 결제 준비 시점에는 albumId가 없으므로 실제 연관관계 설정은 결제 검증 후 앨범을 생성하는 단계에서 구독과 함께 처리할 예정입니다.