### PR TITLE
feat: 유료 앨범 생성 시 구독 처리 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
@@ -3,10 +3,13 @@ package org.cherrypic.domain.album.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.cherrypic.album.enums.AlbumPlan;
 
 public record AlbumCreateRequest(
-        @NotBlank(message = "앨범 이름은 비워둘 수 없습니다.") @Schema(description = "앨범 이름", example = "연인 앨범")
+        @NotBlank(message = "앨범 이름은 비워둘 수 없습니다.")
+                @Schema(description = "앨범 이름", example = "연인 앨범")
+                @Size(max = 20, message = "앨범 이름은 최대 20자까지 가능합니다.")
                 String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
         @NotNull(message = "앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다.")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
@@ -2,8 +2,15 @@ package org.cherrypic.domain.album.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.cherrypic.album.enums.AlbumPlan;
 
 public record AlbumCreateRequest(
         @NotBlank(message = "앨범 이름은 비워둘 수 없습니다.") @Schema(description = "앨범 이름", example = "연인 앨범")
                 String title,
-        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl) {}
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
+        @NotNull(message = "앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다.")
+                @Schema(description = "앨범 플랜 (BASIC: 무료, PRO/PREMIUM: 유료)", example = "BASIC")
+                AlbumPlan plan,
+        @Schema(description = "유료 플랜(PRO, PREMIUM)인 경우 필수. 결제 검증 후 받은 결제 ID", example = "1")
+                Long paymentId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
@@ -2,12 +2,15 @@ package org.cherrypic.domain.album.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
 
 public record AlbumCreateResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
-        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl) {
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
+        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan) {
     public static AlbumCreateResponse from(Album album) {
-        return new AlbumCreateResponse(album.getId(), album.getTitle(), album.getCoverUrl());
+        return new AlbumCreateResponse(
+                album.getId(), album.getTitle(), album.getCoverUrl(), album.getPlan());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -10,7 +10,11 @@ public enum AlbumErrorCode implements BaseErrorCode {
     ALBUM_NOT_FOUND(404, "앨범이 존재하지 않습니다."),
     NOT_ALBUM_HOST(403, "HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."),
     NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다."),
-    LIMITED_AUTHORITY(403, "앨범에 대한 생성/수정 권한이 없습니다.");
+    LIMITED_AUTHORITY(403, "앨범에 대한 생성/수정 권한이 없습니다."),
+
+    PAYMENT_REQUIRED_FOR_PAID_PLAN(400, "유료 플랜은 결제 ID가 필요합니다."),
+    PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 결제 ID가 필요하지 않습니다."),
+    ;
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumException.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumException.java
@@ -1,9 +1,10 @@
 package org.cherrypic.domain.album.exception;
 
 import org.cherrypic.exception.BaseCustomException;
+import org.cherrypic.exception.BaseErrorCode;
 
 public class AlbumException extends BaseCustomException {
-    public AlbumException(AlbumErrorCode errorCode) {
+    public AlbumException(BaseErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -55,7 +55,7 @@ public class AlbumServiceImpl implements AlbumService {
             final Payment payment = getPaidPaymentById(request.paymentId());
 
             validatePaidStatus(payment);
-            validatePaymentMemberMismatch(currentMember, payment);
+            validatePaymentMemberMismatch(payment, currentMember);
             validatePaymentNotUsed(payment);
 
             payment.updatePayment(album);
@@ -109,7 +109,7 @@ public class AlbumServiceImpl implements AlbumService {
         }
     }
 
-    private void validatePaymentMemberMismatch(Member member, Payment payment) {
+    private void validatePaymentMemberMismatch(Payment payment, Member member) {
         if (!payment.getMember().getId().equals(member.getId())) {
             throw new AlbumException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH);
         }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -3,6 +3,7 @@ package org.cherrypic.domain.album.service;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
@@ -10,11 +11,17 @@ import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.participant.repository.ParticipantRepository;
+import org.cherrypic.payment.entity.Payment;
+import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.payment.repository.PaymentRepository;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.repository.SubscriptionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,17 +34,33 @@ public class AlbumServiceImpl implements AlbumService {
     private final InvitationLinkService invitationLinkService;
 
     private final AlbumRepository albumRepository;
+    private final PaymentRepository paymentRepository;
     private final ParticipantRepository participantRepository;
+    private final SubscriptionRepository subscriptionRepository;
     private final InvitationCodeRepository invitationCodeRepository;
 
     @Override
     public AlbumCreateResponse createAlbum(AlbumCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        Album album = Album.createAlbum(request.title(), request.coverUrl());
+        validatePaymentRequirementForPlan(request.plan(), request.paymentId());
+
+        Album album = Album.createAlbum(request.title(), request.coverUrl(), request.plan());
+
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.HOST);
         album.addParticipant(participant);
+
+        if (request.plan() != AlbumPlan.BASIC) {
+            final Payment payment = getPaidPaymentById(request.paymentId());
+
+            validatePaidStatus(payment);
+            validatePaymentMemberMismatch(currentMember, payment);
+
+            Subscription subscription =
+                    Subscription.createSubscription(currentMember, album, payment.getPaidAt());
+            subscriptionRepository.save(subscription);
+        }
 
         albumRepository.save(album);
 
@@ -65,6 +88,34 @@ public class AlbumServiceImpl implements AlbumService {
         String invitationLink = invitationLinkService.createInvitationLink(invitationCode);
 
         return InvitationLinkCreateResponse.of(invitationLink);
+    }
+
+    private void validatePaymentRequirementForPlan(AlbumPlan plan, Long paymentId) {
+        if (plan.requiresPayment() && paymentId == null) {
+            throw new AlbumException(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_PLAN);
+        }
+
+        if (!plan.requiresPayment() && paymentId != null) {
+            throw new AlbumException(AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN);
+        }
+    }
+
+    private void validatePaidStatus(Payment payment) {
+        if (payment.getStatus() != PaymentStatus.PAID) {
+            throw new AlbumException(PaymentErrorCode.NOT_PAID);
+        }
+    }
+
+    private void validatePaymentMemberMismatch(Member member, Payment payment) {
+        if (!payment.getMember().getId().equals(member.getId())) {
+            throw new AlbumException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH);
+        }
+    }
+
+    private Payment getPaidPaymentById(Long paymentId) {
+        return paymentRepository
+                .findById(paymentId)
+                .orElseThrow(() -> new AlbumException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 
     private void validateInvitationAuthority(Long memberId, Long albumId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -58,7 +58,7 @@ public class AlbumServiceImpl implements AlbumService {
             validatePaymentMemberMismatch(currentMember, payment);
             validatePaymentNotUsed(payment);
 
-            album.addPayment(payment);
+            payment.updatePayment(album);
 
             Subscription subscription =
                     Subscription.createSubscription(currentMember, album, payment.getPaidAt());
@@ -116,7 +116,7 @@ public class AlbumServiceImpl implements AlbumService {
     }
 
     private void validatePaymentNotUsed(Payment payment) {
-        if (albumRepository.existsByPayment(payment)) {
+        if (payment.getAlbum() != null) {
             throw new AlbumException(PaymentErrorCode.ALREADY_USED_PAYMENT);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -56,6 +56,9 @@ public class AlbumServiceImpl implements AlbumService {
 
             validatePaidStatus(payment);
             validatePaymentMemberMismatch(currentMember, payment);
+            validatePaymentNotUsed(payment);
+
+            album.addPayment(payment);
 
             Subscription subscription =
                     Subscription.createSubscription(currentMember, album, payment.getPaidAt());
@@ -109,6 +112,12 @@ public class AlbumServiceImpl implements AlbumService {
     private void validatePaymentMemberMismatch(Member member, Payment payment) {
         if (!payment.getMember().getId().equals(member.getId())) {
             throw new AlbumException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH);
+        }
+    }
+
+    private void validatePaymentNotUsed(Payment payment) {
+        if (albumRepository.existsByPayment(payment)) {
+            throw new AlbumException(PaymentErrorCode.ALREADY_USED_PAYMENT);
         }
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
@@ -17,6 +17,8 @@ public enum PaymentErrorCode implements BaseErrorCode {
     IAMPORT_API_UNAVAILABLE(503, "결제 대행 시스템(Iamport)과의 통신에 실패했습니다. 잠시 후 다시 시도해주세요."),
 
     PAYMENT_MEMBER_MISMATCH(403, "결제한 사용자와 일치하지 않습니다."),
+
+    ALREADY_USED_PAYMENT(400, "이미 다른 앨범에 사용된 결제입니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
@@ -14,7 +14,10 @@ public enum PaymentErrorCode implements BaseErrorCode {
     AMOUNT_MISMATCH(400, "결제 금액이 일치하지 않아 검증에 실패했습니다."),
     NOT_PAID(400, "결제가 완료되지 않아 검증에 실패했습니다."),
 
-    IAMPORT_API_UNAVAILABLE(503, "결제 대행 시스템(Iamport)과의 통신에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    IAMPORT_API_UNAVAILABLE(503, "결제 대행 시스템(Iamport)과의 통신에 실패했습니다. 잠시 후 다시 시도해주세요."),
+
+    PAYMENT_MEMBER_MISMATCH(403, "결제한 사용자와 일치하지 않습니다."),
+    ;
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -270,6 +270,51 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("앨범 이름은 비워둘 수 없습니다."));
         }
+
+        @Test
+        void 앨범_이름이_20자를_초과하면_예외가_발생한다() throws Exception {
+            // given
+            AlbumCreateRequest request =
+                    new AlbumCreateRequest("t".repeat(21), "testCoverUrl", AlbumPlan.BASIC, null);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("앨범 이름은 최대 20자까지 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" ", "PROO", "PREMIUMM"})
+        void 앨범_플랜이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String plan) throws Exception {
+            // given
+            AlbumCreateRequest request =
+                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.from(plan), 1L);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다."));
+        }
     }
 
     @Nested

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -11,7 +11,10 @@ import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,30 +42,210 @@ class AlbumControllerTest {
     @Nested
     class 앨범_생성_요청_시 {
 
-        @Test
-        void 유효한_요청이면_앨범_생성_정보를_반환한다() throws Exception {
-            // given
-            AlbumCreateRequest request =
-                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
+        @Nested
+        class BASIC_플랜인_경우 {
 
-            AlbumCreateResponse response =
-                    new AlbumCreateResponse(1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC);
+            @Test
+            void 결제ID_없이_요청하면_앨범_생성_정보를_반환한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
 
-            given(albumService.createAlbum(request)).willReturn(response);
+                AlbumCreateResponse response =
+                        new AlbumCreateResponse(1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC);
 
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
+                given(albumService.createAlbum(request)).willReturn(response);
 
-            perform.andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
-                    .andExpect(jsonPath("$.data.albumId").value(1))
-                    .andExpect(jsonPath("$.data.title").value("testTitle"))
-                    .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"));
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
+                        .andExpect(jsonPath("$.data.albumId").value(1))
+                        .andExpect(jsonPath("$.data.title").value("testTitle"))
+                        .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"))
+                        .andExpect(jsonPath("$.data.plan").value("BASIC"));
+            }
+
+            @Test
+            void 결제ID를_포함하여_요청하면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(
+                                new AlbumException(
+                                        AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                        .andExpect(
+                                jsonPath("$.data.code")
+                                        .value("PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN"))
+                        .andExpect(
+                                jsonPath("$.data.message").value("BASIC 플랜에서는 결제 ID가 필요하지 않습니다."));
+            }
+        }
+
+        @Nested
+        class PRO_또는_PREMIUM_플랜인_경우 {
+
+            @Test
+            void 유효한_결제ID면_앨범_생성_정보를_반환한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+
+                AlbumCreateResponse response =
+                        new AlbumCreateResponse(1L, "testTitle", "testCoverUrl", AlbumPlan.PRO);
+
+                given(albumService.createAlbum(request)).willReturn(response);
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
+                        .andExpect(jsonPath("$.data.albumId").value(1))
+                        .andExpect(jsonPath("$.data.title").value("testTitle"))
+                        .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"))
+                        .andExpect(jsonPath("$.data.plan").value("PRO"));
+            }
+
+            @Test
+            void 결제ID가_null이면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, null);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(
+                                new AlbumException(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_PLAN));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                        .andExpect(jsonPath("$.data.code").value("PAYMENT_REQUIRED_FOR_PAID_PLAN"))
+                        .andExpect(jsonPath("$.data.message").value("유료 플랜은 결제 ID가 필요합니다."));
+            }
+
+            @Test
+            void 존재하지_않는_결제ID면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 999L);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(new AlbumException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                        .andExpect(jsonPath("$.data.code").value("PAYMENT_NOT_FOUND"))
+                        .andExpect(jsonPath("$.data.message").value("결제 정보가 존재하지 않습니다."));
+            }
+
+            @Test
+            void 결제상태가_PAID가_아니면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(new AlbumException(PaymentErrorCode.NOT_PAID));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                        .andExpect(jsonPath("$.data.code").value("NOT_PAID"))
+                        .andExpect(jsonPath("$.data.message").value("결제가 완료되지 않아 검증에 실패했습니다."));
+            }
+
+            @Test
+            void 결제한_회원과_로그인_회원이_일치하지_않으면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(new AlbumException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                        .andExpect(jsonPath("$.data.code").value("PAYMENT_MEMBER_MISMATCH"))
+                        .andExpect(jsonPath("$.data.message").value("결제한 사용자와 일치하지 않습니다."));
+            }
+
+            @Test
+            void 결제가_이미_다른_앨범에_사용된_경우_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(new AlbumException(PaymentErrorCode.ALREADY_USED_PAYMENT));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                        .andExpect(jsonPath("$.data.code").value("ALREADY_USED_PAYMENT"))
+                        .andExpect(jsonPath("$.data.message").value("이미 다른 앨범에 사용된 결제입니다."));
+            }
         }
 
         @ParameterizedTest

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -225,7 +225,7 @@ class AlbumControllerTest {
             }
 
             @Test
-            void 결제가_이미_다른_앨범에_사용된_경우_예외가_발생한다() throws Exception {
+            void 결제가_이미_사용된_경우_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
@@ -41,9 +42,11 @@ class AlbumControllerTest {
         @Test
         void 유효한_요청이면_앨범_생성_정보를_반환한다() throws Exception {
             // given
-            AlbumCreateRequest request = new AlbumCreateRequest("testTitle", "testCoverUrl");
+            AlbumCreateRequest request =
+                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
 
-            AlbumCreateResponse response = new AlbumCreateResponse(1L, "testTitle", "testCoverUrl");
+            AlbumCreateResponse response =
+                    new AlbumCreateResponse(1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC);
 
             given(albumService.createAlbum(request)).willReturn(response);
 
@@ -68,7 +71,8 @@ class AlbumControllerTest {
         @ValueSource(strings = {" "})
         void 앨범_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
             // given
-            AlbumCreateRequest request = new AlbumCreateRequest(title, "testCoverUrl");
+            AlbumCreateRequest request =
+                    new AlbumCreateRequest(title, "testCoverUrl", AlbumPlan.BASIC, null);
 
             // when & then
             ResultActions perform =

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -3,7 +3,10 @@ package org.cherrypic.album.service;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import org.cherrypic.IntegrationTest;
@@ -18,66 +21,266 @@ import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.repository.MemberRepository;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.participant.repository.ParticipantRepository;
+import org.cherrypic.payment.entity.Payment;
+import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.payment.repository.PaymentRepository;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
+import org.cherrypic.subscription.repository.SubscriptionRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.transaction.annotation.Transactional;
 
 class AlbumServiceTest extends IntegrationTest {
 
     @Autowired private RedisCleaner redisCleaner;
+    @Autowired private TransactionUtil transactionUtil;
 
     @Autowired private AlbumService albumService;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
-    @Autowired private InvitationCodeRepository invitationCodeRepository;
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private SubscriptionRepository subscriptionRepository;
     @Autowired private ParticipantRepository participantRepository;
+    @Autowired private InvitationCodeRepository invitationCodeRepository;
 
     @MockitoBean MemberUtil memberUtil;
 
-    @Transactional
     @Nested
     class 앨범을_생성할_때 {
 
-        @BeforeEach
-        void setUp() {
-            Member member =
-                    Member.createMember(
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                            "testNickname",
-                            "testProfileImageUrl");
-            memberRepository.save(member);
+        @Nested
+        class BASIC_플랜인_경우 {
 
-            given(memberUtil.getCurrentMember()).willReturn(member);
+            @BeforeEach
+            void setUp() {
+                Member member =
+                        Member.createMember(
+                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                                "testNickname",
+                                "testProfileImageUrl");
+                memberRepository.save(member);
+
+                given(memberUtil.getCurrentMember()).willReturn(member);
+            }
+
+            @Test
+            void 결제ID_없이_요청하면_앨범과_HOST_참여자가_생성된다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
+
+                // when
+                albumService.createAlbum(request);
+
+                // then
+                Album album =
+                        transactionUtil.getResult(
+                                () -> {
+                                    Album loadedAlbum = albumRepository.findById(1L).get();
+                                    loadedAlbum.getParticipants().get(0);
+                                    return loadedAlbum;
+                                });
+                Participant participant = album.getParticipants().get(0);
+
+                Assertions.assertAll(
+                        () -> assertThat(album.getId()).isEqualTo(1L),
+                        () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
+                        () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
+                        () -> assertThat(album.getPlan()).isEqualTo(AlbumPlan.BASIC),
+                        () -> assertThat(participant.getId()).isEqualTo(1L),
+                        () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
+                        () -> assertThat(participant.getAlbum().getId()).isEqualTo(1L),
+                        () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST));
+            }
+
+            @Test
+            void 결제ID를_포함하여_요청하면_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(
+                                AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN.getMessage());
+            }
         }
 
-        @Test
-        void 유효한_요청이면_앨범과_HOST_참여자가_생성된다() {
-            // given
-            AlbumCreateRequest request =
-                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
+        @Nested
+        class PRO_또는_PREMIUM_플랜인_경우 {
 
-            // when
-            albumService.createAlbum(request);
+            @BeforeEach
+            void setUp() {
+                Member member1 =
+                        Member.createMember(
+                                OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                                "testNickname1",
+                                "testProfileImageUrl1");
+                Member member2 =
+                        Member.createMember(
+                                OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                                "testNickname2",
+                                "testProfileImageUrl2");
+                memberRepository.saveAll(List.of(member1, member2));
 
-            // then
-            Album album = albumRepository.findById(1L).orElseThrow();
-            Participant participant = album.getParticipants().get(0);
+                given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Assertions.assertAll(
-                    () -> assertThat(album.getId()).isEqualTo(1L),
-                    () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
-                    () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
-                    () -> assertThat(participant.getId()).isEqualTo(1L),
-                    () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
-                    () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST));
+                Album album = Album.createAlbum("testPaidTitle", "testPaidCoverUrl", AlbumPlan.PRO);
+                albumRepository.save(album);
+
+                // 검증 완료된 결제
+                Payment payment1 = Payment.createPayment(member1, "testMerchantUid", 3900);
+                payment1.updatePayment(
+                        "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+                // 검증되지 않은 결제
+                Payment payment2 = Payment.createPayment(member1, "testMerchantUid", 3900);
+                // 검증 완료 + 유료 앨범에 쓰인 결제
+                Payment payment3 = Payment.createPayment(member1, "testMerchantUid", 3900);
+                payment3.updatePayment(
+                        "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+                payment3.updatePayment(album);
+                paymentRepository.saveAll(List.of(payment1, payment2, payment3));
+            }
+
+            @Test
+            void 유효한_결제ID면_앨범과_HOST_참여자_및_구독이_생성되고_결제에_앨범이_연결된다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+
+                // when
+                albumService.createAlbum(request);
+
+                // then
+                Album album =
+                        transactionUtil.getResult(
+                                () -> {
+                                    Album loadedAlbum = albumRepository.findById(2L).get();
+                                    loadedAlbum.getParticipants().get(0);
+                                    loadedAlbum.getPayments().get(0);
+                                    return loadedAlbum;
+                                });
+                Participant participant = album.getParticipants().get(0);
+                Payment payment = album.getPayments().get(0);
+
+                Subscription subscription = subscriptionRepository.findById(1L).orElseThrow();
+
+                Assertions.assertAll(
+                        () -> assertThat(album.getId()).isEqualTo(2L),
+                        () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
+                        () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
+                        () -> assertThat(album.getPlan()).isEqualTo(AlbumPlan.PRO),
+                        () -> assertThat(participant.getId()).isEqualTo(1L),
+                        () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
+                        () -> assertThat(participant.getAlbum().getId()).isEqualTo(2L),
+                        () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST),
+                        () -> assertThat(payment.getAlbum().getId()).isEqualTo(2L),
+                        () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID),
+                        () -> assertThat(subscription.getId()).isEqualTo(1L),
+                        () -> assertThat(subscription.getMember().getId()).isEqualTo(1L),
+                        () -> assertThat(subscription.getAlbum().getId()).isEqualTo(2L),
+                        () ->
+                                assertThat(subscription.getStatus())
+                                        .isEqualTo(SubscriptionStatus.ACTIVE),
+                        () ->
+                                assertThat(
+                                                subscription
+                                                        .getStartAt()
+                                                        .truncatedTo(ChronoUnit.MINUTES))
+                                        .isEqualTo(
+                                                LocalDateTime.now()
+                                                        .truncatedTo(ChronoUnit.MINUTES)),
+                        () ->
+                                assertThat(subscription.getEndAt().truncatedTo(ChronoUnit.MINUTES))
+                                        .isEqualTo(
+                                                LocalDateTime.now()
+                                                        .truncatedTo(ChronoUnit.MINUTES)
+                                                        .plusMonths(1)),
+                        () ->
+                                assertThat(
+                                                subscription
+                                                        .getNextBillingAt()
+                                                        .truncatedTo(ChronoUnit.MINUTES))
+                                        .isEqualTo(
+                                                LocalDateTime.now()
+                                                        .truncatedTo(ChronoUnit.MINUTES)
+                                                        .plusMonths(1)
+                                                        .plusDays(1)));
+            }
+
+            @Test
+            void 결제ID가_null이면_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, null);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_PLAN.getMessage());
+            }
+
+            @Test
+            void 존재하지_않는_결제ID면_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 999L);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(PaymentErrorCode.PAYMENT_NOT_FOUND.getMessage());
+            }
+
+            @Test
+            void 결제상태가_PAID가_아니면_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 2L);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(PaymentErrorCode.NOT_PAID.getMessage());
+            }
+
+            @Test
+            void 결제한_회원과_로그인_회원이_일치하지_않으면_예외가_발생한다() {
+                // given
+                given(memberUtil.getCurrentMember())
+                        .willReturn(memberRepository.findById(2L).get());
+
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH.getMessage());
+            }
+
+            @Test
+            void 결제가_이미_다른_앨범에_사용된_경우_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 3L);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(PaymentErrorCode.ALREADY_USED_PAYMENT.getMessage());
+            }
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -271,7 +271,7 @@ class AlbumServiceTest extends IntegrationTest {
             }
 
             @Test
-            void 결제가_이미_다른_앨범에_사용된_경우_예외가_발생한다() {
+            void 결제가_이미_사용된_경우_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 3L);

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -10,6 +10,7 @@ import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
@@ -60,7 +61,8 @@ class AlbumServiceTest extends IntegrationTest {
         @Test
         void 유효한_요청이면_앨범과_HOST_참여자가_생성된다() {
             // given
-            AlbumCreateRequest request = new AlbumCreateRequest("testTitle", "testCoverUrl");
+            AlbumCreateRequest request =
+                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
 
             // when
             albumService.createAlbum(request);
@@ -96,8 +98,8 @@ class AlbumServiceTest extends IntegrationTest {
                             "testProfileImageUrl2");
             memberRepository.saveAll(List.of(member1, member2));
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1");
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2");
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
@@ -59,8 +60,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1");
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2");
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -136,8 +137,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2, member3));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1");
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2");
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -14,6 +14,7 @@ import org.cherrypic.event.entity.Event;
 import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.subscription.entity.Subscription;
 
 @Getter
@@ -24,6 +25,10 @@ public class Album extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
 
     @NotNull private String title;
 
@@ -56,6 +61,10 @@ public class Album extends BaseTimeEntity {
 
     public static Album createAlbum(String title, String coverUrl, AlbumPlan plan) {
         return Album.builder().title(title).coverUrl(coverUrl).plan(plan).build();
+    }
+
+    public void addPayment(Payment payment) {
+        this.payment = payment;
     }
 
     public void addParticipant(Participant participant) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -26,16 +26,15 @@ public class Album extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "payment_id")
-    private Payment payment;
-
     @NotNull private String title;
 
     private String coverUrl;
 
     @Enumerated(EnumType.STRING)
     private AlbumPlan plan;
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Payment> payments = new ArrayList<>();
 
     @OneToOne(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private Subscription subscription;
@@ -61,10 +60,6 @@ public class Album extends BaseTimeEntity {
 
     public static Album createAlbum(String title, String coverUrl, AlbumPlan plan) {
         return Album.builder().title(title).coverUrl(coverUrl).plan(plan).build();
-    }
-
-    public void addPayment(Payment payment) {
-        this.payment = payment;
     }
 
     public void addParticipant(Participant participant) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -14,6 +14,7 @@ import org.cherrypic.event.entity.Event;
 import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.subscription.entity.Subscription;
 
 @Getter
 @Entity
@@ -31,17 +32,20 @@ public class Album extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private AlbumPlan plan;
 
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Favorites> favorites = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Image> images = new ArrayList<>();
+    @OneToOne(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Subscription subscription;
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Event> events = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Participant> participants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Favorites> favorites = new ArrayList<>();
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> images = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Album(String title, String coverUrl) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -48,13 +48,14 @@ public class Album extends BaseTimeEntity {
     private List<Image> images = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Album(String title, String coverUrl) {
+    private Album(String title, String coverUrl, AlbumPlan plan) {
         this.title = title;
         this.coverUrl = coverUrl;
+        this.plan = plan;
     }
 
-    public static Album createAlbum(String title, String coverUrl) {
-        return Album.builder().title(title).coverUrl(coverUrl).build();
+    public static Album createAlbum(String title, String coverUrl, AlbumPlan plan) {
+        return Album.builder().title(title).coverUrl(coverUrl).plan(plan).build();
     }
 
     public void addParticipant(Participant participant) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -14,7 +14,6 @@ import org.cherrypic.event.entity.Event;
 import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.participant.entity.Participant;
-import org.cherrypic.payment.entity.Payment;
 
 @Getter
 @Entity
@@ -31,9 +30,6 @@ public class Album extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private AlbumPlan plan;
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Payment> payments = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorites> favorites = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
@@ -22,4 +22,8 @@ public enum AlbumPlan {
                 .findFirst()
                 .orElse(null);
     }
+
+    public boolean requiresPayment() {
+        return price > 0;
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/repository/AlbumRepository.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/repository/AlbumRepository.java
@@ -1,9 +1,6 @@
 package org.cherrypic.album.repository;
 
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlbumRepository extends JpaRepository<Album, Long> {
-    boolean existsByPayment(Payment payment);
-}
+public interface AlbumRepository extends JpaRepository<Album, Long> {}

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/repository/AlbumRepository.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/repository/AlbumRepository.java
@@ -1,6 +1,9 @@
 package org.cherrypic.album.repository;
 
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlbumRepository extends JpaRepository<Album, Long> {}
+public interface AlbumRepository extends JpaRepository<Album, Long> {
+    boolean existsByPayment(Payment payment);
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -22,9 +22,6 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
-    private Subscription subscription;
-
     @Embedded private OauthInfo oauthInfo;
 
     @NotNull private String nickname;
@@ -43,6 +40,9 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Subscription> subscriptions = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Participant> participants = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.payment.enums.PaymentStatus;
@@ -23,6 +24,10 @@ public class Payment extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id")
+    private Album album;
 
     @NotNull private String merchantUid;
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -67,4 +67,8 @@ public class Payment extends BaseTimeEntity {
         this.status = status;
         this.paidAt = paidAt;
     }
+
+    public void updatePayment(Album album) {
+        this.album = album;
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -7,7 +7,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.payment.enums.PaymentStatus;
@@ -24,10 +23,6 @@ public class Payment extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "album_id")
-    private Album album;
 
     @NotNull private String merchantUid;
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
@@ -36,4 +37,32 @@ public class Subscription {
     private LocalDateTime endAt;
 
     private LocalDateTime nextBillingAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Subscription(
+            Member member,
+            Album album,
+            SubscriptionStatus status,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            LocalDateTime nextBillingAt) {
+        this.member = member;
+        this.album = album;
+        this.status = status;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.nextBillingAt = nextBillingAt;
+    }
+
+    public static Subscription createSubscription(
+            Member member, Album album, LocalDateTime paidAt) {
+        return Subscription.builder()
+                .member(member)
+                .album(album)
+                .status(SubscriptionStatus.ACTIVE)
+                .startAt(paidAt)
+                .endAt(paidAt.plusMonths(1))
+                .nextBillingAt(paidAt.plusMonths(1).plusDays(1))
+                .build();
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -8,13 +8,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Subscription {
+public class Subscription extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cherrypic.album.entity.Album;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 
@@ -18,9 +19,13 @@ public class Subscription {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id", unique = true)
+    private Album album;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -35,7 +35,6 @@ CREATE TABLE album (
 CREATE TABLE payment (
                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
                          member_id BIGINT NOT NULL,
-                         album_id BIGINT,
                          merchant_uid VARCHAR(255) NOT NULL,
                          imp_uid VARCHAR(255),
                          pg_provider VARCHAR(255),
@@ -44,8 +43,7 @@ CREATE TABLE payment (
                          paid_at DATETIME,
                          created_at DATETIME(6) NOT NULL,
                          updated_at DATETIME(6) NOT NULL,
-                         CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id),
-                         CONSTRAINT fk_payment_album FOREIGN KEY (album_id) REFERENCES album (id)
+                         CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id)
 );
 
 

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -47,6 +47,8 @@ CREATE TABLE subscription (
                               start_at DATETIME(6),
                               end_at DATETIME(6),
                               next_billing_at DATETIME(6),
+                              created_at DATETIME(6) NOT NULL,
+                              updated_at DATETIME(6) NOT NULL,
                               CONSTRAINT fk_subscription_member FOREIGN KEY (member_id) REFERENCES member (id),
                               CONSTRAINT fk_subscription_album FOREIGN KEY (album_id) REFERENCES album (id)
 );

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -12,26 +12,6 @@ CREATE TABLE member (
 );
 
 
-CREATE TABLE subscription (
-                              id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                              member_id BIGINT UNIQUE NOT NULL,
-                              status VARCHAR(255) NOT NULL CHECK (status IN ('ACTIVE','CANCELLED','EXPIRED')),
-                              start_at DATETIME(6),
-                              end_at DATETIME(6),
-                              next_billing_at DATETIME(6),
-                              CONSTRAINT fk_subscription_member FOREIGN KEY (member_id) REFERENCES member (id)
-);
-
-
-CREATE TABLE album (
-                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                       title VARCHAR(50) NOT NULL,
-                       cover_url VARCHAR(255),
-                       plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
-                       created_at DATETIME(6) NOT NULL,
-                       updated_at DATETIME(6) NOT NULL
-);
-
 CREATE TABLE payment (
                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
                          member_id BIGINT NOT NULL,
@@ -44,6 +24,29 @@ CREATE TABLE payment (
                          created_at DATETIME(6) NOT NULL,
                          updated_at DATETIME(6) NOT NULL,
                          CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id)
+);
+
+
+CREATE TABLE album (
+                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                       title VARCHAR(50) NOT NULL,
+                       cover_url VARCHAR(255),
+                       plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
+                       created_at DATETIME(6) NOT NULL,
+                       updated_at DATETIME(6) NOT NULL
+);
+
+
+CREATE TABLE subscription (
+                              id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                              member_id BIGINT NOT NULL,
+                              album_id BIGINT UNIQUE,
+                              status VARCHAR(255) NOT NULL CHECK (status IN ('ACTIVE','CANCELLED','EXPIRED')),
+                              start_at DATETIME(6),
+                              end_at DATETIME(6),
+                              next_billing_at DATETIME(6),
+                              CONSTRAINT fk_subscription_member FOREIGN KEY (member_id) REFERENCES member (id),
+                              CONSTRAINT fk_subscription_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
 
 

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -12,9 +12,20 @@ CREATE TABLE member (
 );
 
 
+CREATE TABLE album (
+                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                       title VARCHAR(20) NOT NULL,
+                       cover_url VARCHAR(255),
+                       plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
+                       created_at DATETIME(6) NOT NULL,
+                       updated_at DATETIME(6) NOT NULL
+);
+
+
 CREATE TABLE payment (
                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
                          member_id BIGINT NOT NULL,
+                         album_id BIGINT,
                          merchant_uid VARCHAR(255) NOT NULL,
                          imp_uid VARCHAR(255),
                          pg_provider VARCHAR(255),
@@ -23,19 +34,8 @@ CREATE TABLE payment (
                          paid_at DATETIME,
                          created_at DATETIME(6) NOT NULL,
                          updated_at DATETIME(6) NOT NULL,
-                         CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id)
-);
-
-
-CREATE TABLE album (
-                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                       payment_id BIGINT,
-                       title VARCHAR(20) NOT NULL,
-                       cover_url VARCHAR(255),
-                       plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
-                       created_at DATETIME(6) NOT NULL,
-                       updated_at DATETIME(6) NOT NULL,
-                       CONSTRAINT fk_album_payment FOREIGN KEY (payment_id) REFERENCES payment (id)
+                         CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id),
+                         CONSTRAINT fk_payment_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
 
 

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -29,11 +29,13 @@ CREATE TABLE payment (
 
 CREATE TABLE album (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                       payment_id BIGINT,
                        title VARCHAR(50) NOT NULL,
                        cover_url VARCHAR(255),
                        plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
                        created_at DATETIME(6) NOT NULL,
-                       updated_at DATETIME(6) NOT NULL
+                       updated_at DATETIME(6) NOT NULL,
+                       CONSTRAINT fk_album_payment FOREIGN KEY (payment_id) REFERENCES payment (id)
 );
 
 

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -30,7 +30,7 @@ CREATE TABLE payment (
 CREATE TABLE album (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        payment_id BIGINT,
-                       title VARCHAR(50) NOT NULL,
+                       title VARCHAR(20) NOT NULL,
                        cover_url VARCHAR(255),
                        plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
                        created_at DATETIME(6) NOT NULL,


### PR DESCRIPTION
## 🌱 관련 이슈
- close #67 

---
## 📌 작업 내용 및 특이사항
- 앨범 생성 시 플랜에 따라 결제 ID 검증 및 구독 처리 로직을 추가했습니다.

  - BASIC 플랜은 결제 ID를 포함할 수 없으며, 포함될 경우 예외가 발생합니다.

  - PRO, PREMIUM 플랜은 결제 ID가 필수이며, 아래 조건을 모두 만족해야 합니다.  
    (사전 결제 검증 API가 호출된 이후여야 합니다.)

    - 결제 상태가 PAID인지  
    - 결제한 회원과 현재 로그인한 회원이 일치하는지  
    - 동일 결제가 이미 다른 앨범에 사용되지 않았는지  

- 검증을 통과한 결제는 앨범과 연결되며, **하나의 앨범에는 여러 결제가 연결될 수 있지만,  
  각 결제는 하나의 앨범에만 연결될 수 있도록 Payment → Album의 다대일(N:1) 구조로 변경했습니다.**

- 유료 앨범인 경우, 구독 정보(Subscription)를 함께 생성하여 저장되도록 처리했습니다.

- 기존 Subscription 엔티티는 회원 단위 구독만 관리했으나,  
  **이제는 특정 앨범 기준으로 구독을 관리하도록 구조를 변경**하여  
  Subscription이 Album과 1:1, Member와 N:1의 양방향 연관관계를 갖도록 했습니다.

- 앨범 이름은 최대 20자까지 입력 가능하도록 유효성 검사를 적용했습니다.
---
## 📚 참고사항
- 유료 앨범은 반드시 결제 준비, 결제 검증 API 호출 후 응답받은 결제 ID로 생성하셔야 합니다!