### PR TITLE
feat: 앨범 초대 링크 생성 API 구현 

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -24,4 +24,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
-import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.service.AlbumService;
@@ -29,11 +28,11 @@ public class AlbumController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PostMapping("/invitation-link")
+    @PostMapping("/{albumId}/invitation-link")
     @Operation(summary = "앨범 초대 링크 생성", description = "앨범 초대링크를 생성합니다.")
     public ResponseEntity<InvitationLinkCreateResponse> invitationLinkCreate(
-            @Valid @RequestBody InvitationLinkCreateRequest request) {
-        InvitationLinkCreateResponse response = albumService.createInvitationLink(request);
+            @PathVariable Long albumId) {
+        InvitationLinkCreateResponse response = albumService.createInvitationLink(albumId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -29,8 +29,8 @@ public class AlbumController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PostMapping("/invite-link")
-    @Operation(summary = "앨범 초대 링크 생성", description = "새로운 앨범 초대링크를 생성합니다.")
+    @PostMapping("/invitation-link")
+    @Operation(summary = "앨범 초대 링크 생성", description = "앨범 초대링크를 생성합니다.")
     public ResponseEntity<InvitationLinkCreateResponse> invitationLinkCreate(
             @Valid @RequestBody InvitationLinkCreateRequest request) {
         InvitationLinkCreateResponse response = albumService.createInvitationLink(request);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,14 @@ public class AlbumController {
     public ResponseEntity<AlbumCreateResponse> albumCreate(
             @Valid @RequestBody AlbumCreateRequest request) {
         AlbumCreateResponse response = albumService.createAlbum(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/invite-link")
+    @Operation(summary = "앨범 초대 링크 생성", description = "새로운 앨범 초대링크를 생성합니다.")
+    public ResponseEntity<InvitationLinkCreateResponse> invitationLinkCreate(
+            @Valid @RequestBody InvitationLinkCreateRequest request) {
+        InvitationLinkCreateResponse response = albumService.createInvitationLink(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/InvitationLinkCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/InvitationLinkCreateRequest.java
@@ -1,9 +1,9 @@
 package org.cherrypic.domain.album.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record InvitationLinkCreateRequest(
-        @NotBlank(message = "앨범 ID는 비워둘 수 없습니다")
+        @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
                 @Schema(description = "초대 링크를 생성할 앨범의 ID", example = "1")
                 Long albumId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/InvitationLinkCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/InvitationLinkCreateRequest.java
@@ -1,9 +1,0 @@
-package org.cherrypic.domain.album.dto.request;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
-
-public record InvitationLinkCreateRequest(
-        @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
-                @Schema(description = "초대 링크를 생성할 앨범의 ID", example = "1")
-                Long albumId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/InvitationLinkCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/InvitationLinkCreateRequest.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.album.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record InvitationLinkCreateRequest(
+        @NotBlank(message = "앨범 ID는 비워둘 수 없습니다")
+                @Schema(description = "초대 링크를 생성할 앨범의 ID", example = "1")
+                Long albumId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
@@ -1,7 +1,6 @@
 package org.cherrypic.domain.album.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.cherrypic.album.entity.InvitationCode;
 
 public record InvitationLinkCreateResponse(
         @Schema(
@@ -9,7 +8,7 @@ public record InvitationLinkCreateResponse(
                         example = "https://dev-api.cherrypic.today/participants/join?code=3FA7A9")
                 String invitationLink) {
 
-    public static InvitationLinkCreateResponse from(InvitationCode invitationCode) {
-        return new InvitationLinkCreateResponse(invitationCode.getCode());
+    public static InvitationLinkCreateResponse of(String invitationCode) {
+        return new InvitationLinkCreateResponse(invitationCode);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.album.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.album.entity.InvitationCode;
+
+public record InvitationLinkCreateResponse(
+        @Schema(
+                        description = "엘범 초대 딥링크",
+                        example = "https://dev-api.cherrypic.today/participants/join?code=3FA7A9")
+                String invitationLink) {
+
+    public static InvitationLinkCreateResponse from(InvitationCode invitationCode) {
+        return new InvitationLinkCreateResponse(invitationCode.getCode());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -8,7 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum AlbumErrorCode implements BaseErrorCode {
     ALBUM_NOT_FOUND(404, "앨범이 존재하지 않습니다."),
-    INVALID_INVITATION_AUTHORITY(403, "HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."),
+    NOT_ALBUM_HOST(403, "HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."),
     NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다.");
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -8,7 +8,8 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum AlbumErrorCode implements BaseErrorCode {
     ALBUM_NOT_FOUND(404, "앨범이 존재하지 않습니다."),
-    INVITATION_NOT_ALLOWED(403, "BASIC 앨범을 제외하고 HOST가 아닌경우, 앨범 초대 링크를 생성할 권한이 없습니다.");
+    INVALID_INVITATION_AUTHORITY(403, "HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."),
+    NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -8,7 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum AlbumErrorCode implements BaseErrorCode {
     ALBUM_NOT_FOUND(404, "앨범이 존재하지 않습니다."),
-    ;
+    INVITATION_NOT_ALLOWED(403, "BASIC 앨범을 제외하고 HOST가 아닌경우, 앨범 초대 링크를 생성할 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -1,12 +1,11 @@
 package org.cherrypic.domain.album.service;
 
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
-import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 
 public interface AlbumService {
     AlbumCreateResponse createAlbum(AlbumCreateRequest request);
 
-    InvitationLinkCreateResponse createInvitationLink(InvitationLinkCreateRequest request);
+    InvitationLinkCreateResponse createInvitationLink(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -1,8 +1,12 @@
 package org.cherrypic.domain.album.service;
 
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 
 public interface AlbumService {
     AlbumCreateResponse createAlbum(AlbumCreateRequest request);
+
+    InvitationLinkCreateResponse createInvitationLink(InvitationLinkCreateRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -1,12 +1,9 @@
 package org.cherrypic.domain.album.service;
 
-import java.time.Duration;
 import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
-import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
@@ -15,8 +12,6 @@ import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
-import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
-import org.cherrypic.domain.participant.exception.ParticipantException;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
@@ -31,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlbumServiceImpl implements AlbumService {
 
     private final MemberUtil memberUtil;
+    private final InvitationLinkService invitationLinkService;
 
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
@@ -54,23 +50,23 @@ public class AlbumServiceImpl implements AlbumService {
     public InvitationLinkCreateResponse createInvitationLink(InvitationLinkCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
+        validateAlbumId(request.albumId());
         validateInvitationAuthority(currentMember.getId(), request.albumId());
 
         Optional<InvitationCode> invitationCode =
                 invitationCodeRepository.findById(request.albumId());
         if (invitationCode.isPresent()) {
-            return InvitationLinkCreateResponse.from(invitationCode.get());
+            String invitationLink =
+                    invitationLinkService.createInvitationLink(invitationCode.get());
+            return InvitationLinkCreateResponse.of(invitationLink);
         }
 
-        InvitationCode newCode =
-                InvitationCode.builder()
-                        .albumId(request.albumId())
-                        .code(UUID.randomUUID().toString())
-                        .ttl(Duration.ofMinutes(30).getSeconds())
-                        .build();
+        InvitationCode newCode = invitationLinkService.createInvitationCode(request.albumId());
         invitationCodeRepository.save(newCode);
 
-        return InvitationLinkCreateResponse.from(newCode);
+        String invitationLink = invitationLinkService.createInvitationLink(newCode);
+
+        return InvitationLinkCreateResponse.of(invitationLink);
     }
 
     private void validateInvitationAuthority(Long memberId, Long albumId) {
@@ -78,20 +74,18 @@ public class AlbumServiceImpl implements AlbumService {
                 participantRepository
                         .findByMemberIdAndAlbumId(memberId, albumId)
                         .orElseThrow(
-                                () ->
-                                        new ParticipantException(
-                                                ParticipantErrorCode.PARTICIPANT_NOT_FOUND));
+                                () -> new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
-        Album album =
-                albumRepository
-                        .findById(albumId)
-                        .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+        if (!participant.getRole().equals(ParticipantRole.HOST)) {
+            throw new AlbumException(AlbumErrorCode.INVALID_INVITATION_AUTHORITY);
+        }
+    }
 
-        boolean isNotBasic = !album.getPlan().equals(AlbumPlan.BASIC);
-        boolean isNotHost = !participant.getRole().equals(ParticipantRole.HOST);
+    private void validateAlbumId(Long albumId) {
+        Optional<Album> album = albumRepository.findById(albumId);
 
-        if (isNotBasic && isNotHost) {
-            throw new AlbumException(AlbumErrorCode.INVITATION_NOT_ALLOWED);
+        if (album.isEmpty()) {
+            throw new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -1,14 +1,27 @@
 package org.cherrypic.domain.album.service;
 
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.entity.InvitationCode;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.album.repository.AlbumRepository;
+import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.exception.AlbumException;
+import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
+import org.cherrypic.domain.participant.exception.ParticipantException;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.participant.repository.ParticipantRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +31,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlbumServiceImpl implements AlbumService {
 
     private final MemberUtil memberUtil;
+
     private final AlbumRepository albumRepository;
+    private final ParticipantRepository participantRepository;
+    private final InvitationCodeRepository invitationCodeRepository;
 
     @Override
     public AlbumCreateResponse createAlbum(AlbumCreateRequest request) {
@@ -32,5 +48,50 @@ public class AlbumServiceImpl implements AlbumService {
         albumRepository.save(album);
 
         return AlbumCreateResponse.from(album);
+    }
+
+    @Override
+    public InvitationLinkCreateResponse createInvitationLink(InvitationLinkCreateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        validateInvitationAuthority(currentMember.getId(), request.albumId());
+
+        Optional<InvitationCode> invitationCode =
+                invitationCodeRepository.findById(request.albumId());
+        if (invitationCode.isPresent()) {
+            return InvitationLinkCreateResponse.from(invitationCode.get());
+        }
+
+        InvitationCode newCode =
+                InvitationCode.builder()
+                        .albumId(request.albumId())
+                        .code(UUID.randomUUID().toString())
+                        .ttl(Duration.ofMinutes(30).getSeconds())
+                        .build();
+        invitationCodeRepository.save(newCode);
+
+        return InvitationLinkCreateResponse.from(newCode);
+    }
+
+    private void validateInvitationAuthority(Long memberId, Long albumId) {
+        Participant participant =
+                participantRepository
+                        .findByMemberIdAndAlbumId(memberId, albumId)
+                        .orElseThrow(
+                                () ->
+                                        new ParticipantException(
+                                                ParticipantErrorCode.PARTICIPANT_NOT_FOUND));
+
+        Album album =
+                albumRepository
+                        .findById(albumId)
+                        .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+        boolean isNotBasic = !album.getPlan().equals(AlbumPlan.BASIC);
+        boolean isNotHost = !participant.getRole().equals(ParticipantRole.HOST);
+
+        if (isNotBasic && isNotHost) {
+            throw new AlbumException(AlbumErrorCode.INVITATION_NOT_ALLOWED);
+        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -47,8 +47,8 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     public InvitationLinkCreateResponse createInvitationLink(Long albumId) {
         final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
 
-        Album album = getAlbumById(albumId);
         validateInvitationAuthority(currentMember.getId(), album.getId());
 
         InvitationCode invitationCode =

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -48,7 +48,7 @@ public class AlbumServiceImpl implements AlbumService {
     public InvitationLinkCreateResponse createInvitationLink(Long albumId) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        Album album = getAlbum(albumId);
+        Album album = getAlbumById(albumId);
         validateInvitationAuthority(currentMember.getId(), album.getId());
 
         InvitationCode invitationCode =
@@ -81,7 +81,7 @@ public class AlbumServiceImpl implements AlbumService {
         }
     }
 
-    private Album getAlbum(Long albumId) {
+    private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)
                 .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -50,8 +50,8 @@ public class AlbumServiceImpl implements AlbumService {
     public InvitationLinkCreateResponse createInvitationLink(InvitationLinkCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        validateAlbumId(request.albumId());
-        validateInvitationAuthority(currentMember.getId(), request.albumId());
+        Album album = getAlbum(request.albumId());
+        validateInvitationAuthority(currentMember.getId(), album.getId());
 
         Optional<InvitationCode> invitationCode =
                 invitationCodeRepository.findById(request.albumId());
@@ -76,16 +76,16 @@ public class AlbumServiceImpl implements AlbumService {
                         .orElseThrow(
                                 () -> new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
-        if (!participant.getRole().equals(ParticipantRole.HOST)) {
-            throw new AlbumException(AlbumErrorCode.INVALID_INVITATION_AUTHORITY);
+        boolean isHost = participant.getRole().equals(ParticipantRole.HOST);
+
+        if (!isHost) {
+            throw new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST);
         }
     }
 
-    private void validateAlbumId(Long albumId) {
-        Optional<Album> album = albumRepository.findById(albumId);
-
-        if (album.isEmpty()) {
-            throw new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND);
-        }
+    private Album getAlbum(Long albumId) {
+        return albumRepository
+                .findById(albumId)
+                .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -1,13 +1,11 @@
 package org.cherrypic.domain.album.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
-import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -47,24 +45,24 @@ public class AlbumServiceImpl implements AlbumService {
     }
 
     @Override
-    public InvitationLinkCreateResponse createInvitationLink(InvitationLinkCreateRequest request) {
+    public InvitationLinkCreateResponse createInvitationLink(Long albumId) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        Album album = getAlbum(request.albumId());
+        Album album = getAlbum(albumId);
         validateInvitationAuthority(currentMember.getId(), album.getId());
 
-        Optional<InvitationCode> invitationCode =
-                invitationCodeRepository.findById(request.albumId());
-        if (invitationCode.isPresent()) {
-            String invitationLink =
-                    invitationLinkService.createInvitationLink(invitationCode.get());
-            return InvitationLinkCreateResponse.of(invitationLink);
-        }
+        InvitationCode invitationCode =
+                invitationCodeRepository
+                        .findById(albumId)
+                        .orElseGet(
+                                () -> {
+                                    InvitationCode newCode =
+                                            invitationLinkService.createInvitationCode(albumId);
+                                    invitationCodeRepository.save(newCode);
+                                    return newCode;
+                                });
 
-        InvitationCode newCode = invitationLinkService.createInvitationCode(request.albumId());
-        invitationCodeRepository.save(newCode);
-
-        String invitationLink = invitationLinkService.createInvitationLink(newCode);
+        String invitationLink = invitationLinkService.createInvitationLink(invitationCode);
 
         return InvitationLinkCreateResponse.of(invitationLink);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
@@ -1,0 +1,29 @@
+package org.cherrypic.domain.album.service;
+
+import java.time.Duration;
+import java.util.UUID;
+import org.cherrypic.album.entity.InvitationCode;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@Service
+@Component
+public class InvitationLinkService {
+
+    private static final String INVITATION_LINK_PREFIX =
+            "https://dev-api.cherrypic.today/participants/join?code=";
+    private static final int INVITATION_LINK_DURATION = 30;
+    private static final int UUID_LENGTH = 8;
+
+    public InvitationCode createInvitationCode(Long albumId) {
+        return InvitationCode.builder()
+                .albumId(albumId)
+                .code(UUID.randomUUID().toString().substring(0, UUID_LENGTH))
+                .ttl(Duration.ofMinutes(INVITATION_LINK_DURATION).getSeconds())
+                .build();
+    }
+
+    public String createInvitationLink(InvitationCode invitationCode) {
+        return INVITATION_LINK_PREFIX + invitationCode.getCode();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
@@ -3,11 +3,9 @@ package org.cherrypic.domain.album.service;
 import java.time.Duration;
 import java.util.UUID;
 import org.cherrypic.album.entity.InvitationCode;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 @Service
-@Component
 public class InvitationLinkService {
 
     private static final String INVITATION_LINK_PREFIX =

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.participant.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum ParticipantErrorCode implements BaseErrorCode {
+    PARTICIPANT_NOT_FOUND(404, "참가자를 찾을 수 없습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantException.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.participant.exception;
+
+import org.cherrypic.exception.BaseCustomException;
+
+public class ParticipantException extends BaseCustomException {
+    public ParticipantException(ParticipantErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/RedisCleaner.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/RedisCleaner.java
@@ -1,0 +1,18 @@
+package org.cherrypic;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisCleaner {
+
+    private final RedisConnectionFactory connectionFactory;
+
+    public RedisCleaner(RedisConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    public void flushAll() {
+        connectionFactory.getConnection().flushDb();
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -11,8 +11,6 @@ import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
-import org.cherrypic.domain.album.exception.AlbumErrorCode;
-import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,7 +37,7 @@ class AlbumControllerTest {
     @MockitoBean private AlbumService albumService;
 
     @Nested
-    class 앨범을_생성할_요청_시 {
+    class 앨범_생성_요청_시 {
 
         @Test
         void 유효한_요청이면_앨범_생성_정보를_반환한다() throws Exception {
@@ -119,7 +117,7 @@ class AlbumControllerTest {
         }
 
         @Test
-        void 앨범_id_가_null_이먄_예외가_발생한다() throws Exception {
+        void 앨범_id_가_null_이면_예외가_발생한다() throws Exception {
             // given
             InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(null);
 
@@ -135,71 +133,6 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("앨범 ID는 비워둘 수 없습니다."));
-        }
-
-        @Test
-        void 현재_유저가_HOST가_아닌_경우_예외가_발생한다() throws Exception {
-            // given
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
-            given(albumService.createInvitationLink(request))
-                    .willThrow(new AlbumException(AlbumErrorCode.INVALID_INVITATION_AUTHORITY));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/invite-link")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("INVALID_INVITATION_AUTHORITY"))
-                    .andExpect(
-                            jsonPath("$.data.message")
-                                    .value("HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."));
-        }
-
-        @Test
-        void 현재_유저가_앨범_소속이_아닌_경우_예외가_발생한다() throws Exception {
-            // given
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
-            given(albumService.createInvitationLink(request))
-                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/invite-link")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
-        }
-
-        @Test
-        void 존재하지_않는_앨범_ID_를_입력한_경우_예외가_발생한다() throws Exception {
-            // given
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(999L);
-            given(albumService.createInvitationLink(request))
-                    .willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/invite-link")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -8,7 +8,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,7 +39,7 @@ class AlbumControllerTest {
     @MockitoBean private AlbumService albumService;
 
     @Nested
-    class 앨범을_생성할_때 {
+    class 앨범을_생성할_요청_시 {
 
         @Test
         void 유효한_요청이면_앨범_생성_정보를_반환한다() throws Exception {
@@ -81,6 +85,123 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("앨범 이름은 비워둘 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 앨범_초대_코드_생성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_초대_코드_정보를_반환한다() throws Exception {
+            // given
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+
+            InvitationLinkCreateResponse response =
+                    new InvitationLinkCreateResponse(
+                            "https://dev-api.cherrypic.today/participants/join?code=3FA7A9");
+
+            given(albumService.createInvitationLink(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/invite-link")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
+                    .andExpect(
+                            jsonPath("$.data.invitationLink")
+                                    .value(
+                                            "https://dev-api.cherrypic.today/participants/join?code=3FA7A9"));
+        }
+
+        @Test
+        void 앨범_id_가_null_이먄_예외가_발생한다() throws Exception {
+            // given
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(null);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/invite-link")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("앨범 ID는 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 현재_유저가_HOST가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+            given(albumService.createInvitationLink(request))
+                    .willThrow(new AlbumException(AlbumErrorCode.INVALID_INVITATION_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/invite-link")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("INVALID_INVITATION_AUTHORITY"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."));
+        }
+
+        @Test
+        void 현재_유저가_앨범_소속이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+            given(albumService.createInvitationLink(request))
+                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/invite-link")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("INVALID_INVITATION_AUTHORITY"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."));
+        }
+
+        @Test
+        void 존재하지_않는_앨범_ID_를_입력한_경우_예외가_발생한다() throws Exception {
+            // given
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(999L);
+            given(albumService.createInvitationLink(request))
+                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/invite-link")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -103,7 +103,7 @@ class AlbumControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/invite-link")
+                            post("/albums/invitation-link")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -124,7 +124,7 @@ class AlbumControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/invite-link")
+                            post("/albums/invitation-link")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -151,7 +151,7 @@ class AlbumControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
-            perform.andExpect(status().isBadRequest())
+            perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                     .andExpect(jsonPath("$.data.code").value("INVALID_INVITATION_AUTHORITY"))
@@ -174,13 +174,11 @@ class AlbumControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
-            perform.andExpect(status().isBadRequest())
+            perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("INVALID_INVITATION_AUTHORITY"))
-                    .andExpect(
-                            jsonPath("$.data.message")
-                                    .value("HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."));
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
         }
 
         @Test
@@ -188,7 +186,7 @@ class AlbumControllerTest {
             // given
             InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(999L);
             given(albumService.createInvitationLink(request))
-                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+                    .willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
             // when & then
             ResultActions perform =
@@ -197,11 +195,11 @@ class AlbumControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
-            perform.andExpect(status().isBadRequest())
+            perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
-import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.service.AlbumService;
@@ -92,20 +91,20 @@ class AlbumControllerTest {
         @Test
         void 유효한_요청이면_초대_코드_정보를_반환한다() throws Exception {
             // given
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+            Long albumId = 1L;
 
             InvitationLinkCreateResponse response =
                     new InvitationLinkCreateResponse(
                             "https://dev-api.cherrypic.today/participants/join?code=3FA7A9");
 
-            given(albumService.createInvitationLink(request)).willReturn(response);
+            given(albumService.createInvitationLink(albumId)).willReturn(response);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/invitation-link")
+                            post("/albums/{albumId}/invitation-link", albumId)
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
+                                    .content(objectMapper.writeValueAsString(albumId)));
 
             perform.andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
@@ -114,25 +113,6 @@ class AlbumControllerTest {
                             jsonPath("$.data.invitationLink")
                                     .value(
                                             "https://dev-api.cherrypic.today/participants/join?code=3FA7A9"));
-        }
-
-        @Test
-        void 앨범_id_가_null_이면_예외가_발생한다() throws Exception {
-            // given
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(null);
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/invitation-link")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("앨범 ID는 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -1,26 +1,34 @@
 package org.cherrypic.album.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
 
+import java.util.List;
+import java.util.Optional;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.repository.AlbumRepository;
+import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.participant.repository.ParticipantRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 class AlbumServiceTest extends IntegrationTest {
@@ -28,34 +36,29 @@ class AlbumServiceTest extends IntegrationTest {
     @Autowired private AlbumService albumService;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private InvitationCodeRepository invitationCodeRepository;
+    @Autowired private ParticipantRepository participantRepository;
 
-    @BeforeEach
-    void setUp() {
-        Member member =
-                Member.createMember(
-                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                        "testNickname",
-                        "testProfileImageUrl");
-        memberRepository.save(member);
-
-        UserDetails userDetails =
-                User.withUsername(member.getId().toString())
-                        .password("")
-                        .authorities(member.getRole().name())
-                        .build();
-        UsernamePasswordAuthenticationToken token =
-                new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(token);
-    }
+    @MockitoBean MemberUtil memberUtil;
 
     @Transactional
     @Nested
     class 앨범을_생성할_때 {
 
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+
+            given(memberUtil.getCurrentMember()).willReturn(member);
+        }
+
         @Test
         void 유효한_요청이면_앨범과_HOST_참여자가_생성된다() {
-
             // given
             AlbumCreateRequest request = new AlbumCreateRequest("testTitle", "testCoverUrl");
 
@@ -73,6 +76,105 @@ class AlbumServiceTest extends IntegrationTest {
                     () -> assertThat(participant.getId()).isEqualTo(1L),
                     () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
                     () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST));
+        }
+    }
+
+    @Nested
+    class 초대_코드를_생성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1");
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2");
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album2, ParticipantRole.STANDARD);
+            participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @Test
+        void 유효한_요청이면_초대_코드를_저장한다() {
+            // given
+            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+
+            // when
+            albumService.createInvitationLink(request);
+
+            // then
+            assertThat(invitationCodeRepository.findById(1L)).isPresent();
+        }
+
+        @Test
+        void 유효한_초대_코드가_이미_존재하는_경우_갱신하지_않는다() {
+            // given
+            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
+            InvitationCode invitationCode =
+                    InvitationCode.builder().albumId(1L).code("testInvitationCode").build();
+            invitationCodeRepository.save(invitationCode);
+            String invitationCodeBefore = invitationCode.getCode();
+
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+
+            // when
+            albumService.createInvitationLink(request);
+
+            // then
+            Optional<InvitationCode> code = invitationCodeRepository.findById(1L);
+            Assertions.assertAll(
+                    () -> assertThat(code).isPresent(),
+                    () -> assertThat(invitationCodeBefore).isEqualTo(code.get().getCode()));
+        }
+
+        @Test
+        void 현재_유저가_HOST가_아닌_경우_예외가_발생한다() {
+            // given
+            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(2L);
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createInvitationLink(request))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.INVALID_INVITATION_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 현재_유저가_앨범_소속이_아닌_경우_예외가_발생한다() {
+            // given
+            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createInvitationLink(request))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 존재하지_않는_앨범_ID_를_입력한_경우_예외가_발생한다() {
+            // given
+            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(3L);
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createInvitationLink(request))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -114,7 +114,7 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청이면_초대_코드를_저장하며_반환되는_링크의_뒤에_포함된다() {
+        void 유효한_요청이면_초대_코드를_저장하며_초대_링크가_반환된다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
             InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -13,7 +13,6 @@ import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
-import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
@@ -117,10 +116,9 @@ class AlbumServiceTest extends IntegrationTest {
         void 유효한_요청이면_초대_코드를_저장하며_초대_링크가_반환된다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
 
             // when
-            InvitationLinkCreateResponse response = albumService.createInvitationLink(request);
+            InvitationLinkCreateResponse response = albumService.createInvitationLink(1L);
 
             // then
             InvitationCode savedCode = invitationCodeRepository.findById(1L).orElseThrow();
@@ -140,10 +138,8 @@ class AlbumServiceTest extends IntegrationTest {
             invitationCodeRepository.save(invitationCode);
             String invitationCodeBefore = invitationCode.getCode();
 
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
-
             // when
-            albumService.createInvitationLink(request);
+            albumService.createInvitationLink(1L);
 
             // then
             Optional<InvitationCode> code = invitationCodeRepository.findById(1L);
@@ -156,10 +152,9 @@ class AlbumServiceTest extends IntegrationTest {
         void 유효한_요청에_대해서_유효한_초대코드가_생성된다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
 
             // when
-            albumService.createInvitationLink(request);
+            albumService.createInvitationLink(1L);
 
             // then
             InvitationCode createdCode = invitationCodeRepository.findById(1L).orElseThrow();
@@ -173,10 +168,9 @@ class AlbumServiceTest extends IntegrationTest {
         void 현재_유저가_HOST가_아닌_경우_예외가_발생한다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(2L);
 
             // when & then
-            assertThatThrownBy(() -> albumService.createInvitationLink(request))
+            assertThatThrownBy(() -> albumService.createInvitationLink(2L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
@@ -185,10 +179,9 @@ class AlbumServiceTest extends IntegrationTest {
         void 현재_유저가_앨범_소속이_아닌_경우_예외가_발생한다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
 
             // when & then
-            assertThatThrownBy(() -> albumService.createInvitationLink(request))
+            assertThatThrownBy(() -> albumService.createInvitationLink(1L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -197,10 +190,9 @@ class AlbumServiceTest extends IntegrationTest {
         void 존재하지_않는_앨범_ID_를_입력한_경우_예외가_발생한다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
-            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(3L);
 
             // when & then
-            assertThatThrownBy(() -> albumService.createInvitationLink(request))
+            assertThatThrownBy(() -> albumService.createInvitationLink(3L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import java.util.List;
 import java.util.Optional;
 import org.cherrypic.IntegrationTest;
+import org.cherrypic.RedisCleaner;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.repository.AlbumRepository;
@@ -24,15 +25,14 @@ import org.cherrypic.member.repository.MemberRepository;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.participant.repository.ParticipantRepository;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 class AlbumServiceTest extends IntegrationTest {
+
+    @Autowired private RedisCleaner redisCleaner;
 
     @Autowired private AlbumService albumService;
     @Autowired private AlbumRepository albumRepository;
@@ -106,6 +106,11 @@ class AlbumServiceTest extends IntegrationTest {
             Participant participant2 =
                     Participant.createParticipant(member2, album2, ParticipantRole.STANDARD);
             participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @AfterEach
+        void cleanUp() {
+            redisCleaner.flushAll();
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -178,7 +178,7 @@ class AlbumServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> albumService.createInvitationLink(request))
                     .isInstanceOf(AlbumException.class)
-                    .hasMessage(AlbumErrorCode.INVALID_INVITATION_AUTHORITY.getMessage());
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -13,6 +13,7 @@ import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.InvitationLinkCreateRequest;
+import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
@@ -108,16 +109,21 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청이면_초대_코드를_저장한다() {
+        void 유효한_요청이면_초대_코드를_저장하며_링크의_뒤에_포함된다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
             InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
 
             // when
-            albumService.createInvitationLink(request);
+            InvitationLinkCreateResponse response = albumService.createInvitationLink(request);
 
             // then
-            assertThat(invitationCodeRepository.findById(1L)).isPresent();
+            InvitationCode savedCode = invitationCodeRepository.findById(1L).orElseThrow();
+
+            String link = response.invitationLink();
+            String codeInLink = link.substring(link.lastIndexOf("=") + 1);
+
+            assertThat(codeInLink).isEqualTo(savedCode.getCode());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -109,7 +109,7 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청이면_초대_코드를_저장하며_링크의_뒤에_포함된다() {
+        void 유효한_요청이면_초대_코드를_저장하며_반환되는_링크의_뒤에_포함된다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
             InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
@@ -145,6 +145,23 @@ class AlbumServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(code).isPresent(),
                     () -> assertThat(invitationCodeBefore).isEqualTo(code.get().getCode()));
+        }
+
+        @Test
+        void 유효한_요청에_대해서_유효한_초대코드가_생성된다() {
+            // given
+            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
+            InvitationLinkCreateRequest request = new InvitationLinkCreateRequest(1L);
+
+            // when
+            albumService.createInvitationLink(request);
+
+            // then
+            InvitationCode createdCode = invitationCodeRepository.findById(1L).orElseThrow();
+            Assertions.assertAll(
+                    () -> assertThat(createdCode.getAlbumId()).isEqualTo(1L),
+                    () -> assertThat(createdCode.getCode().length()).isEqualTo(8),
+                    () -> assertThat(createdCode.getTtl()).isEqualTo(1800L));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -35,7 +35,7 @@ public class EventControllerTest {
     @MockitoBean private EventService eventService;
 
     @Nested
-    class 이벤트를_생성시 {
+    class 이벤트를_생성_시 {
 
         @Test
         void 유효한_요청이면_이벤트_생성_정보를_반환한다() throws Exception {

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -35,7 +35,7 @@ public class EventControllerTest {
     @MockitoBean private EventService eventService;
 
     @Nested
-    class 이벤트를_생성_시 {
+    class 이벤트_생성_요청_시 {
 
         @Test
         void 유효한_요청이면_이벤트_생성_정보를_반환한다() throws Exception {

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -35,7 +35,7 @@ public class EventControllerTest {
     @MockitoBean private EventService eventService;
 
     @Nested
-    class 이벤트를_생성할_때 {
+    class 이벤트를_생성시 {
 
         @Test
         void 유효한_요청이면_이벤트_생성_정보를_반환한다() throws Exception {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/InvitationCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/InvitationCode.java
@@ -1,0 +1,25 @@
+package org.cherrypic.album.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash(value = "InvitationCode")
+public class InvitationCode {
+
+    @Id private Long albumId;
+
+    private String code;
+
+    @TimeToLive private long ttl;
+
+    @Builder
+    private InvitationCode(Long albumId, String code, long ttl) {
+        this.albumId = albumId;
+        this.code = code;
+        this.ttl = ttl;
+    }
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/repository/InvitationCodeRepository.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/repository/InvitationCodeRepository.java
@@ -1,0 +1,6 @@
+package org.cherrypic.album.repository;
+
+import org.cherrypic.album.entity.InvitationCode;
+import org.springframework.data.repository.CrudRepository;
+
+public interface InvitationCodeRepository extends CrudRepository<InvitationCode, Long> {}

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/repository/ParticipantRepository.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/repository/ParticipantRepository.java
@@ -1,8 +1,11 @@
 package org.cherrypic.participant.repository;
 
+import java.util.Optional;
 import org.cherrypic.participant.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     boolean existsByMemberIdAndAlbumId(Long memberId, Long albumId);
+
+    Optional<Participant> findByMemberIdAndAlbumId(Long memberId, Long albumId);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #63 

---
## 📌 작업 내용 및 특이사항
- 앨범당 하나의 code를 가지기 때문에 Redis Template이 아닌 Redis Hash를 사용했습니다. 
- Code와 Link를 구분하여 취급하도록 명명했습니다.
- 입장 API는 참가자 API로 분리될 예정입니다.
- Participant와 관련된 exception이 필요하여 구현했습니다.

---
## 📚 참고사항
- 링크 초대 딥링크는 API 주소와는 무관하긴 합니다. 
- 하지만, 프론트의 편의성을 위해서 맞추고자 합니다. 그런데, 앨범 입장 API는 GET으로 처리하기에는 애매한 부분이 있긴합니다. 
쿼리 파라미터를 받음에도 POST로 처리하는 것에 대해서 어떻게 생각하시는지 궁금합니다.