### PR TITLE
feat: 앨범 수정 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -6,8 +6,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.global.pagination.SliceResponse;
@@ -30,6 +32,13 @@ public class AlbumController {
             @Valid @RequestBody AlbumCreateRequest request) {
         AlbumCreateResponse response = albumService.createAlbum(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{albumId}")
+    @Operation(summary = "앨범 수정", description = "앨범의 이름과 커버를 수정합니다.")
+    public AlbumUpdateResponse albumUpdate(
+            @PathVariable Long albumId, @Valid @RequestBody AlbumUpdateRequest request) {
+        return albumService.updateAlbum(albumId, request);
     }
 
     @PostMapping("/{albumId}/invitation-link")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumUpdateRequest.java
@@ -1,0 +1,12 @@
+package org.cherrypic.domain.album.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AlbumUpdateRequest(
+        @NotBlank(message = "앨범 이름은 비워둘 수 없습니다.")
+                @Schema(description = "앨범 이름", example = "연인 앨범")
+                @Size(max = 20, message = "앨범 이름은 최대 20자까지 가능합니다.")
+                String title,
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumUpdateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumUpdateResponse.java
@@ -1,0 +1,16 @@
+package org.cherrypic.domain.album.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+
+public record AlbumUpdateResponse(
+        @Schema(description = "앨범 ID", example = "1") Long albumId,
+        @Schema(description = "앨범 이름", example = "연인 앨범") String title,
+        @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
+        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan) {
+    public static AlbumUpdateResponse from(Album album) {
+        return new AlbumUpdateResponse(
+                album.getId(), album.getTitle(), album.getCoverUrl(), album.getPlan());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -8,7 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum AlbumErrorCode implements BaseErrorCode {
     ALBUM_NOT_FOUND(404, "앨범이 존재하지 않습니다."),
-    NOT_ALBUM_HOST(403, "HOST가 아닌 경우 앨범 초대 링크를 생성할 권한이 없습니다."),
+    NOT_ALBUM_HOST(403, "방장이 아닌 경우 권한이 없습니다."),
     NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다."),
     LIMITED_AUTHORITY(403, "앨범에 대한 생성/수정 권한이 없습니다."),
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -1,14 +1,18 @@
 package org.cherrypic.domain.album.service;
 
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 
 public interface AlbumService {
     AlbumCreateResponse createAlbum(AlbumCreateRequest request);
+
+    AlbumUpdateResponse updateAlbum(Long albumId, AlbumUpdateRequest request);
 
     InvitationLinkCreateResponse createInvitationLink(Long albumId);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -79,7 +79,7 @@ public class AlbumServiceImpl implements AlbumService {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumById(albumId);
 
-        validateInvitationAuthority(currentMember.getId(), album.getId());
+        validateAlbumHost(currentMember.getId(), album.getId());
 
         InvitationCode invitationCode =
                 invitationCodeRepository
@@ -108,6 +108,26 @@ public class AlbumServiceImpl implements AlbumService {
                         currentMember.getId(), lastAlbumId, size, direction);
 
         return SliceResponse.from(results);
+    }
+
+    private Album getAlbumById(Long albumId) {
+        return albumRepository
+                .findById(albumId)
+                .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+
+    private Participant getParticipantByMemberIdAndAlbumId(Long memberId, Long albumId) {
+        return participantRepository
+                .findByMemberIdAndAlbumId(memberId, albumId)
+                .orElseThrow(() -> new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
+    private void validateAlbumHost(Long memberId, Long albumId) {
+        Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
+
+        if (!participant.getRole().equals(ParticipantRole.HOST)) {
+            throw new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST);
+        }
     }
 
     private void validatePaymentRequirementForPlan(AlbumPlan plan, Long paymentId) {
@@ -142,25 +162,5 @@ public class AlbumServiceImpl implements AlbumService {
         return paymentRepository
                 .findById(paymentId)
                 .orElseThrow(() -> new AlbumException(PaymentErrorCode.PAYMENT_NOT_FOUND));
-    }
-
-    private void validateInvitationAuthority(Long memberId, Long albumId) {
-        Participant participant =
-                participantRepository
-                        .findByMemberIdAndAlbumId(memberId, albumId)
-                        .orElseThrow(
-                                () -> new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
-
-        boolean isHost = participant.getRole().equals(ParticipantRole.HOST);
-
-        if (!isHost) {
-            throw new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST);
-        }
-    }
-
-    private Album getAlbumById(Long albumId) {
-        return albumRepository
-                .findById(albumId)
-                .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -5,8 +5,10 @@ import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
@@ -72,6 +74,18 @@ public class AlbumServiceImpl implements AlbumService {
         albumRepository.save(album);
 
         return AlbumCreateResponse.from(album);
+    }
+
+    @Override
+    public AlbumUpdateResponse updateAlbum(Long albumId, AlbumUpdateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateAlbumHost(currentMember.getId(), album.getId());
+
+        album.updateAlbum(request.title(), request.coverUrl());
+
+        return AlbumUpdateResponse.from(album);
     }
 
     @Override

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -2,6 +2,7 @@ package org.cherrypic.album.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -11,8 +12,10 @@ import java.util.List;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
@@ -319,6 +322,144 @@ class AlbumControllerTest {
                     .andExpect(
                             jsonPath("$.data.message")
                                     .value("앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다."));
+        }
+    }
+
+    @Nested
+    class 앨범_수정_요청_시 {
+
+        @Test
+        void 유효한_요청이면_앨범_수정_정보를_반환한다() throws Exception {
+            // given
+            AlbumUpdateRequest request =
+                    new AlbumUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
+
+            AlbumUpdateResponse response =
+                    new AlbumUpdateResponse(
+                            1L, "testUpdatedTitle", "testUpdatedCoverUrl", AlbumPlan.BASIC);
+
+            given(albumService.updateAlbum(1L, request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.albumId").value(1))
+                    .andExpect(jsonPath("$.data.title").value("testUpdatedTitle"))
+                    .andExpect(jsonPath("$.data.coverUrl").value("testUpdatedCoverUrl"));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            given(albumService.updateAlbum(1L, request))
+                    .willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            given(albumService.updateAlbum(1L, request))
+                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            given(albumService.updateAlbum(1L, request))
+                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 앨범_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest(title, "testCoverUrl");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("앨범 이름은 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 앨범_이름이_20자를_초과하면_예외가_발생한다() throws Exception {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("t".repeat(21), "testCoverUrl");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("앨범 이름은 최대 20자까지 가능합니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -14,6 +14,7 @@ import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
+import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -285,6 +286,87 @@ class AlbumServiceTest extends IntegrationTest {
                         .isInstanceOf(AlbumException.class)
                         .hasMessage(PaymentErrorCode.ALREADY_USED_PAYMENT.getMessage());
             }
+        }
+    }
+
+    @Nested
+    class 앨범을_수정할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @Test
+        void 유효한_요청이면_앨범이_수정된다() {
+            // given
+            AlbumUpdateRequest request =
+                    new AlbumUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
+
+            // when
+            albumService.updateAlbum(1L, request);
+
+            // then
+            Album album = albumRepository.findById(1L).get();
+            Assertions.assertAll(
+                    () ->
+                            assertThat(album)
+                                    .extracting("id", "title", "coverUrl", "plan")
+                                    .containsExactly(
+                                            1L,
+                                            "testUpdatedTitle",
+                                            "testUpdatedCoverUrl",
+                                            AlbumPlan.BASIC));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> albumService.updateAlbum(999L, request))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> albumService.updateAlbum(3L, request))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> albumService.updateAlbum(2L, request))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
     }
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -65,4 +65,9 @@ public class Album extends BaseTimeEntity {
     public void addParticipant(Participant participant) {
         participants.add(participant);
     }
+
+    public void updateAlbum(String title, String coverUrl) {
+        this.title = title;
+        this.coverUrl = coverUrl;
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #77 

---
## 📌 작업 내용 및 특이사항
* 앨범 제목 및 커버 URL 수정 API를 구현했습니다.
* 방장(호스트) 권한 검증 로직을 공통 메서드로 리팩토링했습니다.
* 구독 플랜 변경 API는 별도 구현 예정입니다.