### PR TITLE
feat: 참여 중인 앨범 목록 조회 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -1,13 +1,17 @@
 package org.cherrypic.domain.album.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,5 +38,18 @@ public class AlbumController {
             @PathVariable Long albumId) {
         InvitationLinkCreateResponse response = albumService.createInvitationLink(albumId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "앨범 목록 조회", description = "회원이 참여 중인 앨범 목록을 커서 기반 페이징 방식으로 조회합니다.")
+    public SliceResponse<AlbumListResponse> albums(
+            @Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    Long lastAlbumId,
+            @Parameter(description = "페이지당 조회할 앨범 수") @RequestParam int size,
+            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
+                    @RequestParam(defaultValue = "DESC")
+                    SortDirection direction) {
+        return albumService.getParticipatingAlbums(lastAlbumId, size, direction);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
@@ -1,0 +1,16 @@
+package org.cherrypic.domain.album.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+
+public record AlbumListResponse(
+        @Schema(description = "앨범 ID", example = "1") Long albumId,
+        @Schema(description = "앨범 이름", example = "연인 앨범") String title,
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
+        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan) {
+    public static AlbumListResponse from(Album album) {
+        return new AlbumListResponse(
+                album.getId(), album.getTitle(), album.getCoverUrl(), album.getPlan());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
@@ -3,4 +3,4 @@ package org.cherrypic.domain.album.repository;
 import org.cherrypic.album.entity.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlbumRepository extends JpaRepository<Album, Long> {}
+public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -1,0 +1,3 @@
+package org.cherrypic.domain.album.repository;
+
+public interface AlbumRepositoryCustom {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -1,3 +1,10 @@
 package org.cherrypic.domain.album.repository;
 
-public interface AlbumRepositoryCustom {}
+import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.data.domain.Slice;
+
+public interface AlbumRepositoryCustom {
+    Slice<AlbumListResponse> findAllByMemberId(
+            Long memberId, Long lastAlbumId, int size, SortDirection direction);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -1,0 +1,12 @@
+package org.cherrypic.domain.album.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -1,7 +1,18 @@
 package org.cherrypic.domain.album.repository;
 
+import static org.cherrypic.album.entity.QAlbum.album;
+import static org.cherrypic.participant.entity.QParticipant.participant;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,4 +20,47 @@ import org.springframework.stereotype.Repository;
 public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<AlbumListResponse> findAllByMemberId(
+            Long memberId, Long lastAlbumId, int size, SortDirection direction) {
+        List<AlbumListResponse> results =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        AlbumListResponse.class,
+                                        album.id,
+                                        album.title,
+                                        album.coverUrl,
+                                        album.plan))
+                        .from(participant)
+                        .join(participant.album, album)
+                        .where(
+                                participant.member.id.eq(memberId),
+                                lastAlbumIdCondition(lastAlbumId, direction))
+                        .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())
+                        .limit(size + 1)
+                        .fetch();
+
+        return checkLastPage(size, results);
+    }
+
+    private BooleanExpression lastAlbumIdCondition(Long albumId, SortDirection direction) {
+        if (albumId == null) {
+            return null;
+        }
+
+        return direction == SortDirection.DESC ? album.id.lt(albumId) : album.id.gt(albumId);
+    }
+
+    private Slice<AlbumListResponse> checkLastPage(int pageSize, List<AlbumListResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -2,10 +2,16 @@ package org.cherrypic.domain.album.service;
 
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 
 public interface AlbumService {
     AlbumCreateResponse createAlbum(AlbumCreateRequest request);
 
     InvitationLinkCreateResponse createInvitationLink(Long albumId);
+
+    SliceResponse<AlbumListResponse> getParticipatingAlbums(
+            Long lastAlbumId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -6,6 +6,7 @@ import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
@@ -15,6 +16,8 @@ import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
@@ -22,6 +25,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentStatus;
 import org.cherrypic.subscription.entity.Subscription;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,6 +95,19 @@ public class AlbumServiceImpl implements AlbumService {
         String invitationLink = invitationLinkService.createInvitationLink(invitationCode);
 
         return InvitationLinkCreateResponse.of(invitationLink);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SliceResponse<AlbumListResponse> getParticipatingAlbums(
+            Long lastAlbumId, int size, SortDirection direction) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        Slice<AlbumListResponse> results =
+                albumRepository.findAllByMemberId(
+                        currentMember.getId(), lastAlbumId, size, direction);
+
+        return SliceResponse.from(results);
     }
 
     private void validatePaymentRequirementForPlan(AlbumPlan plan, Long paymentId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/global/pagination/SliceResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/pagination/SliceResponse.java
@@ -1,0 +1,10 @@
+package org.cherrypic.global.pagination;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(List<T> content, boolean isLast) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(slice.getContent(), slice.isLast());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/global/pagination/SortDirection.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/pagination/SortDirection.java
@@ -1,0 +1,6 @@
+package org.cherrypic.global.pagination;
+
+public enum SortDirection {
+    ASC,
+    DESC
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -1,20 +1,25 @@
 package org.cherrypic.album.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
+import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -345,6 +350,117 @@ class AlbumControllerTest {
                             jsonPath("$.data.invitationLink")
                                     .value(
                                             "https://dev-api.cherrypic.today/participants/join?code=3FA7A9"));
+        }
+    }
+
+    @Nested
+    class 앨범_목록_조회_요청_시 {
+
+        @Test
+        void 정렬_조건이_ASC이면_albumId를_오름차순으로_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC),
+                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO));
+
+            given(albumService.getParticipatingAlbums(null, 2, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("size", "2").param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].albumId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_albumId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO),
+                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC));
+
+            given(albumService.getParticipatingAlbums(null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("size", "2").param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(2))
+                    .andExpect(jsonPath("$.data.content[1].albumId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC));
+
+            given(albumService.getParticipatingAlbums(null, 1, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("size", "1").param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO),
+                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC));
+
+            given(albumService.getParticipatingAlbums(null, 1, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, false));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("size", "1").param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(false));
+        }
+
+        @Test
+        void 앨범이_없는_경우_빈_리스트를_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums = List.of();
+
+            given(albumService.getParticipatingAlbums(null, 10, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("size", "10").param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content").isEmpty())
+                    .andExpect(jsonPath("$.data.isLast").value(true));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -95,14 +95,15 @@ class AlbumServiceTest extends IntegrationTest {
                 Participant participant = album.getParticipants().get(0);
 
                 Assertions.assertAll(
-                        () -> assertThat(album.getId()).isEqualTo(1L),
-                        () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
-                        () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
-                        () -> assertThat(album.getPlan()).isEqualTo(AlbumPlan.BASIC),
-                        () -> assertThat(participant.getId()).isEqualTo(1L),
-                        () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
-                        () -> assertThat(participant.getAlbum().getId()).isEqualTo(1L),
-                        () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST));
+                        () ->
+                                assertThat(album)
+                                        .extracting("id", "title", "coverUrl", "plan")
+                                        .containsExactly(
+                                                1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC),
+                        () ->
+                                assertThat(participant)
+                                        .extracting("id", "member.id", "album.id", "role")
+                                        .containsExactly(1L, 1L, 1L, ParticipantRole.HOST));
             }
 
             @Test
@@ -179,22 +180,23 @@ class AlbumServiceTest extends IntegrationTest {
                 Subscription subscription = subscriptionRepository.findById(1L).orElseThrow();
 
                 Assertions.assertAll(
-                        () -> assertThat(album.getId()).isEqualTo(2L),
-                        () -> assertThat(album.getTitle()).isEqualTo("testTitle"),
-                        () -> assertThat(album.getCoverUrl()).isEqualTo("testCoverUrl"),
-                        () -> assertThat(album.getPlan()).isEqualTo(AlbumPlan.PRO),
-                        () -> assertThat(participant.getId()).isEqualTo(1L),
-                        () -> assertThat(participant.getMember().getId()).isEqualTo(1L),
-                        () -> assertThat(participant.getAlbum().getId()).isEqualTo(2L),
-                        () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.HOST),
-                        () -> assertThat(payment.getAlbum().getId()).isEqualTo(2L),
-                        () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID),
-                        () -> assertThat(subscription.getId()).isEqualTo(1L),
-                        () -> assertThat(subscription.getMember().getId()).isEqualTo(1L),
-                        () -> assertThat(subscription.getAlbum().getId()).isEqualTo(2L),
                         () ->
-                                assertThat(subscription.getStatus())
-                                        .isEqualTo(SubscriptionStatus.ACTIVE),
+                                assertThat(album)
+                                        .extracting("id", "title", "coverUrl", "plan")
+                                        .containsExactly(
+                                                2L, "testTitle", "testCoverUrl", AlbumPlan.PRO),
+                        () ->
+                                assertThat(participant)
+                                        .extracting("id", "member.id", "album.id", "role")
+                                        .containsExactly(1L, 1L, 2L, ParticipantRole.HOST),
+                        () ->
+                                assertThat(payment)
+                                        .extracting("album.id", "status")
+                                        .containsExactly(2L, PaymentStatus.PAID),
+                        () ->
+                                assertThat(subscription)
+                                        .extracting("id", "member.id", "album.id", "status")
+                                        .containsExactly(1L, 1L, 2L, SubscriptionStatus.ACTIVE),
                         () ->
                                 assertThat(
                                                 subscription

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -503,8 +503,8 @@ class AlbumServiceTest extends IntegrationTest {
         private void createTestAlbums() {
             Member member = memberRepository.findById(1L).get();
 
-            Album album1 = Album.createAlbum("first", "url1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("second", "url2", AlbumPlan.PRO);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.PRO);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -1,9 +1,8 @@
 package org.cherrypic.album.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -15,6 +14,7 @@ import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
@@ -26,6 +26,8 @@ import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
@@ -400,6 +402,114 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.createInvitationLink(3L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 앨범_목록을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+
+            given(memberUtil.getCurrentMember()).willReturn(member);
+        }
+
+        @Test
+        void 정렬_조건이_ASC이면_albumId를_오름차순으로_조회한다() {
+            // given
+            createTestAlbums();
+
+            // when
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbums(null, 2, SortDirection.ASC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content())
+                                    .extracting("albumId")
+                                    .containsExactly(1L, 2L),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_albumId를_내림차순으로_조회한다() {
+            // given
+            createTestAlbums();
+
+            // when
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbums(null, 2, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content())
+                                    .extracting("albumId")
+                                    .containsExactly(2L, 1L),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_반환한다() {
+            // given
+            createTestAlbums();
+
+            // when
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbums(null, 2, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(2),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
+            // given
+            createTestAlbums();
+
+            // when
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbums(null, 1, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(1),
+                    () -> assertThat(response.isLast()).isFalse());
+        }
+
+        @Test
+        void 앨범이_없는_경우_빈_리스트를_조회한다() {
+            // when
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbums(null, 10, SortDirection.DESC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isZero(),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        private void createTestAlbums() {
+            Member member = memberRepository.findById(1L).get();
+
+            Album album1 = Album.createAlbum("first", "url1", AlbumPlan.BASIC);
+            Album album2 = Album.createAlbum("second", "url2", AlbumPlan.PRO);
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2));
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #70 

---
## 📌 작업 내용 및 특이사항
* 회원이 참여 중인 앨범 목록을 조회하는 API를 추가했습니다.
* AlbumRepositoryImpl에 QueryDSL 기반 커스텀 쿼리를 작성했습니다.
* 커서 기반 페이지네이션을 적용하여 lastAlbumId를 기준으로 다음 페이지 조회가 가능합니다.
* 정렬 방향(오래된 순 / 최신 순) 설정을 위해 SortDirection enum을 도입했으며, 기본값은 최신순(DESC)입니다.
* 응답은 SliceResponse<T>로 감싸 필요한 정보만 클라이언트에 전달되도록 구성했습니다.