### PR TITLE
feat: 참가자 초대 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -7,10 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
-import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
-import org.cherrypic.domain.album.dto.response.AlbumListResponse;
-import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
-import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -46,6 +43,15 @@ public class AlbumController {
     public ResponseEntity<InvitationLinkCreateResponse> invitationLinkCreate(
             @PathVariable Long albumId) {
         InvitationLinkCreateResponse response = albumService.createInvitationLink(albumId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/{albumId}/join")
+    @Operation(summary = "앨범 입장", description = "앨범에 입장합니다.")
+    public ResponseEntity<AlbumJoinResponse> albumJoin(
+            @PathVariable Long albumId,
+            @Parameter(description = "앨범의 초대 코드") @RequestParam String code) {
+        AlbumJoinResponse response = albumService.joinAlbum(albumId, code);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumJoinResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumJoinResponse.java
@@ -1,0 +1,19 @@
+package org.cherrypic.domain.album.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+
+public record AlbumJoinResponse(
+        @Schema(description = "참가자 ID", example = "1") Long participantId,
+        @Schema(description = "앨범 ID", example = "1") Long albumId,
+        @Schema(description = "회원 ID", example = "1") Long memberId,
+        @Schema(description = "참가자 권한", example = "STANDARD") ParticipantRole role) {
+    public static AlbumJoinResponse from(Participant participant) {
+        return new AlbumJoinResponse(
+                participant.getId(),
+                participant.getAlbum().getId(),
+                participant.getMember().getId(),
+                participant.getRole());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -17,7 +17,6 @@ public enum AlbumErrorCode implements BaseErrorCode {
 
     INVITATION_CODE_OUTDATED(404, "앨범의 초대 코드가 만료되었습니다."),
     INVITATION_CODE_INVALID(400, "초대코드가 올바르지 않습니다.");
-    ;
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -15,8 +15,8 @@ public enum AlbumErrorCode implements BaseErrorCode {
     PAYMENT_REQUIRED_FOR_PAID_PLAN(400, "유료 플랜은 결제 ID가 필요합니다."),
     PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 결제 ID가 필요하지 않습니다."),
 
-    INVITATION_CODE_OUTDATED(404, "앨범의 초대 코드가 만료되었습니다."),
-    INVITATION_CODE_INVALID(400, "초대코드가 올바르지 않습니다.");
+    INVITATION_CODE_NOT_FOUND(404, "앨범의 초대 코드가 만료되었습니다."),
+    INVITATION_CODE_MISMATCH(400, "초대코드가 올바르지 않습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -16,7 +16,7 @@ public enum AlbumErrorCode implements BaseErrorCode {
     PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 결제 ID가 필요하지 않습니다."),
 
     INVITATION_CODE_NOT_FOUND(404, "앨범의 초대 코드가 만료되었습니다."),
-    INVITATION_CODE_MISMATCH(400, "초대코드가 올바르지 않습니다.");
+    INVITATION_CODE_MISMATCH(400, "초대 코드가 올바르지 않습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -14,6 +14,9 @@ public enum AlbumErrorCode implements BaseErrorCode {
 
     PAYMENT_REQUIRED_FOR_PAID_PLAN(400, "유료 플랜은 결제 ID가 필요합니다."),
     PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 결제 ID가 필요하지 않습니다."),
+
+    INVITATION_CODE_NOT_FOUND(404, "앨범의 초대 코드가 존재하지 않거나, 만료되었습니다."),
+    INVITATION_CODE_MISMATCH(400, "초대코드가 만료되었습니다.");
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -15,8 +15,8 @@ public enum AlbumErrorCode implements BaseErrorCode {
     PAYMENT_REQUIRED_FOR_PAID_PLAN(400, "유료 플랜은 결제 ID가 필요합니다."),
     PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 결제 ID가 필요하지 않습니다."),
 
-    INVITATION_CODE_NOT_FOUND(404, "앨범의 초대 코드가 존재하지 않거나, 만료되었습니다."),
-    INVITATION_CODE_MISMATCH(400, "초대코드가 만료되었습니다.");
+    INVITATION_CODE_OUTDATED(404, "앨범의 초대 코드가 만료되었습니다."),
+    INVITATION_CODE_INVALID(400, "초대코드가 올바르지 않습니다.");
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -2,10 +2,7 @@ package org.cherrypic.domain.album.service;
 
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
-import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
-import org.cherrypic.domain.album.dto.response.AlbumListResponse;
-import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
-import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 
@@ -18,4 +15,6 @@ public interface AlbumService {
 
     SliceResponse<AlbumListResponse> getParticipatingAlbums(
             Long lastAlbumId, int size, SortDirection direction);
+
+    AlbumJoinResponse joinAlbum(Long albumId, String code);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -130,10 +130,10 @@ public class AlbumServiceImpl implements AlbumService {
                 invitationCodeRepository
                         .findById(album.getId())
                         .orElseThrow(
-                                () -> new AlbumException(AlbumErrorCode.INVITATION_CODE_NOT_FOUND));
+                                () -> new AlbumException(AlbumErrorCode.INVITATION_CODE_OUTDATED));
 
         if (!currentInvitationCode.getCode().equals(code)) {
-            throw new AlbumException(AlbumErrorCode.INVITATION_CODE_MISMATCH);
+            throw new AlbumException(AlbumErrorCode.INVITATION_CODE_INVALID);
         }
 
         Participant participant =

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -132,13 +132,18 @@ public class AlbumServiceImpl implements AlbumService {
                         .orElseThrow(
                                 () -> new AlbumException(AlbumErrorCode.INVITATION_CODE_OUTDATED));
 
-        if (!currentInvitationCode.getCode().equals(code)) {
-            throw new AlbumException(AlbumErrorCode.INVITATION_CODE_INVALID);
-        }
+        validateInvitationCode(currentInvitationCode, code);
 
-        Participant participant =
-                Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
-        participantRepository.save(participant);
+        Participant participant;
+        if (album.getPlan().equals(AlbumPlan.BASIC)) {
+            participant =
+                    Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
+            participantRepository.save(participant);
+        } else {
+            participant =
+                    Participant.createParticipant(currentMember, album, ParticipantRole.LIMITED);
+            participantRepository.save(participant);
+        }
 
         return AlbumJoinResponse.from(participant);
     }
@@ -195,5 +200,11 @@ public class AlbumServiceImpl implements AlbumService {
         return paymentRepository
                 .findById(paymentId)
                 .orElseThrow(() -> new AlbumException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    private void validateInvitationCode(InvitationCode currentInvitationCode, String code) {
+        if (!currentInvitationCode.getCode().equals(code)) {
+            throw new AlbumException(AlbumErrorCode.INVITATION_CODE_INVALID);
+        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -6,10 +6,7 @@ import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
-import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
-import org.cherrypic.domain.album.dto.response.AlbumListResponse;
-import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
-import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.repository.AlbumRepository;
@@ -122,6 +119,28 @@ public class AlbumServiceImpl implements AlbumService {
                         currentMember.getId(), lastAlbumId, size, direction);
 
         return SliceResponse.from(results);
+    }
+
+    @Override
+    public AlbumJoinResponse joinAlbum(Long albumId, String code) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        InvitationCode currentInvitationCode =
+                invitationCodeRepository
+                        .findById(album.getId())
+                        .orElseThrow(
+                                () -> new AlbumException(AlbumErrorCode.INVITATION_CODE_NOT_FOUND));
+
+        if (!currentInvitationCode.getCode().equals(code)) {
+            throw new AlbumException(AlbumErrorCode.INVITATION_CODE_MISMATCH);
+        }
+
+        Participant participant =
+                Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
+        participantRepository.save(participant);
+
+        return AlbumJoinResponse.from(participant);
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -130,7 +130,7 @@ public class AlbumServiceImpl implements AlbumService {
                 invitationCodeRepository
                         .findById(album.getId())
                         .orElseThrow(
-                                () -> new AlbumException(AlbumErrorCode.INVITATION_CODE_OUTDATED));
+                                () -> new AlbumException(AlbumErrorCode.INVITATION_CODE_NOT_FOUND));
 
         validateInvitationCode(currentInvitationCode, code);
 
@@ -197,7 +197,7 @@ public class AlbumServiceImpl implements AlbumService {
 
     private void validateInvitationCode(InvitationCode currentInvitationCode, String code) {
         if (!currentInvitationCode.getCode().equals(code)) {
-            throw new AlbumException(AlbumErrorCode.INVITATION_CODE_INVALID);
+            throw new AlbumException(AlbumErrorCode.INVITATION_CODE_MISMATCH);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -134,16 +134,9 @@ public class AlbumServiceImpl implements AlbumService {
 
         validateInvitationCode(currentInvitationCode, code);
 
-        Participant participant;
-        if (album.getPlan().equals(AlbumPlan.BASIC)) {
-            participant =
-                    Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
-            participantRepository.save(participant);
-        } else {
-            participant =
-                    Participant.createParticipant(currentMember, album, ParticipantRole.LIMITED);
-            participantRepository.save(participant);
-        }
+        Participant participant =
+                Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
+        participantRepository.save(participant);
 
         return AlbumJoinResponse.from(participant);
     }

--- a/cherrypic-api/src/main/resources/static/.well-known/apple-app-site-association
+++ b/cherrypic-api/src/main/resources/static/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "ABCDE12345.com.example.myapp",
+        "paths": [ "/albums/join/*" ]
+      }
+    ]
+  }
+}

--- a/cherrypic-api/src/main/resources/static/.well-known/apple-app-site-association
+++ b/cherrypic-api/src/main/resources/static/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "ABCDE12345.com.example.myapp",
+        "appID": "appID": "V57B45UFKH.today.cherrypic.ios",
         "paths": [ "/albums/join/*" ]
       }
     ]

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -13,16 +13,14 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
-import org.cherrypic.domain.album.dto.response.AlbumCreateResponse;
-import org.cherrypic.domain.album.dto.response.AlbumListResponse;
-import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
-import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.participant.enums.ParticipantRole;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -659,6 +657,31 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
                     .andExpect(jsonPath("$.data.content").isEmpty())
                     .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+    }
+
+    @Nested
+    class 앨범_입장_요청_시 {
+
+        @Test
+        void 유효한_요청이면_참가자_정보를_반환한다() throws Exception {
+            // given
+            AlbumJoinResponse response =
+                    new AlbumJoinResponse(1L, 1L, 1L, ParticipantRole.STANDARD);
+
+            given(albumService.joinAlbum(1L, "testInvitationCode")).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
+
+            perform.andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
+                    .andExpect(jsonPath("$.data.participantId").value(1))
+                    .andExpect(jsonPath("$.data.albumId").value(1))
+                    .andExpect(jsonPath("$.data.memberId").value(1))
+                    .andExpect(jsonPath("$.data.role").value("STANDARD"));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -732,7 +732,7 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_MISMATCH"))
-                    .andExpect(jsonPath("$.data.message").value("초대코드가 올바르지 않습니다."));
+                    .andExpect(jsonPath("$.data.message").value("초대 코드가 올바르지 않습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -719,7 +719,7 @@ class AlbumControllerTest {
         }
 
         @Test
-        void 앨범_초대_코드가_앨범의_현재_코드와_일치하지_않는_경우_예외가_발생한다() throws Exception {
+        void 앨범_초대_코드가_redis에_저장된_코드와_일치하지_않는_경우_예외가_발생한다() throws Exception {
             // given
             given(albumService.joinAlbum(1L, "ExpiredInvitationCode"))
                     .willThrow(new AlbumException(AlbumErrorCode.INVITATION_CODE_MISMATCH));

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -683,5 +683,56 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.memberId").value(1))
                     .andExpect(jsonPath("$.data.role").value("STANDARD"));
         }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(999L, "testInvitationCode"))
+                    .willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/999/join").param("code", "testInvitationCode"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_초대_코드가_redis에_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "NoneExistingCode"))
+                    .willThrow(new AlbumException(AlbumErrorCode.INVITATION_CODE_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "NoneExistingCode"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범의 초대 코드가 만료되었습니다."));
+        }
+
+        @Test
+        void 앨범_초대_코드가_앨범의_현재_코드와_일치하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "ExpiredInvitationCode"))
+                    .willThrow(new AlbumException(AlbumErrorCode.INVITATION_CODE_MISMATCH));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "ExpiredInvitationCode"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("초대코드가 올바르지 않습니다."));
+        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -15,6 +16,7 @@ import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
+import org.cherrypic.domain.album.dto.response.AlbumJoinResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -586,6 +588,78 @@ class AlbumServiceTest extends IntegrationTest {
             Participant participant2 =
                     Participant.createParticipant(member, album2, ParticipantRole.HOST);
             participantRepository.saveAll(List.of(participant1, participant2));
+        }
+    }
+
+    @Nested
+    class 앨범에_입장할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
+            albumRepository.saveAll(List.of(album1, album2));
+
+            InvitationCode invitationCode =
+                    InvitationCode.builder()
+                            .albumId(1L)
+                            .code("testInvitationCode")
+                            .ttl(Duration.ofMinutes(30).getSeconds())
+                            .build();
+            invitationCodeRepository.save(invitationCode);
+        }
+
+        @AfterEach
+        void cleanUp() {
+            redisCleaner.flushAll();
+        }
+
+        @Test
+        void 유요한_초대코드면_앨범에_참가하며_참가_정보를_반환한다() {
+            // when
+            AlbumJoinResponse response = albumService.joinAlbum(1L, "testInvitationCode");
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response)
+                                    .extracting("participantId", "albumId", "memberId", "role")
+                                    .containsExactly(1L, 1L, 1L, ParticipantRole.STANDARD),
+                    () ->
+                            assertThat(participantRepository.findByMemberIdAndAlbumId(1L, 1L))
+                                    .isPresent());
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(999L, "testInvitationCode"))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_초대_코드가_존재하지_않거나_만료된_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(2L, "expiredInvitationCode"))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.INVITATION_CODE_OUTDATED.getMessage());
+        }
+
+        @Test
+        void 앨범_초대_코드가_앨범의_현재_코드와_일치하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(1L, "expiredInvitationCode"))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.INVITATION_CODE_INVALID.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -655,7 +655,7 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 앨범_초대_코드가_앨범의_현재_코드와_일치하지_않는_경우_예외가_발생한다() {
+        void 앨범_초대_코드가_redis에_저장된_코드와_일치하지_않는_경우_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> albumService.joinAlbum(1L, "expiredInvitationCode"))
                     .isInstanceOf(AlbumException.class)

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -623,7 +623,7 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_초대_코드면_앨범에_참가하면_참가자가_생성된다() {
+        void 유효한_초대_코드면_앨범_참가자가_생성된다() {
             // when
             AlbumJoinResponse response = albumService.joinAlbum(1L, "testInvitationCode");
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -438,7 +438,7 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청에_대해서_유효한_초대코드가_생성된다() {
+        void 유효한_요청에_대해서_유효한_초대_코드가_생성된다() {
             // when
             albumService.createInvitationLink(1L);
 
@@ -623,19 +623,17 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유요한_초대코드면_앨범에_참가하며_참가_정보를_반환한다() {
+        void 유효한_초대_코드면_앨범에_참가하면_참가자가_생성된다() {
             // when
             AlbumJoinResponse response = albumService.joinAlbum(1L, "testInvitationCode");
 
             // then
+            Participant participant =
+                    participantRepository.findByMemberIdAndAlbumId(1L, 1L).orElseThrow();
+
             Assertions.assertAll(
-                    () ->
-                            assertThat(response)
-                                    .extracting("participantId", "albumId", "memberId", "role")
-                                    .containsExactly(1L, 1L, 1L, ParticipantRole.STANDARD),
-                    () ->
-                            assertThat(participantRepository.findByMemberIdAndAlbumId(1L, 1L))
-                                    .isPresent());
+                    () -> assertThat(participant).isNotNull(),
+                    () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.STANDARD));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -647,11 +647,11 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 앨범_초대_코드가_존재하지_않거나_만료된_경우_예외가_발생한다() {
+        void 앨범_초대_코드가_redis에_존재하지_않는_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> albumService.joinAlbum(2L, "expiredInvitationCode"))
+            assertThatThrownBy(() -> albumService.joinAlbum(2L, "NoneExistingCode"))
                     .isInstanceOf(AlbumException.class)
-                    .hasMessage(AlbumErrorCode.INVITATION_CODE_OUTDATED.getMessage());
+                    .hasMessage(AlbumErrorCode.INVITATION_CODE_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -659,7 +659,7 @@ class AlbumServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> albumService.joinAlbum(1L, "expiredInvitationCode"))
                     .isInstanceOf(AlbumException.class)
-                    .hasMessage(AlbumErrorCode.INVITATION_CODE_INVALID.getMessage());
+                    .hasMessage(AlbumErrorCode.INVITATION_CODE_MISMATCH.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #80 

---
## 📌 작업 내용 및 특이사항
- 참가자 초대 API를 구현했습니다.
- 사용자의 입장에서 자연스럽게 에러 메시지를 작성했습니다.
   - 앨범 ID를 기준으로 초대 코드를 Invitation repository에서 찾지 못한 경우 : 사용자는 링크가 발급 되고 링크를 통해서 왔을 태니, 만료되는 경우 일 것이라고 생각했습니다. 
   - 초대 링크와 앨범의 초대 링크가 일치 하지 않는 경우 : 만료된 링크로 접속 or 복사를 제대로 안함 -> 따라서, 올바르지 않다고 설명
- 에러 메시지의 중점적으로 봐주시면 감사하겠습니다.

---
## 📚 참고사항
- 딥링크를 검증해주는 json은 현재 프론트에서 안드로이드 작업이 완료되지 않아 iOS 인증서만 업로드 되어 있습니다.