### PR TITLE
feat: 이벤트 수정 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -9,7 +9,8 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum AlbumErrorCode implements BaseErrorCode {
     ALBUM_NOT_FOUND(404, "앨범이 존재하지 않습니다."),
     NOT_ALBUM_HOST(403, "HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."),
-    NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다.");
+    NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다."),
+    LIMITED_AUTHORITY(403, "앨범에 대한 생성/수정 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -6,13 +6,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventCreateResponse;
+import org.cherrypic.domain.event.dto.EventUpdateRequest;
+import org.cherrypic.domain.event.dto.EventUpdateResponse;
 import org.cherrypic.domain.event.service.EventService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/events")
@@ -28,5 +27,12 @@ public class EventController {
             @Valid @RequestBody EventCreateRequest request) {
         EventCreateResponse response = eventService.createEvent(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{eventId}")
+    @Operation(summary = "이벤트 수정", description = "기존 이벤트를 수정합니다.")
+    public EventUpdateResponse eventUpdate(
+            @PathVariable Long eventId, @Valid @RequestBody EventUpdateRequest request) {
+        return eventService.updateEvent(eventId, request);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventCreateRequest.java
@@ -10,7 +10,7 @@ public record EventCreateRequest(
                 @Schema(description = "이벤트가 속한 엘범의 ID", example = "1")
                 Long albumId,
         @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")
-                @Size(max = 100, message = "이벤트 이름은 최대 100자까지 가능합니다.")
+                @Size(max = 20, message = "이벤트 이름은 최대 20자까지 가능합니다.")
                 @Schema(description = "이벤트의 이름", example = "일본 여행")
                 String title,
         @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventUpdateRequest.java
@@ -1,0 +1,12 @@
+package org.cherrypic.domain.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record EventUpdateRequest(
+        @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")
+                @Size(max = 100, message = "이벤트 이름은 최대 100자까지 가능합니다.")
+                @Schema(description = "이벤트의 이름", example = "일본 여행")
+                String title,
+        @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventUpdateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record EventUpdateRequest(
         @NotBlank(message = "이벤트 이름은 비워둘 수 없습니다.")
-                @Size(max = 100, message = "이벤트 이름은 최대 100자까지 가능합니다.")
+                @Size(max = 20, message = "이벤트 이름은 최대 20자까지 가능합니다.")
                 @Schema(description = "이벤트의 이름", example = "일본 여행")
                 String title,
         @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventUpdateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/EventUpdateResponse.java
@@ -1,0 +1,13 @@
+package org.cherrypic.domain.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.event.entity.Event;
+
+public record EventUpdateResponse(
+        @Schema(description = "이벤트 ID", example = "1") Long eventId,
+        @Schema(description = "이벤트 제목", example = "일본 여행") String title,
+        @Schema(description = "이벤트 커버 URL", example = "https://example.jpg") String coverUrl) {
+    public static EventUpdateResponse from(Event event) {
+        return new EventUpdateResponse(event.getId(), event.getTitle(), event.getCoverUrl());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -7,9 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
-    NOT_ALBUM_PARTICIPANT(403, "참여하지 않은 앨범에는 이벤트를 생성할 권한이 없습니다"),
-    EVENT_NOT_FOUND(404, "존재하지 않는 이밴트입니다."),
-    LIMITED_AUTHORITY(403, "LIMITED 유저는 앨범에 대한 생성/수정 권한이 없습니다.");
+    EVENT_NOT_FOUND(404, "존재하지 않는 이밴트입니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
-    EVENT_NOT_FOUND(404, "존재하지 않는 이밴트입니다.");
+    EVENT_NOT_FOUND(404, "존재하지 않는 이벤트입니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -7,7 +7,8 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
-    NOT_ALBUM_PARTICIPANT(403, "참여하지 않은 앨범에는 이벤트를 생성할 권한이 없습니다");
+    NOT_ALBUM_PARTICIPANT(403, "참여하지 않은 앨범에는 이벤트를 생성할 권한이 없습니다"),
+    EVENT_NOT_FOUND(404, "존재하지 않는 이밴트입니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -8,7 +8,8 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
     NOT_ALBUM_PARTICIPANT(403, "참여하지 않은 앨범에는 이벤트를 생성할 권한이 없습니다"),
-    EVENT_NOT_FOUND(404, "존재하지 않는 이밴트입니다.");
+    EVENT_NOT_FOUND(404, "존재하지 않는 이밴트입니다."),
+    LIMITED_AUTHORITY(403, "LIMITED 유저는 앨범에 대한 생성/수정 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventException.java
@@ -1,9 +1,10 @@
 package org.cherrypic.domain.event.exception;
 
 import org.cherrypic.exception.BaseCustomException;
+import org.cherrypic.exception.BaseErrorCode;
 
 public class EventException extends BaseCustomException {
-    public EventException(EventErrorCode errorCode) {
+    public EventException(BaseErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
@@ -2,7 +2,11 @@ package org.cherrypic.domain.event.service;
 
 import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventCreateResponse;
+import org.cherrypic.domain.event.dto.EventUpdateRequest;
+import org.cherrypic.domain.event.dto.EventUpdateResponse;
 
 public interface EventService {
     EventCreateResponse createEvent(EventCreateRequest request);
+
+    EventUpdateResponse updateEvent(Long eventId, EventUpdateRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -7,6 +7,8 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventCreateResponse;
+import org.cherrypic.domain.event.dto.EventUpdateRequest;
+import org.cherrypic.domain.event.dto.EventUpdateResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.event.entity.Event;
@@ -31,13 +33,28 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventCreateResponse createEvent(EventCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Album album = getAlbumById(request.albumId());
+        Album album = getAlbumById(request.albumId());
         validateAlbumParticipant(currentMember, album);
 
         Event event = Event.createEvent(album, request.title(), request.coverUrl());
         eventRepository.save(event);
 
         return EventCreateResponse.from(event);
+    }
+
+    @Override
+    public EventUpdateResponse updateEvent(Long eventId, EventUpdateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        Event event =
+                eventRepository
+                        .findById(eventId)
+                        .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
+
+        event.changeTitle(request.title());
+        event.changeCoverUrl(request.coverUrl());
+
+        return EventUpdateResponse.from(event);
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -52,8 +52,7 @@ public class EventServiceImpl implements EventService {
 
         validateParticipantAuthority(currentMember, event.getAlbum());
 
-        event.changeTitle(request.title());
-        event.changeCoverUrl(request.coverUrl());
+        event.updateEvent(request.title(), request.coverUrl());
 
         return EventUpdateResponse.from(event);
     }
@@ -75,11 +74,11 @@ public class EventServiceImpl implements EventService {
                 participantRepository
                         .findByMemberIdAndAlbumId(member.getId(), album.getId())
                         .orElseThrow(
-                                () -> new EventException(EventErrorCode.NOT_ALBUM_PARTICIPANT));
+                                () -> new EventException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
         boolean isLimited = participant.getRole().equals(ParticipantRole.LIMITED);
         if (isLimited) {
-            throw new EventException(EventErrorCode.LIMITED_AUTHORITY);
+            throw new EventException(AlbumErrorCode.LIMITED_AUTHORITY);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -69,12 +69,15 @@ public class EventServiceImpl implements EventService {
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
     }
 
+    private Participant getParticipantByMemberIdAndAlbumId(Long memberId, Long albumId) {
+        return participantRepository
+                .findByMemberIdAndAlbumId(memberId, albumId)
+                .orElseThrow(() -> new EventException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
     private void validateParticipantAuthority(Member member, Album album) {
-        Participant participant =
-                participantRepository
-                        .findByMemberIdAndAlbumId(member.getId(), album.getId())
-                        .orElseThrow(
-                                () -> new EventException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+        Participant participant = getParticipantByMemberIdAndAlbumId(member.getId(), album.getId());
 
         boolean isLimited = participant.getRole().equals(ParticipantRole.LIMITED);
         if (isLimited) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -15,6 +15,8 @@ import org.cherrypic.event.entity.Event;
 import org.cherrypic.event.repository.EventRepository;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.participant.repository.ParticipantRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,8 +35,9 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventCreateResponse createEvent(EventCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        Album album = getAlbumById(request.albumId());
-        validateAlbumParticipant(currentMember, album);
+        final Album album = getAlbumById(request.albumId());
+
+        validateParticipantAuthority(currentMember, album);
 
         Event event = Event.createEvent(album, request.title(), request.coverUrl());
         eventRepository.save(event);
@@ -45,11 +48,9 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventUpdateResponse updateEvent(Long eventId, EventUpdateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
+        final Event event = getEventById(eventId);
 
-        Event event =
-                eventRepository
-                        .findById(eventId)
-                        .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
+        validateParticipantAuthority(currentMember, event.getAlbum());
 
         event.changeTitle(request.title());
         event.changeCoverUrl(request.coverUrl());
@@ -63,9 +64,22 @@ public class EventServiceImpl implements EventService {
                 .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
     }
 
-    private void validateAlbumParticipant(Member member, Album album) {
-        if (!participantRepository.existsByMemberIdAndAlbumId(member.getId(), album.getId())) {
-            throw new EventException(EventErrorCode.NOT_ALBUM_PARTICIPANT);
+    private Event getEventById(Long eventId) {
+        return eventRepository
+                .findById(eventId)
+                .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
+    }
+
+    private void validateParticipantAuthority(Member member, Album album) {
+        Participant participant =
+                participantRepository
+                        .findByMemberIdAndAlbumId(member.getId(), album.getId())
+                        .orElseThrow(
+                                () -> new EventException(EventErrorCode.NOT_ALBUM_PARTICIPANT));
+
+        boolean isLimited = participant.getRole().equals(ParticipantRole.LIMITED);
+        if (isLimited) {
+            throw new EventException(EventErrorCode.LIMITED_AUTHORITY);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
@@ -7,8 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum ParticipantErrorCode implements BaseErrorCode {
-    PARTICIPANT_NOT_FOUND(404, "참가자를 찾을 수 없습니다."),
-    ;
+    PARTICIPANT_NOT_FOUND(404, "참가자를 찾을 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -154,8 +154,6 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.data.coverUrl").value("testUpdatedCoverUrl"));
         }
 
-        // null 추가 생각
-
         @ParameterizedTest
         @NullSource
         @EmptySource

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -127,7 +127,7 @@ public class EventControllerTest {
     }
 
     @Nested
-    class 이벤트_수정_시 {
+    class 이벤트_수정_요청_시 {
 
         @Test
         void 유효한_요청이면_이벤트_수정_정보를_반환한다() throws Exception {

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -1,6 +1,7 @@
 package org.cherrypic.event.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,6 +10,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.event.controller.EventController;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventCreateResponse;
+import org.cherrypic.domain.event.dto.EventUpdateRequest;
+import org.cherrypic.domain.event.dto.EventUpdateResponse;
 import org.cherrypic.domain.event.service.EventService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -104,10 +107,9 @@ public class EventControllerTest {
         }
 
         @Test
-        void 이벤트_이름이_100자를_넘어가면_예외가_발생한다() throws Exception {
+        void 이벤트_이름이_20자를_넘어가면_예외가_발생한다() throws Exception {
             // given
-            EventCreateRequest request =
-                    new EventCreateRequest(1L, "t".repeat(101), "testCoverUrl");
+            EventCreateRequest request = new EventCreateRequest(1L, "t".repeat(21), "testCoverUrl");
 
             // when & then
             ResultActions perform =
@@ -120,7 +122,80 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("이벤트 이름은 최대 100자까지 가능합니다."));
+                    .andExpect(jsonPath("$.data.message").value("이벤트 이름은 최대 20자까지 가능합니다."));
+        }
+    }
+
+    @Nested
+    class 이벤트_수정_시 {
+
+        @Test
+        void 유효한_요청이면_이벤트_수정_정보를_반환한다() throws Exception {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
+            EventUpdateResponse response =
+                    new EventUpdateResponse(1L, "testUpdatedTitle", "testUpdatedCoverUrl");
+
+            given(eventService.updateEvent(1L, request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.eventId").value(1))
+                    .andExpect(jsonPath("$.data.title").value("testUpdatedTitle"))
+                    .andExpect(jsonPath("$.data.coverUrl").value("testUpdatedCoverUrl"));
+        }
+
+        // null 추가 생각
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 이벤트_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
+            // given
+            EventUpdateRequest request = new EventUpdateRequest(title, "testUpdatedCoverUrl");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이벤트 이름은 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 이벤트_이름이_20자를_넘어가면_예외가_발생한다() throws Exception {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("t".repeat(21), "testUpdatedCoverUrl");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이벤트 이름은 최대 20자까지 가능합니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -2,17 +2,20 @@ package org.cherrypic.event.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
 
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
+import org.cherrypic.domain.event.dto.EventUpdateRequest;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.service.EventService;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.event.repository.EventRepository;
+import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
@@ -24,53 +27,46 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class EventServiceTest extends IntegrationTest {
 
     @Autowired private EventService eventService;
+
     @Autowired private EventRepository eventRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private ParticipantRepository participantRepository;
 
-    private Member member;
-
-    @BeforeEach
-    void setUp() {
-        member =
-                Member.createMember(
-                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                        "testNickname",
-                        "testProfileImageUrl");
-        memberRepository.save(member);
-
-        UserDetails userDetails =
-                User.withUsername(member.getId().toString())
-                        .password("")
-                        .authorities(member.getRole().name())
-                        .build();
-        UsernamePasswordAuthenticationToken token =
-                new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(token);
-    }
+    @MockitoBean MemberUtil memberUtil;
 
     @Nested
     class 이벤트를_생성할_때 {
 
         @BeforeEach
         void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
             Album album1 = Album.createAlbum("testAlbum1", "testURL1");
             Album album2 = Album.createAlbum("testAlbum2", "testURL2");
             albumRepository.saveAll(List.of(album1, album2));
 
-            Participant participant =
-                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
-            participantRepository.save(participant);
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
         }
 
         @Test
@@ -99,6 +95,118 @@ public class EventServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> eventService.createEvent(request))
                     .isInstanceOf(EventException.class)
                     .hasMessage(EventErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_이벤트를_생성하면_예외가_발생한다() {
+            // given
+            Member limitedMember = memberRepository.findById(2L).orElseThrow();
+            given(memberUtil.getCurrentMember()).willReturn(limitedMember);
+
+            EventCreateRequest request = new EventCreateRequest(1L, "testEvent", "tesCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> eventService.createEvent(request))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(EventErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+    }
+
+    @Nested
+    class 이벤트를_수정할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            Member member3 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId3", "testOauthProvider3"),
+                            "testNickname3",
+                            "testProfileImageUrl3");
+            memberRepository.saveAll(List.of(member1, member2, member3));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1");
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2");
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.LIMITED);
+            Participant participant3 =
+                    Participant.createParticipant(member3, album2, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Event event1 = Event.createEvent(album1, "testEvent1", "testEventCoverUrl1");
+            Event event2 = Event.createEvent(album2, "testEvent1", "testEventCoverUrl1");
+            eventRepository.saveAll(List.of(event1, event2));
+        }
+
+        @Test
+        void 유효한_요청이면_이벤트가_수정된다() {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
+
+            // when
+            eventService.updateEvent(1L, request);
+
+            // then
+            Event event = eventRepository.findById(1L).orElseThrow();
+            Assertions.assertAll(
+                    () -> assertThat(event.getId()).isEqualTo(1L),
+                    () -> assertThat(event.getAlbum().getId()).isEqualTo(1L),
+                    () -> assertThat(event.getTitle()).isEqualTo("changedTestEventTitle"),
+                    () -> assertThat(event.getCoverUrl()).isEqualTo("changedTestEventCoverUrl"));
+        }
+
+        @Test
+        void 존재하지_않는_이벤트를_수정_하면_예외가_발생한다() {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
+
+            // when % then
+            assertThatThrownBy(() -> eventService.updateEvent(2L, request))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_이벤트를_수정하면_예외가_발생한다() {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> eventService.updateEvent(2L, request))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(EventErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_이벤트를_수정하면_예외가_발생한다() {
+            // given
+            Member limitedMember = memberRepository.findById(2L).orElseThrow();
+            given(memberUtil.getCurrentMember()).willReturn(limitedMember);
+
+            EventUpdateRequest request =
+                    new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> eventService.updateEvent(1L, request))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(EventErrorCode.LIMITED_AUTHORITY.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -177,7 +177,7 @@ public class EventServiceTest extends IntegrationTest {
                     new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
 
             // when % then
-            assertThatThrownBy(() -> eventService.updateEvent(2L, request))
+            assertThatThrownBy(() -> eventService.updateEvent(999L, request))
                     .isInstanceOf(EventException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.repository.AlbumRepository;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventUpdateRequest;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -94,7 +95,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.createEvent(request))
                     .isInstanceOf(EventException.class)
-                    .hasMessage(EventErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
 
         @Test
@@ -108,7 +109,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.createEvent(request))
                     .isInstanceOf(EventException.class)
-                    .hasMessage(EventErrorCode.LIMITED_AUTHORITY.getMessage());
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
     }
 
@@ -191,7 +192,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.updateEvent(2L, request))
                     .isInstanceOf(EventException.class)
-                    .hasMessage(EventErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
 
         @Test
@@ -206,7 +207,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.updateEvent(1L, request))
                     .isInstanceOf(EventException.class)
-                    .hasMessage(EventErrorCode.LIMITED_AUTHORITY.getMessage());
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -42,11 +42,8 @@ public class Event extends BaseTimeEntity {
         return Event.builder().album(album).title(title).coverUrl(coverUrl).build();
     }
 
-    public void changeTitle(String title) {
+    public void updateEvent(String title, String coverUrl) {
         this.title = title;
-    }
-
-    public void changeCoverUrl(String coverUrl) {
         this.coverUrl = coverUrl;
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -41,4 +41,12 @@ public class Event extends BaseTimeEntity {
     public static Event createEvent(Album album, String title, String coverUrl) {
         return Event.builder().album(album).title(title).coverUrl(coverUrl).build();
     }
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeCoverUrl(String coverUrl) {
+        this.coverUrl = coverUrl;
+    }
 }

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -52,7 +52,7 @@ CREATE TABLE payment (
 CREATE TABLE event (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        album_id BIGINT NOT NULL,
-                       title VARCHAR(100) NOT NULL,
+                       title VARCHAR(20) NOT NULL,
                        cover_url VARCHAR(255),
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,


### PR DESCRIPTION
## 🌱 관련 이슈
- close #66 

---
## 📌 작업 내용 및 특이사항
- 이벤트를 수정하는 API입니다. 
- 이벤트 이름의 길이와 이벤트 coverUrl을 수정할 수 있습니다.
- Limited 권한에 대한 검증이 이벤트 생성 API에도 추가되었습니다.

---
## 📚 참고사항
- 테스트 코드에서 member를 여러명 생성해야 하는 관계로 전체 BeforeEach를 제거했습니다.