### PR TITLE
feat: 이벤트 삭제 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ sonarqube {
         property 'sonar.sourceEncoding', 'UTF-8'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/** ,**/*Application*.java , **/*Config*.java,' +
-                '**/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java'
+                '**/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java,**/*EventImage*.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -40,6 +40,6 @@ public class EventController {
     @Operation(summary = "이벤트 삭제", description = "기존 이벤트를 삭제합니다.")
     public ResponseEntity<Void> eventDelete(@PathVariable Long eventId) {
         eventService.deleteEvent(eventId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -35,4 +35,11 @@ public class EventController {
             @PathVariable Long eventId, @Valid @RequestBody EventUpdateRequest request) {
         return eventService.updateEvent(eventId, request);
     }
+
+    @DeleteMapping("/{eventId}")
+    @Operation(summary = "이벤트 삭제", description = "기존 이벤트를 삭제합니다.")
+    public ResponseEntity<Void> eventDelete(@PathVariable Long eventId) {
+        eventService.deleteEvent(eventId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventImageRepository.java
@@ -3,4 +3,6 @@ package org.cherrypic.domain.event.repository;
 import org.cherrypic.event.entity.EventImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventImageRepository extends JpaRepository<EventImage, Long> {}
+public interface EventImageRepository extends JpaRepository<EventImage, Long> {
+    long countByEventId(Long eventId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
@@ -9,4 +9,6 @@ public interface EventService {
     EventCreateResponse createEvent(EventCreateRequest request);
 
     EventUpdateResponse updateEvent(Long eventId, EventUpdateRequest request);
+
+    void deleteEvent(Long eventId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -59,7 +59,11 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public void deleteEvent(Long eventId) {
-        Event event = getEventById(eventId);
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Event event = getEventById(eventId);
+
+        validateParticipantAuthority(currentMember, event.getAlbum());
+
         eventRepository.delete(event);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -57,6 +57,12 @@ public class EventServiceImpl implements EventService {
         return EventUpdateResponse.from(event);
     }
 
+    @Override
+    public void deleteEvent(Long eventId) {
+        Event event = getEventById(eventId);
+        eventRepository.delete(event);
+    }
+
     private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -7,11 +7,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.controller.EventController;
 import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventCreateResponse;
 import org.cherrypic.domain.event.dto.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.EventUpdateResponse;
+import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.service.EventService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -124,6 +126,50 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("이벤트 이름은 최대 20자까지 가능합니다."));
         }
+
+        @Test
+        void 요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+
+            given(eventService.createEvent(request))
+                    .willThrow(new EventException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 요청자가_LIMITED_권한을_가지는_경우_예외가_발생한다() throws Exception {
+            // given
+            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+
+            given(eventService.createEvent(request))
+                    .willThrow(new EventException(AlbumErrorCode.LIMITED_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
     }
 
     @Nested
@@ -194,6 +240,50 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("이벤트 이름은 최대 20자까지 가능합니다."));
+        }
+
+        @Test
+        void 요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+
+            given(eventService.createEvent(request))
+                    .willThrow(new EventException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 요청자가_LIMITED_권한을_가지는_경우_예외가_발생한다() throws Exception {
+            // given
+            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+
+            given(eventService.createEvent(request))
+                    .willThrow(new EventException(AlbumErrorCode.LIMITED_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -243,6 +243,29 @@ public class EventControllerTest {
         }
 
         @Test
+        void 이벤트가_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
+
+            given(eventService.updateEvent(1L, request))
+                    .willThrow(new EventException(EventErrorCode.EVENT_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
+        }
+
+        @Test
         void 요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
             EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -322,6 +322,44 @@ public class EventControllerTest {
                         .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
                         .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
             }
+
+            @Test
+            void 요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+                // given
+                willThrow(new EventException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                        .given(eventService)
+                        .deleteEvent(1L);
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+
+                perform.andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                        .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                        .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+            }
+
+            @Test
+            void 요청자가_LIMITED_권한을_가지는_경우_예외가_발생한다() throws Exception {
+                // given
+                willThrow(new EventException(AlbumErrorCode.LIMITED_AUTHORITY))
+                        .given(eventService)
+                        .deleteEvent(1L);
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+
+                perform.andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                        .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                        .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+            }
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -1,8 +1,7 @@
 package org.cherrypic.event.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -13,6 +12,7 @@ import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventCreateResponse;
 import org.cherrypic.domain.event.dto.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.EventUpdateResponse;
+import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.service.EventService;
 import org.junit.jupiter.api.Nested;
@@ -284,6 +284,44 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                     .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
                     .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Nested
+        class 이벤트_삭제_요청_시 {
+
+            @Test
+            void 유효한_요청이면_이벤트를_삭제하고_NO_CONTENT_로_반환한다() throws Exception {
+                // given
+                willDoNothing().given(eventService).deleteEvent(1L);
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+
+                perform.andExpect(status().isNoContent())
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+            }
+
+            @Test
+            void 이벤트가_존재하지_않는_경우_예외가_발생한다() throws Exception {
+                // given
+                willThrow(new EventException(EventErrorCode.EVENT_NOT_FOUND))
+                        .given(eventService)
+                        .deleteEvent(1L);
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+
+                perform.andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                        .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
+                        .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
+            }
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -286,7 +286,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 존재하지_않는_이벤트를_삭제_하면_예외가_발생한다() {
+        void 존재하지_않는_이벤트를_삭제하면_예외가_발생한다() {
             // given
             Long nonExistingEventId = 999L;
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -1,9 +1,9 @@
 package org.cherrypic.event.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
@@ -14,12 +14,17 @@ import org.cherrypic.domain.event.dto.EventCreateRequest;
 import org.cherrypic.domain.event.dto.EventUpdateRequest;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
+import org.cherrypic.domain.event.repository.EventImageRepository;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.event.service.EventService;
+import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.TransactionUtil;
+import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.participant.entity.Participant;
@@ -33,12 +38,16 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class EventServiceTest extends IntegrationTest {
 
+    @Autowired private TransactionUtil transactionUtil;
+
     @Autowired private EventService eventService;
 
     @Autowired private EventRepository eventRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private ParticipantRepository participantRepository;
+    @Autowired private ImageRepository imageRepository;
+    @Autowired private EventImageRepository eventImageRepository;
 
     @MockitoBean MemberUtil memberUtil;
 
@@ -178,7 +187,7 @@ public class EventServiceTest extends IntegrationTest {
             EventUpdateRequest request =
                     new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
 
-            // when % then
+            // when & then
             assertThatThrownBy(() -> eventService.updateEvent(999L, request))
                     .isInstanceOf(EventException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
@@ -236,7 +245,8 @@ public class EventServiceTest extends IntegrationTest {
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
-            albumRepository.save(album1);
+            Album album2 = Album.createAlbum("testAlbum2", "testURl2", AlbumPlan.BASIC);
+            albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
@@ -244,8 +254,79 @@ public class EventServiceTest extends IntegrationTest {
                     Participant.createParticipant(member2, album1, ParticipantRole.LIMITED);
             participantRepository.saveAll(List.of(participant1, participant2));
 
-            Event event = Event.createEvent(album1, "testEvent", "testEventCoverUrl");
-            eventRepository.save(event);
+            Event event1 = Event.createEvent(album1, "testEvent1", "testEventCoverUrl1");
+            Event event2 = Event.createEvent(album2, "testEvent2", "testEventCoverUrl2");
+            eventRepository.saveAll(List.of(event1, event2));
+
+            Image image1 = Image.createImage(album1, 1L, "testImageUrl1", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, 1L, "testImageUrl2", LocalDateTime.now());
+            Image image3 = Image.createImage(album1, 1L, "testImageUrl3", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3));
+
+            EventImage eventImage1 = EventImage.createEventImage(event1, image1);
+            EventImage eventImage2 = EventImage.createEventImage(event1, image2);
+            EventImage eventImage3 = EventImage.createEventImage(event1, image3);
+            eventImageRepository.saveAll(List.of(eventImage1, eventImage2, eventImage3));
+        }
+
+        @Test
+        void 유효한_요청일_경우_이벤트와_이벤트_이미지를_모두_삭제한다() {
+            // given
+            Event event =
+                    transactionUtil.getResult(
+                            () -> {
+                                Event loadedEvent = eventRepository.findById(1L).orElseThrow();
+                                loadedEvent.getEventImages().get(0);
+                                return loadedEvent;
+                            });
+
+            assertThat(event.getEventImages())
+                    .hasSize(3)
+                    .extracting("id", "event.id", "image.id")
+                    .containsExactlyInAnyOrder(
+                            tuple(1L, 1L, 1L), tuple(2L, 1L, 2L), tuple(3L, 1L, 3L));
+
+            // when
+            eventService.deleteEvent(1L);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(eventRepository.findById(1L).isPresent()).isFalse(),
+                    () -> assertThat(eventImageRepository.countByEventId(1L)).isEqualTo(0L));
+        }
+
+        @Test
+        void 존재하지_않는_이벤트를_삭제_하면_예외가_발생한다() {
+            // given
+            Long nonExistingEventId = 999L;
+
+            // when & then
+            assertThatThrownBy(() -> eventService.deleteEvent(nonExistingEventId))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_이벤트를_삭제하면_예외가_발생한다() {
+            // given
+            Long notParticipatingEventId = 2L;
+
+            // when & then
+            assertThatThrownBy(() -> eventService.deleteEvent(notParticipatingEventId))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_이벤트를_수정하면_예외가_발생한다() {
+            // given
+            Member limitedMember = memberRepository.findById(2L).orElseThrow();
+            given(memberUtil.getCurrentMember()).willReturn(limitedMember);
+
+            // when & then
+            assertThatThrownBy(() -> eventService.deleteEvent(1L))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -90,11 +90,9 @@ public class EventServiceTest extends IntegrationTest {
 
             // then
             Event event = eventRepository.findById(1L).orElseThrow();
-            Assertions.assertAll(
-                    () -> assertThat(event.getId()).isEqualTo(1L),
-                    () -> assertThat(event.getAlbum().getId()).isEqualTo(1L),
-                    () -> assertThat(event.getTitle()).isEqualTo("testEvent"),
-                    () -> assertThat(event.getCoverUrl()).isEqualTo("testCoverUrl"));
+            assertThat(event)
+                    .extracting("id", "album.id", "title", "coverUrl")
+                    .containsExactly(1L, 1L, "testEvent", "testCoverUrl");
         }
 
         @Test
@@ -174,11 +172,9 @@ public class EventServiceTest extends IntegrationTest {
 
             // then
             Event event = eventRepository.findById(1L).orElseThrow();
-            Assertions.assertAll(
-                    () -> assertThat(event.getId()).isEqualTo(1L),
-                    () -> assertThat(event.getAlbum().getId()).isEqualTo(1L),
-                    () -> assertThat(event.getTitle()).isEqualTo("changedTestEventTitle"),
-                    () -> assertThat(event.getCoverUrl()).isEqualTo("changedTestEventCoverUrl"));
+            assertThat(event)
+                    .extracting("id", "album.id", "title", "coverUrl")
+                    .containsExactly(1L, 1L, "changedTestEventTitle", "changedTestEventCoverUrl");
         }
 
         @Test
@@ -283,8 +279,7 @@ public class EventServiceTest extends IntegrationTest {
             assertThat(event.getEventImages())
                     .hasSize(3)
                     .extracting("id", "event.id", "image.id")
-                    .containsExactlyInAnyOrder(
-                            tuple(1L, 1L, 1L), tuple(2L, 1L, 2L), tuple(3L, 1L, 3L));
+                    .containsExactly(tuple(1L, 1L, 1L), tuple(2L, 1L, 2L), tuple(3L, 1L, 3L));
 
             // when
             eventService.deleteEvent(1L);

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -232,12 +232,7 @@ public class EventServiceTest extends IntegrationTest {
                             OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
                             "testNickname2",
                             "testProfileImageUrl2");
-            Member member3 =
-                    Member.createMember(
-                            OauthInfo.createOauthInfo("testOauthId3", "testOauthProvider3"),
-                            "testNickname3",
-                            "testProfileImageUrl3");
-            memberRepository.saveAll(List.of(member1, member2, member3));
+            memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
@@ -303,11 +298,8 @@ public class EventServiceTest extends IntegrationTest {
 
         @Test
         void 앨범에_속하지_않은_사용자가_이벤트를_삭제하면_예외가_발생한다() {
-            // given
-            Long notParticipatingEventId = 2L;
-
             // when & then
-            assertThatThrownBy(() -> eventService.deleteEvent(notParticipatingEventId))
+            assertThatThrownBy(() -> eventService.deleteEvent(2L))
                     .isInstanceOf(EventException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -287,11 +287,8 @@ public class EventServiceTest extends IntegrationTest {
 
         @Test
         void 존재하지_않는_이벤트를_삭제하면_예외가_발생한다() {
-            // given
-            Long nonExistingEventId = 999L;
-
             // when & then
-            assertThatThrownBy(() -> eventService.deleteEvent(nonExistingEventId))
+            assertThatThrownBy(() -> eventService.deleteEvent(999L))
                     .isInstanceOf(EventException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -211,4 +211,41 @@ public class EventServiceTest extends IntegrationTest {
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
     }
+
+    @Nested
+    class 이벤트를_삭제할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            Member member3 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId3", "testOauthProvider3"),
+                            "testNickname3",
+                            "testProfileImageUrl3");
+            memberRepository.saveAll(List.of(member1, member2, member3));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
+            albumRepository.save(album1);
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+
+            Event event = Event.createEvent(album1, "testEvent", "testEventCoverUrl");
+            eventRepository.save(event);
+        }
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/Event.java
@@ -31,7 +31,7 @@ public class Event extends BaseTimeEntity {
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventImage> eventImages = new ArrayList<>();
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Event(Album album, String title, String coverUrl) {
         this.album = album;
         this.title = title;

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
@@ -2,6 +2,7 @@ package org.cherrypic.event.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.common.model.BaseTimeEntity;
@@ -23,4 +24,14 @@ public class EventImage extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
     private Image image;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private EventImage(Event event, Image image) {
+        this.event = event;
+        this.image = image;
+    }
+
+    public static EventImage createEventImage(Event event, Image image) {
+        return EventImage.builder().event(event).image(image).build();
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -30,26 +30,26 @@ public class Image extends BaseTimeEntity {
 
     @NotNull private String url;
 
-    private LocalDateTime imageFileCreatedAt;
+    private LocalDateTime generatedAt;
 
     @OneToMany(mappedBy = "image", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventImage> eventImages = new ArrayList<>();
 
     @Builder
-    private Image(Album album, Long memberId, String url, LocalDateTime imageFileCreatedAt) {
+    private Image(Album album, Long memberId, String url, LocalDateTime generatedAt) {
         this.album = album;
         this.memberId = memberId;
         this.url = url;
-        this.imageFileCreatedAt = imageFileCreatedAt;
+        this.generatedAt = generatedAt;
     }
 
     public static Image createImage(
-            Album album, Long memberId, String url, LocalDateTime imageFileCreatedAt) {
+            Album album, Long memberId, String url, LocalDateTime generatedAt) {
         return Image.builder()
                 .album(album)
                 .memberId(memberId)
                 .url(url)
-                .imageFileCreatedAt(imageFileCreatedAt)
+                .generatedAt(generatedAt)
                 .build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
@@ -33,4 +34,22 @@ public class Image extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "image", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventImage> eventImages = new ArrayList<>();
+
+    @Builder
+    private Image(Album album, Long memberId, String url, LocalDateTime imageFileCreatedAt) {
+        this.album = album;
+        this.memberId = memberId;
+        this.url = url;
+        this.imageFileCreatedAt = imageFileCreatedAt;
+    }
+
+    public static Image createImage(
+            Album album, Long memberId, String url, LocalDateTime imageFileCreatedAt) {
+        return Image.builder()
+                .album(album)
+                .memberId(memberId)
+                .url(url)
+                .imageFileCreatedAt(imageFileCreatedAt)
+                .build();
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #75 

---
## 📌 작업 내용 및 특이사항
- 이벤트 삭제 기능을 구현했습니다.
- 검증 사항은 생성, 수정과 동일합니다.
- Void로 설계하고 204(NO_CONTENT)를 반환하도록 했습니다.

---
## 📚 참고사항
<img width="641" height="104" alt="스크린샷 2025-07-31 오전 1 55 33" src="https://github.com/user-attachments/assets/981a3aa2-e85f-4721-8be3-79a1658724ca" />

- Void 메서드의 경우 given -> willThrow가 불가능해서 반대로 구현되어 있습니다.