### PR TITLE
refactor: 초대 코드 발급 및 테스트 코드 리팩토링

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
@@ -6,7 +6,7 @@ public record InvitationLinkCreateResponse(
         @Schema(
                         description = "엘범 초대 딥링크",
                         example =
-                                "https://dev-api.cherrypic.today/participants/join?albumId=1&code=3FA7A9")
+                                "https://dev-api.cherrypic.today/albums/join?albumId=1&code=3FA7A9")
                 String invitationLink) {
 
     public static InvitationLinkCreateResponse of(String invitationCode) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/InvitationLinkCreateResponse.java
@@ -5,7 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record InvitationLinkCreateResponse(
         @Schema(
                         description = "엘범 초대 딥링크",
-                        example = "https://dev-api.cherrypic.today/participants/join?code=3FA7A9")
+                        example =
+                                "https://dev-api.cherrypic.today/participants/join?albumId=1&code=3FA7A9")
                 String invitationLink) {
 
     public static InvitationLinkCreateResponse of(String invitationCode) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class InvitationLinkService {
 
     private static final String INVITATION_LINK_PREFIX =
-            "https://dev-api.cherrypic.today/participants/join?albumId=%d&code=%s";
+            "https://dev-api.cherrypic.today/albums/join?albumId=%d&code=%s";
     private static final int INVITATION_LINK_DURATION = 30;
     private static final int UUID_LENGTH = 8;
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class InvitationLinkService {
 
     private static final String INVITATION_LINK_PREFIX =
-            "https://dev-api.cherrypic.today/participants/join?code=";
+            "https://dev-api.cherrypic.today/participants/join?albumId=%d&code=%s";
     private static final int INVITATION_LINK_DURATION = 30;
     private static final int UUID_LENGTH = 8;
 
@@ -22,6 +22,7 @@ public class InvitationLinkService {
     }
 
     public String createInvitationLink(InvitationCode invitationCode) {
-        return INVITATION_LINK_PREFIX + invitationCode.getCode();
+        return String.format(
+                INVITATION_LINK_PREFIX, invitationCode.getAlbumId(), invitationCode.getCode());
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -494,26 +494,26 @@ class AlbumControllerTest {
         }
 
         @Test
-        void 현재_유저가_HOST가_아닌_경우_예외가_발생한다() throws Exception {
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
             // given
-            given(albumService.createInvitationLink(1L))
-                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST));
+            given(albumService.createInvitationLink(999L))
+                    .willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/invitation-link")
+                            post("/albums/999/invitation-link")
                                     .contentType(MediaType.APPLICATION_JSON));
 
-            perform.andExpect(status().isForbidden())
+            perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
-                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
         }
 
         @Test
-        void 현재_유저가_앨범_소속이_아닌_경우_예외가_발생한다() throws Exception {
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
             given(albumService.createInvitationLink(1L))
                     .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
@@ -532,22 +532,22 @@ class AlbumControllerTest {
         }
 
         @Test
-        void 존재하지_않는_앨범_ID_를_입력한_경우_예외가_발생한다() throws Exception {
+        void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            given(albumService.createInvitationLink(999L))
-                    .willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+            given(albumService.createInvitationLink(1L))
+                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/999/invitation-link")
+                            post("/albums/1/invitation-link")
                                     .contentType(MediaType.APPLICATION_JSON));
 
-            perform.andExpect(status().isNotFound())
+            perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -473,7 +473,7 @@ class AlbumControllerTest {
 
             InvitationLinkCreateResponse response =
                     new InvitationLinkCreateResponse(
-                            "https://dev-api.cherrypic.today/participants/join?albumId=1&code=3FA7A9");
+                            "https://dev-api.cherrypic.today/albums/join?albumId=1&code=3FA7A9");
 
             given(albumService.createInvitationLink(albumId)).willReturn(response);
 
@@ -490,7 +490,7 @@ class AlbumControllerTest {
                     .andExpect(
                             jsonPath("$.data.invitationLink")
                                     .value(
-                                            "https://dev-api.cherrypic.today/participants/join?albumId=1&code=3FA7A9"));
+                                            "https://dev-api.cherrypic.today/albums/join?albumId=1&code=3FA7A9"));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -473,7 +473,7 @@ class AlbumControllerTest {
 
             InvitationLinkCreateResponse response =
                     new InvitationLinkCreateResponse(
-                            "https://dev-api.cherrypic.today/participants/join?code=3FA7A9");
+                            "https://dev-api.cherrypic.today/participants/join?albumId=1&code=3FA7A9");
 
             given(albumService.createInvitationLink(albumId)).willReturn(response);
 
@@ -490,7 +490,64 @@ class AlbumControllerTest {
                     .andExpect(
                             jsonPath("$.data.invitationLink")
                                     .value(
-                                            "https://dev-api.cherrypic.today/participants/join?code=3FA7A9"));
+                                            "https://dev-api.cherrypic.today/participants/join?albumId=1&code=3FA7A9"));
+        }
+
+        @Test
+        void 현재_유저가_HOST가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.createInvitationLink(1L))
+                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/invitation-link")
+                                    .contentType(MediaType.APPLICATION_JSON));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void 현재_유저가_앨범_소속이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.createInvitationLink(1L))
+                    .willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/invitation-link")
+                                    .contentType(MediaType.APPLICATION_JSON));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 존재하지_않는_앨범_ID_를_입력한_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.createInvitationLink(999L))
+                    .willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/999/invitation-link")
+                                    .contentType(MediaType.APPLICATION_JSON));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -454,18 +454,18 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 현재_유저가_HOST가_아닌_경우_예외가_발생한다() {
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
 
             // when & then
-            assertThatThrownBy(() -> albumService.createInvitationLink(2L))
+            assertThatThrownBy(() -> albumService.createInvitationLink(3L))
                     .isInstanceOf(AlbumException.class)
-                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
 
         @Test
-        void 현재_유저가_앨범_소속이_아닌_경우_예외가_발생한다() {
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
 
@@ -476,14 +476,14 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 존재하지_않는_앨범_ID_를_입력한_경우_예외가_발생한다() {
+        void 앨범_방장이_아닌_경우_예외가_발생한다() {
             // given
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
 
             // when & then
-            assertThatThrownBy(() -> albumService.createInvitationLink(3L))
+            assertThatThrownBy(() -> albumService.createInvitationLink(2L))
                     .isInstanceOf(AlbumException.class)
-                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
 
         private Map<String, String> parseParameter(String str) {

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -417,9 +417,8 @@ class AlbumServiceTest extends IntegrationTest {
             String link = response.invitationLink();
             Map<String, String> parameters = parseParameter(link);
 
-            Assertions.assertAll(
-                    () -> assertThat(Integer.parseInt(parameters.get("albumId"))).isEqualTo(1L),
-                    () -> assertThat(parameters.get("code")).isEqualTo(savedCode.getCode()));
+            assertThat(parameters)
+                    .containsOnly(entry("albumId", "1"), entry("code", savedCode.getCode()));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -6,7 +6,9 @@ import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
@@ -386,6 +388,7 @@ class AlbumServiceTest extends IntegrationTest {
                             "testNickname2",
                             "testProfileImageUrl2");
             memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
@@ -405,9 +408,6 @@ class AlbumServiceTest extends IntegrationTest {
 
         @Test
         void 유효한_요청이면_초대_코드를_저장하며_초대_링크가_반환된다() {
-            // given
-            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
-
             // when
             InvitationLinkCreateResponse response = albumService.createInvitationLink(1L);
 
@@ -415,15 +415,16 @@ class AlbumServiceTest extends IntegrationTest {
             InvitationCode savedCode = invitationCodeRepository.findById(1L).orElseThrow();
 
             String link = response.invitationLink();
-            String codeInLink = link.substring(link.lastIndexOf("=") + 1);
+            Map<String, String> parameters = parseParameter(link);
 
-            assertThat(codeInLink).isEqualTo(savedCode.getCode());
+            Assertions.assertAll(
+                    () -> assertThat(Integer.parseInt(parameters.get("albumId"))).isEqualTo(1L),
+                    () -> assertThat(parameters.get("code")).isEqualTo(savedCode.getCode()));
         }
 
         @Test
         void 유효한_초대_코드가_이미_존재하는_경우_갱신하지_않는다() {
             // given
-            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
             InvitationCode invitationCode =
                     InvitationCode.builder().albumId(1L).code("testInvitationCode").build();
             invitationCodeRepository.save(invitationCode);
@@ -441,9 +442,6 @@ class AlbumServiceTest extends IntegrationTest {
 
         @Test
         void 유효한_요청에_대해서_유효한_초대코드가_생성된다() {
-            // given
-            given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(1L).get());
-
             // when
             albumService.createInvitationLink(1L);
 
@@ -486,6 +484,21 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.createInvitationLink(3L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        private Map<String, String> parseParameter(String str) {
+            Map<String, String> result = new HashMap<>();
+
+            String query = str.substring(str.indexOf('?') + 1);
+
+            String[] params = query.split("&");
+
+            for (String param : params) {
+                String[] kv = param.split("=", 2); // "key=value"
+                result.put(kv[0], kv[1]);
+            }
+
+            return result;
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -6,9 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
@@ -415,10 +413,8 @@ class AlbumServiceTest extends IntegrationTest {
             InvitationCode savedCode = invitationCodeRepository.findById(1L).orElseThrow();
 
             String link = response.invitationLink();
-            Map<String, String> parameters = parseParameter(link);
-
-            assertThat(parameters)
-                    .containsOnly(entry("albumId", "1"), entry("code", savedCode.getCode()));
+            assertThat(link)
+                    .containsPattern(String.format(".*albumId=%d&code=%s", 1, savedCode.getCode()));
         }
 
         @Test
@@ -446,10 +442,9 @@ class AlbumServiceTest extends IntegrationTest {
 
             // then
             InvitationCode createdCode = invitationCodeRepository.findById(1L).orElseThrow();
-            Assertions.assertAll(
-                    () -> assertThat(createdCode.getAlbumId()).isEqualTo(1L),
-                    () -> assertThat(createdCode.getCode().length()).isEqualTo(8),
-                    () -> assertThat(createdCode.getTtl()).isEqualTo(1800L));
+            assertThat(createdCode)
+                    .extracting("albumId", "code", "ttl")
+                    .containsExactly(1L, createdCode.getCode(), 1800L);
         }
 
         @Test
@@ -483,21 +478,6 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.createInvitationLink(2L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
-        }
-
-        private Map<String, String> parseParameter(String str) {
-            Map<String, String> result = new HashMap<>();
-
-            String query = str.substring(str.indexOf('?') + 1);
-
-            String[] params = query.split("&");
-
-            for (String param : params) {
-                String[] kv = param.split("=", 2); // "key=value"
-                result.put(kv[0], kv[1]);
-            }
-
-            return result;
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #85 

---
## 📌 작업 내용 및 특이사항
- 반환하는 링크 형식에 albumId를 포함했습니다.
- 서비스 로직과 관련된 테스트 코드를 추가했습니다.
- member util과 관련된 given 절을 BeforeEach로 옮겼습니다.