### PR TITLE
feat: 앨범 삭제 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -76,4 +76,11 @@ public class AlbumController {
                     SortDirection direction) {
         return albumService.getParticipatingAlbums(lastAlbumId, size, direction);
     }
+
+    @DeleteMapping("/{albumId}")
+    @Operation(summary = "앨범 삭제", description = "앨범을 삭제합니다.")
+    public ResponseEntity<Void> albumDelete(@PathVariable Long albumId) {
+        albumService.deleteAlbum(albumId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -22,6 +22,7 @@ public enum AlbumErrorCode implements BaseErrorCode {
     ALREADY_PARTICIPATED(400, "이미 참가한 앨범입니다."),
 
     OTHER_PARTICIPANTS_EXIST(400, "다른 참가자가 남아 있어 앨범을 삭제할 수 없습니다."),
+    SUBSCRIPTION_ACTIVE(400, "구독 중인 앨범은 삭제할 수 없습니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -19,7 +19,10 @@ public enum AlbumErrorCode implements BaseErrorCode {
 
     INVITATION_CODE_NOT_FOUND(404, "앨범의 초대 코드가 만료되었습니다."),
     INVITATION_CODE_MISMATCH(400, "초대 코드가 올바르지 않습니다."),
-    ALREADY_PARTICIPATED(400, "이미 참가한 앨범입니다.");
+    ALREADY_PARTICIPATED(400, "이미 참가한 앨범입니다."),
+
+    OTHER_PARTICIPANTS_EXIST(400, "다른 참가자가 남아 있어 앨범을 삭제할 수 없습니다."),
+    ;
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -19,4 +19,5 @@ public interface AlbumService {
             Long lastAlbumId, int size, SortDirection direction);
 
     AlbumJoinResponse joinAlbum(Long albumId, String code);
+    void deleteAlbum(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -19,5 +19,6 @@ public interface AlbumService {
             Long lastAlbumId, int size, SortDirection direction);
 
     AlbumJoinResponse joinAlbum(Long albumId, String code);
+
     void deleteAlbum(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -171,6 +171,7 @@ public class AlbumServiceImpl implements AlbumService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+        validateRemainingParticipants(album.getId(), currentMember.getId());
 
         albumRepository.delete(album);
     }
@@ -248,5 +249,11 @@ public class AlbumServiceImpl implements AlbumService {
                         p -> {
                             throw new AlbumException(AlbumErrorCode.ALREADY_PARTICIPATED);
                         });
+    }
+
+    private void validateRemainingParticipants(Long albumId, Long memberId) {
+        if (participantRepository.existsByAlbumIdAndMemberIdIsNot(albumId, memberId)) {
+            throw new AlbumException(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST);
+        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -24,6 +24,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentStatus;
 import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -171,6 +172,7 @@ public class AlbumServiceImpl implements AlbumService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionInactive(album);
         validateRemainingParticipants(album.getId(), currentMember.getId());
 
         albumRepository.delete(album);
@@ -254,6 +256,14 @@ public class AlbumServiceImpl implements AlbumService {
     private void validateRemainingParticipants(Long albumId, Long memberId) {
         if (participantRepository.existsByAlbumIdAndMemberIdIsNot(albumId, memberId)) {
             throw new AlbumException(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST);
+        }
+    }
+
+    private void validateSubscriptionInactive(Album album) {
+        if (album.getPlan() == AlbumPlan.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.ACTIVE) {
+            throw new AlbumException(AlbumErrorCode.SUBSCRIPTION_ACTIVE);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -165,6 +165,16 @@ public class AlbumServiceImpl implements AlbumService {
         return AlbumJoinResponse.from(participant);
     }
 
+    @Override
+    public void deleteAlbum(Long albumId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateAlbumHost(currentMember.getId(), album.getId());
+
+        albumRepository.delete(album);
+    }
+
     private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -16,4 +16,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
                     "UPDATE participant SET role = 'STANDARD' WHERE album_id = :albumId AND role = 'LIMITED'",
             nativeQuery = true)
     void bulkChangeLimitedToStandard(@Param("albumId") Long albumId);
+
+    boolean existsByAlbumIdAndMemberIdIsNot(Long AlbumId, Long memberId);
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -1019,5 +1019,22 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.code").value("OTHER_PARTICIPANTS_EXIST"))
                     .andExpect(jsonPath("$.data.message").value("다른 참가자가 남아 있어 앨범을 삭제할 수 없습니다."));
         }
+
+        @Test
+        void 구독_중인_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new AlbumException(AlbumErrorCode.SUBSCRIPTION_ACTIVE))
+                    .given(albumService)
+                    .deleteAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_ACTIVE"))
+                    .andExpect(jsonPath("$.data.message").value("구독 중인 앨범은 삭제할 수 없습니다."));
+        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -1002,5 +1002,22 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
                     .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
         }
+
+        @Test
+        void 다른_참가자가_남아있는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new AlbumException(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST))
+                    .given(albumService)
+                    .deleteAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("OTHER_PARTICIPANTS_EXIST"))
+                    .andExpect(jsonPath("$.data.message").value("다른 참가자가 남아 있어 앨범을 삭제할 수 없습니다."));
+        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -1,9 +1,7 @@
 package org.cherrypic.album.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -935,6 +933,74 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_MISMATCH"))
                     .andExpect(jsonPath("$.data.message").value("초대 코드가 올바르지 않습니다."));
+        }
+    }
+
+    @Nested
+    class 앨범_삭제_요청_시 {
+
+        @Test
+        void 유효한_요청이면_앨범을_삭제하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            willDoNothing().given(albumService).deleteAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1"));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(albumService)
+                    .deleteAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(albumService)
+                    .deleteAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new AlbumException(AlbumErrorCode.NOT_ALBUM_HOST))
+                    .given(albumService)
+                    .deleteAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -841,68 +841,68 @@ class AlbumServiceTest extends IntegrationTest {
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.ALREADY_PARTICIPATED.getMessage());
         }
+    }
 
-        @Nested
-        class 앨범을_삭제할_때 {
+    @Nested
+    class 앨범을_삭제할_때 {
 
-            @BeforeEach
-            void setUp() {
-                Member member =
-                        Member.createMember(
-                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                                "testNickname",
-                                "testProfileImageUrl");
-                memberRepository.save(member);
-                given(memberUtil.getCurrentMember()).willReturn(member);
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
 
-                Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-                Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-                Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
-                albumRepository.saveAll(List.of(album1, album2, album3));
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
 
-                Participant participant1 =
-                        Participant.createParticipant(member, album1, ParticipantRole.HOST);
-                Participant participant2 =
-                        Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
-                participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
 
-                eventRepository.save(Event.createEvent(album1, "testTitle1", "testCoverUrl1"));
-            }
+            eventRepository.save(Event.createEvent(album1, "testTitle1", "testCoverUrl1"));
+        }
 
-            @Test
-            void 유효한_요청일_경우_앨범과_내부_이벤트가_모두_삭제된다() {
-                // when
-                albumService.deleteAlbum(1L);
+        @Test
+        void 유효한_요청일_경우_앨범과_내부_이벤트가_모두_삭제된다() {
+            // when
+            albumService.deleteAlbum(1L);
 
-                // then
-                Assertions.assertAll(
-                        () -> assertThat(albumRepository.findById(1L).isPresent()).isFalse(),
-                        () -> assertThat(eventRepository.findById(1L).isPresent()).isFalse());
-            }
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(albumRepository.findById(1L).isPresent()).isFalse(),
+                    () -> assertThat(eventRepository.findById(1L).isPresent()).isFalse());
+        }
 
-            @Test
-            void 앨범이_존재하지_않는_경우_예외가_발생한다() {
-                // when & then
-                assertThatThrownBy(() -> albumService.deleteAlbum(999L))
-                        .isInstanceOf(AlbumException.class)
-                        .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
-            }
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.deleteAlbum(999L))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
 
-            @Test
-            void 앨범_참가자가_아닌_경우_예외가_발생한다() {
-                // when & then
-                assertThatThrownBy(() -> albumService.deleteAlbum(3L))
-                        .isInstanceOf(AlbumException.class)
-                        .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
-            }
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.deleteAlbum(3L))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
 
-            @Test
-            void 앨범_방장이_아닌_경우_예외가_발생한다() {
-                // when & then
-                assertThatThrownBy(() -> albumService.deleteAlbum(2L))
-                        .isInstanceOf(AlbumException.class)
-                        .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
-            }
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.deleteAlbum(2L))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -48,30 +48,19 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class AlbumServiceTest extends IntegrationTest {
 
-    @Autowired
-    private RedisCleaner redisCleaner;
-    @Autowired
-    private TransactionUtil transactionUtil;
+    @Autowired private RedisCleaner redisCleaner;
+    @Autowired private TransactionUtil transactionUtil;
 
-    @Autowired
-    private AlbumService albumService;
-    @Autowired
-    private AlbumRepository albumRepository;
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private PaymentRepository paymentRepository;
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
-    @Autowired
-    private ParticipantRepository participantRepository;
-    @Autowired
-    private InvitationCodeRepository invitationCodeRepository;
-    @Autowired
-    private EventRepository eventRepository;
+    @Autowired private AlbumService albumService;
+    @Autowired private AlbumRepository albumRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private SubscriptionRepository subscriptionRepository;
+    @Autowired private ParticipantRepository participantRepository;
+    @Autowired private InvitationCodeRepository invitationCodeRepository;
+    @Autowired private EventRepository eventRepository;
 
-    @MockitoBean
-    MemberUtil memberUtil;
+    @MockitoBean MemberUtil memberUtil;
 
     @Nested
     class 앨범을_생성할_때 {
@@ -253,9 +242,9 @@ class AlbumServiceTest extends IntegrationTest {
                                         .containsExactly(1L, 1L, 2L, SubscriptionStatus.ACTIVE),
                         () ->
                                 assertThat(
-                                        subscription
-                                                .getStartAt()
-                                                .truncatedTo(ChronoUnit.MINUTES))
+                                                subscription
+                                                        .getStartAt()
+                                                        .truncatedTo(ChronoUnit.MINUTES))
                                         .isEqualTo(
                                                 LocalDateTime.now()
                                                         .truncatedTo(ChronoUnit.MINUTES)),
@@ -267,9 +256,9 @@ class AlbumServiceTest extends IntegrationTest {
                                                         .plusMonths(1)),
                         () ->
                                 assertThat(
-                                        subscription
-                                                .getNextBillingAt()
-                                                .truncatedTo(ChronoUnit.MINUTES))
+                                                subscription
+                                                        .getNextBillingAt()
+                                                        .truncatedTo(ChronoUnit.MINUTES))
                                         .isEqualTo(
                                                 LocalDateTime.now()
                                                         .truncatedTo(ChronoUnit.MINUTES)
@@ -853,7 +842,6 @@ class AlbumServiceTest extends IntegrationTest {
                     .hasMessage(AlbumErrorCode.ALREADY_PARTICIPATED.getMessage());
         }
 
-
         @Nested
         class 앨범을_삭제할_때 {
 
@@ -867,9 +855,9 @@ class AlbumServiceTest extends IntegrationTest {
                 memberRepository.save(member);
                 given(memberUtil.getCurrentMember()).willReturn(member);
 
-                Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
-                Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
-                Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC);
+                Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+                Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+                Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
                 albumRepository.saveAll(List.of(album1, album2, album3));
 
                 Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -865,7 +865,11 @@ class AlbumServiceTest extends IntegrationTest {
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
             Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
             Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3, album4));
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
+
+            subscriptionRepository.save(
+                    Subscription.createSubscription(member1, album5, LocalDateTime.now()));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
@@ -875,8 +879,10 @@ class AlbumServiceTest extends IntegrationTest {
                     Participant.createParticipant(member1, album3, ParticipantRole.HOST);
             Participant participant4 =
                     Participant.createParticipant(member2, album3, ParticipantRole.LIMITED);
+            Participant participant5 =
+                    Participant.createParticipant(member1, album5, ParticipantRole.HOST);
             participantRepository.saveAll(
-                    List.of(participant1, participant2, participant3, participant4));
+                    List.of(participant1, participant2, participant3, participant4, participant5));
 
             eventRepository.save(Event.createEvent(album1, "testTitle1", "testCoverUrl1"));
         }
@@ -922,6 +928,14 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.deleteAlbum(3L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST.getMessage());
+        }
+
+        @Test
+        void 구독_중인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.deleteAlbum(5L))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.SUBSCRIPTION_ACTIVE.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -23,11 +23,13 @@ import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
+import org.cherrypic.event.entity.Event;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
@@ -46,18 +48,30 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class AlbumServiceTest extends IntegrationTest {
 
-    @Autowired private RedisCleaner redisCleaner;
-    @Autowired private TransactionUtil transactionUtil;
+    @Autowired
+    private RedisCleaner redisCleaner;
+    @Autowired
+    private TransactionUtil transactionUtil;
 
-    @Autowired private AlbumService albumService;
-    @Autowired private AlbumRepository albumRepository;
-    @Autowired private MemberRepository memberRepository;
-    @Autowired private PaymentRepository paymentRepository;
-    @Autowired private SubscriptionRepository subscriptionRepository;
-    @Autowired private ParticipantRepository participantRepository;
-    @Autowired private InvitationCodeRepository invitationCodeRepository;
+    @Autowired
+    private AlbumService albumService;
+    @Autowired
+    private AlbumRepository albumRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PaymentRepository paymentRepository;
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
+    @Autowired
+    private InvitationCodeRepository invitationCodeRepository;
+    @Autowired
+    private EventRepository eventRepository;
 
-    @MockitoBean MemberUtil memberUtil;
+    @MockitoBean
+    MemberUtil memberUtil;
 
     @Nested
     class 앨범을_생성할_때 {
@@ -239,9 +253,9 @@ class AlbumServiceTest extends IntegrationTest {
                                         .containsExactly(1L, 1L, 2L, SubscriptionStatus.ACTIVE),
                         () ->
                                 assertThat(
-                                                subscription
-                                                        .getStartAt()
-                                                        .truncatedTo(ChronoUnit.MINUTES))
+                                        subscription
+                                                .getStartAt()
+                                                .truncatedTo(ChronoUnit.MINUTES))
                                         .isEqualTo(
                                                 LocalDateTime.now()
                                                         .truncatedTo(ChronoUnit.MINUTES)),
@@ -253,9 +267,9 @@ class AlbumServiceTest extends IntegrationTest {
                                                         .plusMonths(1)),
                         () ->
                                 assertThat(
-                                                subscription
-                                                        .getNextBillingAt()
-                                                        .truncatedTo(ChronoUnit.MINUTES))
+                                        subscription
+                                                .getNextBillingAt()
+                                                .truncatedTo(ChronoUnit.MINUTES))
                                         .isEqualTo(
                                                 LocalDateTime.now()
                                                         .truncatedTo(ChronoUnit.MINUTES)
@@ -837,6 +851,70 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.joinAlbum(3L, "testInvitationCode2"))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.ALREADY_PARTICIPATED.getMessage());
+        }
+
+
+        @Nested
+        class 앨범을_삭제할_때 {
+
+            @BeforeEach
+            void setUp() {
+                Member member =
+                        Member.createMember(
+                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                                "testNickname",
+                                "testProfileImageUrl");
+                memberRepository.save(member);
+                given(memberUtil.getCurrentMember()).willReturn(member);
+
+                Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
+                Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
+                Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC);
+                albumRepository.saveAll(List.of(album1, album2, album3));
+
+                Participant participant1 =
+                        Participant.createParticipant(member, album1, ParticipantRole.HOST);
+                Participant participant2 =
+                        Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+                participantRepository.saveAll(List.of(participant1, participant2));
+
+                eventRepository.save(Event.createEvent(album1, "testTitle1", "testCoverUrl1"));
+            }
+
+            @Test
+            void 유효한_요청일_경우_앨범과_내부_이벤트가_모두_삭제된다() {
+                // when
+                albumService.deleteAlbum(1L);
+
+                // then
+                Assertions.assertAll(
+                        () -> assertThat(albumRepository.findById(1L).isPresent()).isFalse(),
+                        () -> assertThat(eventRepository.findById(1L).isPresent()).isFalse());
+            }
+
+            @Test
+            void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+                // when & then
+                assertThatThrownBy(() -> albumService.deleteAlbum(999L))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+            }
+
+            @Test
+            void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+                // when & then
+                assertThatThrownBy(() -> albumService.deleteAlbum(3L))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+            }
+
+            @Test
+            void 앨범_방장이_아닌_경우_예외가_발생한다() {
+                // when & then
+                assertThatThrownBy(() -> albumService.deleteAlbum(2L))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+            }
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -848,24 +848,35 @@ class AlbumServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            Member member =
+            Member member1 =
                     Member.createMember(
                             OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
                             "testNickname",
                             "testProfileImageUrl");
-            memberRepository.save(member);
-            given(memberUtil.getCurrentMember()).willReturn(member);
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
             Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4));
 
             Participant participant1 =
-                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
             Participant participant2 =
-                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
-            participantRepository.saveAll(List.of(participant1, participant2));
+                    Participant.createParticipant(member1, album2, ParticipantRole.LIMITED);
+            Participant participant3 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.HOST);
+            Participant participant4 =
+                    Participant.createParticipant(member2, album3, ParticipantRole.LIMITED);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4));
 
             eventRepository.save(Event.createEvent(album1, "testTitle1", "testCoverUrl1"));
         }
@@ -892,7 +903,7 @@ class AlbumServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> albumService.deleteAlbum(3L))
+            assertThatThrownBy(() -> albumService.deleteAlbum(4L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -903,6 +914,14 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.deleteAlbum(2L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void 다른_참가자가_남아있는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.deleteAlbum(3L))
+                    .isInstanceOf(AlbumException.class)
+                    .hasMessage(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #78 

---
## 📌 작업 내용 및 특이사항
- 앨범 삭제 API를 구현하였습니다.
- 앨범 방장이 아닌 경우와 방장을 제외한 참가자가 1명이라도 존재하면 앨범을 삭제할 수 없도록 예외 처리하였습니다.
- 또한, 구독 중인 앨범의 경우 구독 해지를 하고 삭제할 수 있도록 예외 처리를 추가하였습니다.
- 기존 이벤트 삭제 테스트에서 부모 객체로부터 자식 객체를 가져와 검증하는 부분은 초기에 테스트 데이터를 세팅하고 진행하니 제거하였습니다.

---
## 📚 참고사항
* 방장을 제외한 참가자가 1명이라도 존재하는 상황에서 방장이 앨범을 삭제하려고 하면 이외 참가자들에게 알림을 보내주려고 합니다.
* 위 기능은 향후 PR에서 진행하도록 하겠습니다.