### PR TITLE
feat: 앨범 생성 시 권한 부여 필드 추가

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
@@ -2,6 +2,7 @@ package org.cherrypic.domain.album.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.global.annotation.Enum;
@@ -16,4 +17,7 @@ public record AlbumCreateRequest(
                 @Schema(description = "앨범 플랜 (BASIC: 무료, PRO/PREMIUM: 유료)", example = "BASIC")
                 AlbumPlan plan,
         @Schema(description = "유료 플랜(PRO, PREMIUM)인 경우 필수. 결제 검증 후 받은 결제 ID", example = "1")
-                Long paymentId) {}
+                Long paymentId,
+        @NotNull(message = "권한 부여 활성화 여부는 비워둘 수 없습니다.")
+                @Schema(description = "권한 부여 활성화 여부", example = "false")
+                Boolean permissionControl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
@@ -8,9 +8,14 @@ public record AlbumCreateResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan) {
+        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan,
+        @Schema(description = "권한 부여 활성화 여부", example = "false") Boolean permissionControl) {
     public static AlbumCreateResponse from(Album album) {
         return new AlbumCreateResponse(
-                album.getId(), album.getTitle(), album.getCoverUrl(), album.getPlan());
+                album.getId(),
+                album.getTitle(),
+                album.getCoverUrl(),
+                album.getPlan(),
+                album.isPermissionControl());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -12,6 +12,8 @@ public enum AlbumErrorCode implements BaseErrorCode {
     NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다."),
     LIMITED_AUTHORITY(403, "앨범에 대한 생성/수정 권한이 없습니다."),
 
+    PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 권한 부여 활성화가 허용되지 않습니다."),
+
     PAYMENT_REQUIRED_FOR_PAID_PLAN(400, "유료 플랜은 결제 ID가 필요합니다."),
     PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 결제 ID가 필요하지 않습니다."),
     ;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -51,7 +51,14 @@ public class AlbumServiceImpl implements AlbumService {
 
         validatePaymentRequirementForPlan(request.plan(), request.paymentId());
 
-        Album album = Album.createAlbum(request.title(), request.coverUrl(), request.plan());
+        validatePermissionControl(request.plan(), request.permissionControl());
+
+        Album album =
+                Album.createAlbum(
+                        request.title(),
+                        request.coverUrl(),
+                        request.plan(),
+                        request.permissionControl());
 
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.HOST);
@@ -151,6 +158,12 @@ public class AlbumServiceImpl implements AlbumService {
 
         if (!plan.requiresPayment() && paymentId != null) {
             throw new AlbumException(AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN);
+        }
+    }
+
+    private void validatePermissionControl(AlbumPlan plan, Boolean permissionControl) {
+        if (plan == AlbumPlan.BASIC && permissionControl) {
+            throw new AlbumException(AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN);
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -368,6 +368,28 @@ class AlbumControllerTest {
                             jsonPath("$.data.message")
                                     .value("앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다."));
         }
+
+        @ParameterizedTest
+        @NullSource
+        void 권한_부여_활성화_여부가_null이면_예외가_발생한다(Boolean permissionControl) throws Exception {
+            // given
+            AlbumCreateRequest request =
+                    new AlbumCreateRequest(
+                            "testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L, permissionControl);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("권한 부여 활성화 여부는 비워둘 수 없습니다."));
+        }
     }
 
     @Nested

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -57,10 +57,12 @@ class AlbumControllerTest {
             void 결제ID_없이_요청하면_앨범_생성_정보를_반환한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, false);
 
                 AlbumCreateResponse response =
-                        new AlbumCreateResponse(1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC);
+                        new AlbumCreateResponse(
+                                1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
 
                 given(albumService.createAlbum(request)).willReturn(response);
 
@@ -84,7 +86,8 @@ class AlbumControllerTest {
             void 결제ID를_포함하여_요청하면_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(
@@ -116,10 +119,12 @@ class AlbumControllerTest {
             void 유효한_결제ID면_앨범_생성_정보를_반환한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 AlbumCreateResponse response =
-                        new AlbumCreateResponse(1L, "testTitle", "testCoverUrl", AlbumPlan.PRO);
+                        new AlbumCreateResponse(
+                                1L, "testTitle", "testCoverUrl", AlbumPlan.PRO, false);
 
                 given(albumService.createAlbum(request)).willReturn(response);
 
@@ -143,7 +148,8 @@ class AlbumControllerTest {
             void 결제ID가_null이면_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, null);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, null, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(
@@ -167,7 +173,8 @@ class AlbumControllerTest {
             void 존재하지_않는_결제ID면_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 999L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 999L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(new AlbumException(PaymentErrorCode.PAYMENT_NOT_FOUND));
@@ -190,7 +197,8 @@ class AlbumControllerTest {
             void 결제상태가_PAID가_아니면_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(new AlbumException(PaymentErrorCode.NOT_PAID));
@@ -213,7 +221,8 @@ class AlbumControllerTest {
             void 결제한_회원과_로그인_회원이_일치하지_않으면_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(new AlbumException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH));
@@ -236,7 +245,8 @@ class AlbumControllerTest {
             void 결제가_이미_사용된_경우_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(new AlbumException(PaymentErrorCode.ALREADY_USED_PAYMENT));
@@ -263,7 +273,7 @@ class AlbumControllerTest {
         void 앨범_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
             // given
             AlbumCreateRequest request =
-                    new AlbumCreateRequest(title, "testCoverUrl", AlbumPlan.BASIC, null);
+                    new AlbumCreateRequest(title, "testCoverUrl", AlbumPlan.BASIC, null, false);
 
             // when & then
             ResultActions perform =
@@ -283,7 +293,8 @@ class AlbumControllerTest {
         void 앨범_이름이_20자를_초과하면_예외가_발생한다() throws Exception {
             // given
             AlbumCreateRequest request =
-                    new AlbumCreateRequest("t".repeat(21), "testCoverUrl", AlbumPlan.BASIC, null);
+                    new AlbumCreateRequest(
+                            "t".repeat(21), "testCoverUrl", AlbumPlan.BASIC, null, false);
 
             // when & then
             ResultActions perform =
@@ -306,7 +317,8 @@ class AlbumControllerTest {
         void 앨범_플랜이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String plan) throws Exception {
             // given
             AlbumCreateRequest request =
-                    new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.from(plan), 1L);
+                    new AlbumCreateRequest(
+                            "testTitle", "testCoverUrl", AlbumPlan.from(plan), 1L, false);
 
             // when & then
             ResultActions perform =

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -79,7 +79,8 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.data.albumId").value(1))
                         .andExpect(jsonPath("$.data.title").value("testTitle"))
                         .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"))
-                        .andExpect(jsonPath("$.data.plan").value("BASIC"));
+                        .andExpect(jsonPath("$.data.plan").value("BASIC"))
+                        .andExpect(jsonPath("$.data.permissionControl").value("false"));
             }
 
             @Test
@@ -110,6 +111,37 @@ class AlbumControllerTest {
                         .andExpect(
                                 jsonPath("$.data.message").value("BASIC 플랜에서는 결제 ID가 필요하지 않습니다."));
             }
+
+            @Test
+            void 권한_부여_활성화_여부를_true로_요청하면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, true);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(
+                                new AlbumException(
+                                        AlbumErrorCode
+                                                .PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                        .andExpect(
+                                jsonPath("$.data.code")
+                                        .value("PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN"))
+                        .andExpect(
+                                jsonPath("$.data.message")
+                                        .value("BASIC 플랜에서는 권한 부여 활성화가 허용되지 않습니다."));
+            }
         }
 
         @Nested
@@ -120,11 +152,11 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, true);
 
                 AlbumCreateResponse response =
                         new AlbumCreateResponse(
-                                1L, "testTitle", "testCoverUrl", AlbumPlan.PRO, false);
+                                1L, "testTitle", "testCoverUrl", AlbumPlan.PRO, true);
 
                 given(albumService.createAlbum(request)).willReturn(response);
 
@@ -141,7 +173,8 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.data.albumId").value(1))
                         .andExpect(jsonPath("$.data.title").value("testTitle"))
                         .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"))
-                        .andExpect(jsonPath("$.data.plan").value("PRO"));
+                        .andExpect(jsonPath("$.data.plan").value("PRO"))
+                        .andExpect(jsonPath("$.data.permissionControl").value("true"));
             }
 
             @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -99,9 +99,18 @@ class AlbumServiceTest extends IntegrationTest {
                 Assertions.assertAll(
                         () ->
                                 assertThat(album)
-                                        .extracting("id", "title", "coverUrl", "plan")
+                                        .extracting(
+                                                "id",
+                                                "title",
+                                                "coverUrl",
+                                                "plan",
+                                                "permissionControl")
                                         .containsExactly(
-                                                1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC),
+                                                1L,
+                                                "testTitle",
+                                                "testCoverUrl",
+                                                AlbumPlan.BASIC,
+                                                false),
                         () ->
                                 assertThat(participant)
                                         .extracting("id", "member.id", "album.id", "role")
@@ -120,6 +129,21 @@ class AlbumServiceTest extends IntegrationTest {
                         .isInstanceOf(AlbumException.class)
                         .hasMessage(
                                 AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN.getMessage());
+            }
+
+            @Test
+            void 권한_부여_활성화_여부를_true로_요청하면_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, true);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(AlbumException.class)
+                        .hasMessage(
+                                AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN
+                                        .getMessage());
             }
         }
 
@@ -166,7 +190,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, true);
 
                 // when
                 albumService.createAlbum(request);
@@ -188,9 +212,18 @@ class AlbumServiceTest extends IntegrationTest {
                 Assertions.assertAll(
                         () ->
                                 assertThat(album)
-                                        .extracting("id", "title", "coverUrl", "plan")
+                                        .extracting(
+                                                "id",
+                                                "title",
+                                                "coverUrl",
+                                                "plan",
+                                                "permissionControl")
                                         .containsExactly(
-                                                2L, "testTitle", "testCoverUrl", AlbumPlan.PRO),
+                                                2L,
+                                                "testTitle",
+                                                "testCoverUrl",
+                                                AlbumPlan.PRO,
+                                                true),
                         () ->
                                 assertThat(participant)
                                         .extracting("id", "member.id", "album.id", "role")

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -80,7 +80,8 @@ class AlbumServiceTest extends IntegrationTest {
             void 결제ID_없이_요청하면_앨범과_HOST_참여자가_생성된다() {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, null);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, false);
 
                 // when
                 albumService.createAlbum(request);
@@ -111,7 +112,8 @@ class AlbumServiceTest extends IntegrationTest {
             void 결제ID를_포함하여_요청하면_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -140,7 +142,9 @@ class AlbumServiceTest extends IntegrationTest {
 
                 given(memberUtil.getCurrentMember()).willReturn(member1);
 
-                Album album = Album.createAlbum("testPaidTitle", "testPaidCoverUrl", AlbumPlan.PRO);
+                Album album =
+                        Album.createAlbum(
+                                "testPaidTitle", "testPaidCoverUrl", AlbumPlan.PRO, false);
                 albumRepository.save(album);
 
                 // 검증 완료된 결제
@@ -161,7 +165,8 @@ class AlbumServiceTest extends IntegrationTest {
             void 유효한_결제ID면_앨범과_HOST_참여자_및_구독이_생성되고_결제에_앨범이_연결된다() {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 // when
                 albumService.createAlbum(request);
@@ -228,7 +233,8 @@ class AlbumServiceTest extends IntegrationTest {
             void 결제ID가_null이면_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, null);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, null, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -240,7 +246,8 @@ class AlbumServiceTest extends IntegrationTest {
             void 존재하지_않는_결제ID면_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 999L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 999L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -252,7 +259,8 @@ class AlbumServiceTest extends IntegrationTest {
             void 결제상태가_PAID가_아니면_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 2L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 2L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -267,7 +275,8 @@ class AlbumServiceTest extends IntegrationTest {
                         .willReturn(memberRepository.findById(2L).get());
 
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 1L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -279,7 +288,8 @@ class AlbumServiceTest extends IntegrationTest {
             void 결제가_이미_사용된_경우_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
-                        new AlbumCreateRequest("testTitle", "testCoverUrl", AlbumPlan.PRO, 3L);
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 3L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -302,9 +312,9 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -388,8 +398,8 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -577,8 +587,8 @@ class AlbumServiceTest extends IntegrationTest {
         private void createTestAlbums() {
             Member member = memberRepository.findById(1L).get();
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.PRO);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.PRO, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -72,8 +72,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -147,8 +147,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2, member3));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -238,8 +238,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("testAlbum2", "testURl2", AlbumPlan.BASIC);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURl2", AlbumPlan.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -330,8 +330,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -54,14 +54,21 @@ public class Album extends BaseTimeEntity {
     private List<Image> images = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Album(String title, String coverUrl, AlbumPlan plan) {
+    private Album(String title, String coverUrl, AlbumPlan plan, boolean permissionControl) {
         this.title = title;
         this.coverUrl = coverUrl;
         this.plan = plan;
+        this.permissionControl = permissionControl;
     }
 
-    public static Album createAlbum(String title, String coverUrl, AlbumPlan plan) {
-        return Album.builder().title(title).coverUrl(coverUrl).plan(plan).build();
+    public static Album createAlbum(
+            String title, String coverUrl, AlbumPlan plan, boolean permissionControl) {
+        return Album.builder()
+                .title(title)
+                .coverUrl(coverUrl)
+                .plan(plan)
+                .permissionControl(permissionControl)
+                .build();
     }
 
     public void addParticipant(Participant participant) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -33,6 +33,8 @@ public class Album extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private AlbumPlan plan;
 
+    private boolean permissionControl;
+
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
 

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -17,6 +17,7 @@ CREATE TABLE album (
                        title VARCHAR(20) NOT NULL,
                        cover_url VARCHAR(255),
                        plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
+                       permission_control BOOLEAN NOT NULL,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
 );


### PR DESCRIPTION
## 🌱 관련 이슈
- close #90 

---
## 📌 작업 내용 및 특이사항
* 앨범 생성 시 권한 부여 활성화 필드를 추가했습니다.
* BASIC 플랜은 권한 부여 옵션을 true로 설정할 수 없어 예외가 발생하도록 처리했습니다.
* 앨범 생성 후 응답 바디에 권한 부여 활성화 필드를 포함했습니다. 수정은 별도 토글 API로 구현할 예정이므로 응답에 포함하지 않았습니다.

---
## 📚 참고사항
* 권한 부여 토글 변경 기능은 별도 API로 구현할 예정입니다.