### PR TITLE
feat: Enum 값 유효성 검증 일괄 적용

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -12,16 +12,19 @@ import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.AlbumUpdateResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.service.AlbumService;
+import org.cherrypic.global.annotation.PageSize;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/albums")
 @RequiredArgsConstructor
 @Tag(name = "3. 앨범 API", description = "앨범 관련 API입니다.")
+@Validated
 public class AlbumController {
 
     private final AlbumService albumService;
@@ -55,7 +58,7 @@ public class AlbumController {
             @Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastAlbumId,
-            @Parameter(description = "페이지당 조회할 앨범 수") @RequestParam int size,
+            @Parameter(description = "페이지당 조회할 앨범 수") @RequestParam @PageSize Integer size,
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
@@ -2,9 +2,9 @@ package org.cherrypic.domain.album.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.global.annotation.Enum;
 
 public record AlbumCreateRequest(
         @NotBlank(message = "앨범 이름은 비워둘 수 없습니다.")
@@ -12,7 +12,7 @@ public record AlbumCreateRequest(
                 @Size(max = 20, message = "앨범 이름은 최대 20자까지 가능합니다.")
                 String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @NotNull(message = "앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다.")
+        @Enum(message = "앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다.")
                 @Schema(description = "앨범 플랜 (BASIC: 무료, PRO/PREMIUM: 유료)", example = "BASIC")
                 AlbumPlan plan,
         @Schema(description = "유료 플랜(PRO, PREMIUM)인 경우 필수. 결제 검증 후 받은 결제 ID", example = "1")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
@@ -1,10 +1,10 @@
 package org.cherrypic.domain.image.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.global.annotation.Enum;
 
 public record MemberProfileImageUploadRequest(
-        @NotNull(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
+        @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
                 @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/request/PaymentReadyRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/request/PaymentReadyRequest.java
@@ -1,10 +1,10 @@
 package org.cherrypic.domain.payment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.global.annotation.Enum;
 
 public record PaymentReadyRequest(
-        @NotNull(message = "앨범 구독 플랜은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다.")
+        @Enum(message = "앨범 구독 플랜은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다.")
                 @Schema(description = "앨범 구독 플랜", defaultValue = "PRO")
                 AlbumPlan plan) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/global/validator/EnumValidator.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/validator/EnumValidator.java
@@ -2,14 +2,11 @@ package org.cherrypic.global.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import java.util.Arrays;
 import org.cherrypic.global.annotation.Enum;
 
 public class EnumValidator implements ConstraintValidator<Enum, java.lang.Enum> {
     @Override
     public boolean isValid(java.lang.Enum value, ConstraintValidatorContext context) {
-        if (value == null) return false;
-        Class<?> reflectionEnumClass = value.getDeclaringClass();
-        return Arrays.asList(reflectionEnumClass.getEnumConstants()).contains(value);
+        return value != null;
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -660,5 +660,34 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.content").isEmpty())
                     .andExpect(jsonPath("$.data.isLast").value(true));
         }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "-999", "0"})
+        void 페이지_크기가_0_이하이면_예외가_발생한다(String pageSize) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums").param("size", pageSize).param("direction", "DESC"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ConstraintViolationException"))
+                    .andExpect(jsonPath("$.data.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
+        void 존재하지_않는_정렬_기준을_입력하면_예외가_발생한다(String sort) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("size", "2").param("direction", sort));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
+        }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #83 

---
## 📌 작업 내용 및 특이사항
* JsonCreator 파싱 시 잘못된 값은 null로 처리되어, EnumValidator가 간결하게 검증할 수 있도록 유지했습니다.
* 이를 바탕으로 EnumValidator 로직을 간소화하여 중복 검증을 제거했습니다.
* DTO의 기존 ```@NotNull```을 커스텀 ```@Enum``` 어노테이션으로 변경해 Enum 검증을 통일했습니다.
* 앨범 목록 조회 API 테스트에 페이지 크기 0 이하 및 존재하지 않는 정렬 기준 입력 시 예외 발생 검증을 추가했습니다.