### PR TITLE
feat: FCM 푸시 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,9 @@ sonarqube {
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
         property 'sonar.test.inclusions', '**/*Test.java'
-        property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/** ,**/*Application*.java , **/*Config*.java,' +
-                '**/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java,**/*EventImage*.java,**/*Image*.java, **/*Validator*.java'
+        property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/**, **/*Application*.java, **/*Config*.java,' +
+                '**/*Dto*.java, **/*Request*.java, **/*Response*.java, **/*Exception*.java, **/*ErrorCode*.java, **/*Validator*.java,' +
+                '**/*FcmService*.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -37,4 +37,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 }

--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteEvent.java
@@ -2,8 +2,18 @@ package org.cherrypic.domain.album.event;
 
 import java.util.List;
 
-public record AlbumDeleteEvent(Long albumId, Long senderId, List<Long> receiverIds) {
-    public static AlbumDeleteEvent of(Long albumId, Long senderId, List<Long> receiverIds) {
-        return new AlbumDeleteEvent(albumId, senderId, receiverIds);
+public record AlbumDeleteEvent(
+        Long albumId,
+        Long senderId,
+        String hostNickname,
+        String albumTitle,
+        List<Long> receiverIds) {
+    public static AlbumDeleteEvent of(
+            Long albumId,
+            Long senderId,
+            String hostNickname,
+            String albumTitle,
+            List<Long> receiverIds) {
+        return new AlbumDeleteEvent(albumId, senderId, hostNickname, albumTitle, receiverIds);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteEvent.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.album.event;
+
+import java.util.List;
+
+public record AlbumDeleteEvent(Long albumId, Long senderId, List<Long> receiverIds) {
+    public static AlbumDeleteEvent of(Long albumId, Long senderId, List<Long> receiverIds) {
+        return new AlbumDeleteEvent(albumId, senderId, receiverIds);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
@@ -2,10 +2,5 @@ package org.cherrypic.domain.album.repository;
 
 import org.cherrypic.album.entity.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {
-    @Query("select a.title from Album a where a.id = :id")
-    String findTitleById(@Param("id") Long id);
-}
+public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
@@ -2,5 +2,10 @@ package org.cherrypic.domain.album.repository;
 
 import org.cherrypic.album.entity.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {}
+public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {
+    @Query("select a.title from Album a where a.id = :id")
+    String findTitleById(@Param("id") Long id);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -178,7 +178,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         validateAlbumHost(currentMember.getId(), album.getId());
         validateSubscriptionInactive(album);
-        validateRemainingParticipants(album.getId(), currentMember.getId());
+        validateRemainingParticipants(album, currentMember);
 
         albumRepository.delete(album);
     }
@@ -258,12 +258,18 @@ public class AlbumServiceImpl implements AlbumService {
                         });
     }
 
-    private void validateRemainingParticipants(Long albumId, Long memberId) {
+    private void validateRemainingParticipants(Album album, Member member) {
         List<Long> otherMemberIds =
-                participantRepository.findOtherParticipantMemberIds(albumId, memberId);
+                participantRepository.findOtherParticipantMemberIds(album.getId(), member.getId());
 
         if (!otherMemberIds.isEmpty()) {
-            eventPublisher.publishEvent(AlbumDeleteEvent.of(albumId, memberId, otherMemberIds));
+            eventPublisher.publishEvent(
+                    AlbumDeleteEvent.of(
+                            album.getId(),
+                            member.getId(),
+                            member.getNickname(),
+                            album.getTitle(),
+                            otherMemberIds));
             throw new AlbumException(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.album.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
@@ -7,6 +8,7 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
+import org.cherrypic.domain.album.event.AlbumDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.repository.AlbumRepository;
@@ -25,6 +27,7 @@ import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentStatus;
 import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +45,8 @@ public class AlbumServiceImpl implements AlbumService {
     private final ParticipantRepository participantRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final InvitationCodeRepository invitationCodeRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public AlbumCreateResponse createAlbum(AlbumCreateRequest request) {
@@ -254,7 +259,11 @@ public class AlbumServiceImpl implements AlbumService {
     }
 
     private void validateRemainingParticipants(Long albumId, Long memberId) {
-        if (participantRepository.existsByAlbumIdAndMemberIdIsNot(albumId, memberId)) {
+        List<Long> otherMemberIds =
+                participantRepository.findOtherParticipantMemberIds(albumId, memberId);
+
+        if (!otherMemberIds.isEmpty()) {
+            eventPublisher.publishEvent(AlbumDeleteEvent.of(albumId, memberId, otherMemberIds));
             throw new AlbumException(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
@@ -2,9 +2,12 @@ package org.cherrypic.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.service.MemberService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,5 +22,15 @@ public class MemberController {
     @Operation(summary = "회원 정보 조회", description = "로그인한 회원 정보를 조회합니다.")
     public MemberInfoResponse memberInfo() {
         return memberService.getMemberInfo();
+    }
+
+    @PostMapping("/fcm-tokens")
+    @Operation(
+            summary = "FCM 토큰 저장",
+            description = "클라이언트에서 발급된 FCM 토큰을 서버에 저장합니다. 한 계정에 여러 디바이스(다중 토큰)를 지원합니다.")
+    public ResponseEntity<Void> memberFcmTokenSave(
+            @Valid @RequestBody FcmTokenSaveRequest request) {
+        memberService.saveFcmToken(request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/request/FcmTokenSaveRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/request/FcmTokenSaveRequest.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenSaveRequest(
+        @NotBlank(message = "FCM Token은 비워둘 수 없습니다.")
+                @Schema(description = "FCM 토큰", defaultValue = "FCM Token")
+                String fcmToken) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/repository/MemberRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/repository/MemberRepository.java
@@ -4,7 +4,12 @@ import java.util.Optional;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+
+    @Query("select m.nickname from Member m where m.id = :id")
+    String findNicknameById(@Param("id") Long id);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/repository/MemberRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/repository/MemberRepository.java
@@ -4,12 +4,7 @@ import java.util.Optional;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
-
-    @Query("select m.nickname from Member m where m.id = :id")
-    String findNicknameById(@Param("id") Long id);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
@@ -1,7 +1,10 @@
 package org.cherrypic.domain.member.service;
 
+import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 
 public interface MemberService {
     MemberInfoResponse getMemberInfo();
+
+    void saveFcmToken(FcmTokenSaveRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -1,7 +1,9 @@
 package org.cherrypic.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.notification.service.FcmTokenService;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.springframework.stereotype.Service;
@@ -13,12 +15,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberUtil memberUtil;
+    private final FcmTokenService fcmTokenService;
 
     @Override
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo() {
         final Member currentMember = memberUtil.getCurrentMember();
-
         return MemberInfoResponse.from(currentMember);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void saveFcmToken(FcmTokenSaveRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        fcmTokenService.saveFcmToken(currentMember.getId(), request.fcmToken());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
@@ -21,6 +21,10 @@ public class AlbumDeleteEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleAlbumDeleteEvent(AlbumDeleteEvent event) {
         notificationService.sendAlbumDeleteNotification(
-                event.albumId(), event.senderId(), event.receiverIds());
+                event.albumId(),
+                event.senderId(),
+                event.hostNickname(),
+                event.albumTitle(),
+                event.receiverIds());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
@@ -3,8 +3,11 @@ package org.cherrypic.domain.notification.event;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.event.AlbumDeleteEvent;
 import org.cherrypic.domain.notification.service.NotificationService;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -12,7 +15,8 @@ public class AlbumDeleteEventListener {
 
     private final NotificationService notificationService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleAlbumDeleteEvent(AlbumDeleteEvent event) {
         notificationService.sendAlbumDeleteNotification(
                 event.albumId(), event.senderId(), event.receiverIds());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
@@ -2,6 +2,7 @@ package org.cherrypic.domain.notification.event;
 
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.event.AlbumDeleteEvent;
+import org.cherrypic.domain.notification.service.NotificationService;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AlbumDeleteEventListener {
 
+    private final NotificationService notificationService;
+
     @EventListener
-    public void handleAlbumDeleteEvent(AlbumDeleteEvent event) {}
+    public void handleAlbumDeleteEvent(AlbumDeleteEvent event) {
+        notificationService.sendAlbumDeleteNotification(
+                event.albumId(), event.senderId(), event.receiverIds());
+    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
@@ -1,0 +1,14 @@
+package org.cherrypic.domain.notification.event;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.album.event.AlbumDeleteEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumDeleteEventListener {
+
+    @EventListener
+    public void handleAlbumDeleteEvent(AlbumDeleteEvent event) {}
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/AlbumDeleteEventListener.java
@@ -3,6 +3,7 @@ package org.cherrypic.domain.notification.event;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.album.event.AlbumDeleteEvent;
 import org.cherrypic.domain.notification.service.NotificationService;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ public class AlbumDeleteEventListener {
 
     private final NotificationService notificationService;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleAlbumDeleteEvent(AlbumDeleteEvent event) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,24 @@
+package org.cherrypic.domain.notification.repository;
+
+import org.cherrypic.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+            value =
+                    """
+            insert into notification (sender_id, receiver_id, album_id, type, created_at, updated_at)
+            select :senderId, p.member_id, :albumId, 'ALBUM', CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+            from participant p
+            where p.album_id = :albumId
+              and p.member_id <> :senderId
+            """,
+            nativeQuery = true)
+    void bulkInsertAlbumDeleteNotifications(
+            @Param("albumId") Long albumId, @Param("senderId") Long senderId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
@@ -12,13 +12,16 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query(
             value =
                     """
-            insert into notification (sender_id, receiver_id, album_id, type, created_at, updated_at)
-            select :senderId, p.member_id, :albumId, 'ALBUM', CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+            insert into notification (sender_id, receiver_id, album_id, title, content, type, created_at, updated_at)
+            select :senderId, p.member_id, :albumId, :title, :content, 'ALBUM', CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
             from participant p
             where p.album_id = :albumId
               and p.member_id <> :senderId
             """,
             nativeQuery = true)
     void bulkInsertAlbumDeleteNotifications(
-            @Param("albumId") Long albumId, @Param("senderId") Long senderId);
+            @Param("albumId") Long albumId,
+            @Param("senderId") Long senderId,
+            @Param("title") String title,
+            @Param("content") String content);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/FcmService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/FcmService.java
@@ -1,0 +1,37 @@
+package org.cherrypic.domain.notification.service;
+
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.*;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FcmService {
+
+    public ApiFuture<BatchResponse> sendGroupMessageAsync(
+            List<String> tokens, String title, String content) {
+        MulticastMessage multicast =
+                MulticastMessage.builder()
+                        .addAllTokens(tokens)
+                        .setNotification(
+                                Notification.builder().setTitle(title).setBody(content).build())
+                        .build();
+
+        return FirebaseMessaging.getInstance().sendEachForMulticastAsync(multicast);
+    }
+
+    public ApiFuture<String> sendMessageAsync(String token, String title, String content) {
+        if (token == null || token.isEmpty()) {
+            return null;
+        }
+
+        Message message =
+                Message.builder()
+                        .setToken(token)
+                        .setNotification(
+                                Notification.builder().setTitle(title).setBody(content).build())
+                        .build();
+
+        return FirebaseMessaging.getInstance().sendAsync(message);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/FcmTokenService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/FcmTokenService.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.notification.service;
 
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -14,5 +15,16 @@ public class FcmTokenService {
 
     public void saveFcmToken(Long memberId, String token) {
         redisTemplate.opsForSet().add(String.format(FCM_TOKEN_KEY, memberId), token);
+    }
+
+    public List<String> getFcmTokens(List<Long> memberIds) {
+        Set<String> tokens = new HashSet<>();
+        for (Long id : memberIds) {
+            Set<String> s = redisTemplate.opsForSet().members(String.format(FCM_TOKEN_KEY, id));
+            if (s != null) {
+                tokens.addAll(s);
+            }
+        }
+        return new ArrayList<>(tokens);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/FcmTokenService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/FcmTokenService.java
@@ -1,0 +1,18 @@
+package org.cherrypic.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+
+    private static final String FCM_TOKEN_KEY = "fcmToken:%d";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void saveFcmToken(Long memberId, String token) {
+        redisTemplate.opsForSet().add(String.format(FCM_TOKEN_KEY, memberId), token);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationService.java
@@ -3,5 +3,10 @@ package org.cherrypic.domain.notification.service;
 import java.util.List;
 
 public interface NotificationService {
-    void sendAlbumDeleteNotification(Long albumId, Long senderId, List<Long> receiverIds);
+    void sendAlbumDeleteNotification(
+            Long albumId,
+            Long senderId,
+            String hostNickname,
+            String albumTitle,
+            List<Long> receiverIds);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationService.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.notification.service;
+
+import java.util.List;
+
+public interface NotificationService {
+    void sendAlbumDeleteNotification(Long albumId, Long senderId, List<Long> receiverIds);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
@@ -18,6 +18,7 @@ public class NotificationServiceImpl implements NotificationService {
             "%s님이 '%s' 앨범을 삭제하려고 합니다. 이미지를 백업한 후 앨범에서 나가주세요.";
 
     private final FcmService fcmService;
+    private final FcmTokenService fcmTokenService;
 
     private final MemberRepository memberRepository;
     private final AlbumRepository albumRepository;
@@ -30,8 +31,13 @@ public class NotificationServiceImpl implements NotificationService {
 
         notificationRepository.bulkInsertAlbumDeleteNotifications(albumId, senderId);
 
+        List<String> tokens = fcmTokenService.getFcmTokens(receiverIds);
+        if (tokens.isEmpty()) {
+            return;
+        }
+
         fcmService.sendGroupMessageAsync(
-                List.of("FCM 토큰 저장 로직을 아직 구현하지 않아 임시로 남겨두겠습니다."),
+                tokens,
                 PUSH_ALBUM_DELETE_TITLE,
                 String.format(PUSH_ALBUM_DELETE_BODY, hostNickname, albumTitle));
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
@@ -25,9 +25,12 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationRepository notificationRepository;
 
     @Override
-    public void sendAlbumDeleteNotification(Long albumId, Long senderId, List<Long> receiverIds) {
-        final String hostNickname = getMemberNicknameById(senderId);
-        final String albumTitle = getAlbumTitleById(albumId);
+    public void sendAlbumDeleteNotification(
+            Long albumId,
+            Long senderId,
+            String hostNickname,
+            String albumTitle,
+            List<Long> receiverIds) {
         final String content = String.format(PUSH_ALBUM_DELETE_BODY, hostNickname, albumTitle);
 
         notificationRepository.bulkInsertAlbumDeleteNotifications(
@@ -39,13 +42,5 @@ public class NotificationServiceImpl implements NotificationService {
         }
 
         fcmService.sendGroupMessageAsync(tokens, PUSH_ALBUM_DELETE_TITLE, content);
-    }
-
-    private String getMemberNicknameById(Long senderId) {
-        return memberRepository.findNicknameById(senderId);
-    }
-
-    private String getAlbumTitleById(Long albumId) {
-        return albumRepository.findTitleById(albumId);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
@@ -15,7 +15,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     private static final String PUSH_ALBUM_DELETE_TITLE = "앨범 삭제 안내";
     private static final String PUSH_ALBUM_DELETE_BODY =
-            "%s님이 '%s' 앨범을 삭제하려고 합니다. 이미지를 백업한 후 앨범에서 나가주세요.";
+            "%s님이 %s 앨범을 삭제하려고 합니다. 이미지를 백업한 후 앨범에서 나가주세요.";
 
     private final FcmService fcmService;
     private final FcmTokenService fcmTokenService;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,46 @@
+package org.cherrypic.domain.notification.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.notification.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationServiceImpl implements NotificationService {
+
+    private static final String PUSH_ALBUM_DELETE_TITLE = "앨범 삭제 안내";
+    private static final String PUSH_ALBUM_DELETE_BODY =
+            "%s님이 '%s' 앨범을 삭제하려고 합니다. 이미지를 백업한 후 앨범에서 나가주세요.";
+
+    private final FcmService fcmService;
+
+    private final MemberRepository memberRepository;
+    private final AlbumRepository albumRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    public void sendAlbumDeleteNotification(Long albumId, Long senderId, List<Long> receiverIds) {
+        final String hostNickname = getMemberNicknameById(senderId);
+        final String albumTitle = getAlbumTitleById(albumId);
+
+        notificationRepository.bulkInsertAlbumDeleteNotifications(albumId, senderId);
+
+        fcmService.sendGroupMessageAsync(
+                List.of("FCM 토큰 저장 로직을 아직 구현하지 않아 임시로 남겨두겠습니다."),
+                PUSH_ALBUM_DELETE_TITLE,
+                String.format(PUSH_ALBUM_DELETE_BODY, hostNickname, albumTitle));
+    }
+
+    private String getMemberNicknameById(Long senderId) {
+        return memberRepository.findNicknameById(senderId);
+    }
+
+    private String getAlbumTitleById(Long albumId) {
+        return albumRepository.findTitleById(albumId);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
@@ -28,18 +28,17 @@ public class NotificationServiceImpl implements NotificationService {
     public void sendAlbumDeleteNotification(Long albumId, Long senderId, List<Long> receiverIds) {
         final String hostNickname = getMemberNicknameById(senderId);
         final String albumTitle = getAlbumTitleById(albumId);
+        final String content = String.format(PUSH_ALBUM_DELETE_BODY, hostNickname, albumTitle);
 
-        notificationRepository.bulkInsertAlbumDeleteNotifications(albumId, senderId);
+        notificationRepository.bulkInsertAlbumDeleteNotifications(
+                albumId, senderId, PUSH_ALBUM_DELETE_TITLE, content);
 
         List<String> tokens = fcmTokenService.getFcmTokens(receiverIds);
         if (tokens.isEmpty()) {
             return;
         }
 
-        fcmService.sendGroupMessageAsync(
-                tokens,
-                PUSH_ALBUM_DELETE_TITLE,
-                String.format(PUSH_ALBUM_DELETE_BODY, hostNickname, albumTitle));
+        fcmService.sendGroupMessageAsync(tokens, PUSH_ALBUM_DELETE_TITLE, content);
     }
 
     private String getMemberNicknameById(Long senderId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/service/NotificationServiceImpl.java
@@ -15,7 +15,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     private static final String PUSH_ALBUM_DELETE_TITLE = "앨범 삭제 안내";
     private static final String PUSH_ALBUM_DELETE_BODY =
-            "%s님이 %s 앨범을 삭제하려고 합니다. 이미지를 백업한 후 앨범에서 나가주세요.";
+            "%s님이 %s 앨범을 삭제하려고 합니다. 중요한 사진은 미리 다운로드받은 뒤 앨범에서 나가주세요.";
 
     private final FcmService fcmService;
     private final FcmTokenService fcmTokenService;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.participant.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.cherrypic.participant.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,9 +14,12 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     @Modifying(clearAutomatically = true)
     @Query(
             value =
-                    "UPDATE participant SET role = 'STANDARD' WHERE album_id = :albumId AND role = 'LIMITED'",
+                    "update participant set role = 'STANDARD' where album_id = :albumId and role = 'LIMITED'",
             nativeQuery = true)
     void bulkChangeLimitedToStandard(@Param("albumId") Long albumId);
 
-    boolean existsByAlbumIdAndMemberIdIsNot(Long AlbumId, Long memberId);
+    @Query(
+            "select p.member.id from Participant p where p.album.id = :albumId and p.member.id <> :memberId")
+    List<Long> findOtherParticipantMemberIds(
+            @Param("albumId") Long albumId, @Param("memberId") Long memberId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/async/AsyncConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/async/AsyncConfig.java
@@ -1,0 +1,8 @@
+package org.cherrypic.global.config.async;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/cherrypic-api/src/main/resources/application.yml
+++ b/cherrypic-api/src/main/resources/application.yml
@@ -12,3 +12,6 @@ management:
   endpoint:
     health:
       access: unrestricted
+
+fcm:
+  certification: ${FCM_CERTIFICATION:}

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -18,6 +18,7 @@ import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.event.AlbumDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.repository.AlbumRepository;
@@ -45,13 +46,17 @@ import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
+@RecordApplicationEvents
 class AlbumServiceTest extends IntegrationTest {
 
     @Autowired private RedisCleaner redisCleaner;
     @Autowired private TransactionUtil transactionUtil;
 
     @Autowired private AlbumService albumService;
+    @Autowired private ApplicationEvents applicationEvents;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private PaymentRepository paymentRepository;
@@ -60,7 +65,7 @@ class AlbumServiceTest extends IntegrationTest {
     @Autowired private InvitationCodeRepository invitationCodeRepository;
     @Autowired private EventRepository eventRepository;
 
-    @MockitoBean MemberUtil memberUtil;
+    @MockitoBean private MemberUtil memberUtil;
 
     @Nested
     class 앨범을_생성할_때 {
@@ -923,11 +928,16 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 다른_참가자가_남아있는_경우_예외가_발생한다() {
+        void 다른_참가자가_남아있는_경우_이벤트가_발행되고_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> albumService.deleteAlbum(3L))
                     .isInstanceOf(AlbumException.class)
                     .hasMessage(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST.getMessage());
+
+            var events = applicationEvents.stream(AlbumDeleteEvent.class).toList();
+            Assertions.assertAll(
+                    () -> assertThat(events).hasSize(1),
+                    () -> assertThat(events.getFirst().albumId()).isEqualTo(3L));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -2,8 +2,7 @@ package org.cherrypic.member.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,6 +14,10 @@ import org.cherrypic.member.enums.MemberRole;
 import org.cherrypic.member.enums.MemberStatus;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -85,6 +88,28 @@ class MemberControllerTest {
             perform.andExpect(status().isNoContent())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void FCM_토큰이_null_또는_공백이면_예외가_발생한다(String fcmToken) throws Exception {
+            // given
+            FcmTokenSaveRequest request = new FcmTokenSaveRequest(fcmToken);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/members/fcm-tokens")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("FCM Token은 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -1,11 +1,14 @@
 package org.cherrypic.member.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.member.controller.MemberController;
+import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.service.MemberService;
 import org.cherrypic.member.enums.MemberRole;
@@ -15,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -57,6 +62,29 @@ class MemberControllerTest {
                     .andExpect(jsonPath("$.data.profileImageUrl").value("testProfileImageUrl"))
                     .andExpect(jsonPath("$.data.status").value("NORMAL"))
                     .andExpect(jsonPath("$.data.role").value("USER"));
+        }
+    }
+
+    @Nested
+    class FCM_토큰_저장_요청_시 {
+
+        @Test
+        void 유효한_요청이면_FCM_토큰을_저장하고_NO_CONTENT로_반환한다() throws Exception {
+            // given
+            FcmTokenSaveRequest request = new FcmTokenSaveRequest("testFcmToken");
+
+            willDoNothing().given(memberService).saveFcmToken(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/members/fcm-tokens")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import org.cherrypic.IntegrationTest;
+import org.cherrypic.RedisCleaner;
+import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.member.service.MemberService;
@@ -12,13 +14,18 @@ import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.enums.MemberRole;
 import org.cherrypic.member.enums.MemberStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class MemberServiceTest extends IntegrationTest {
+
+    @Autowired private RedisCleaner redisCleaner;
+    @Autowired private StringRedisTemplate redisTemplate;
 
     @Autowired private MemberService memberService;
     @Autowired private MemberRepository memberRepository;
@@ -61,6 +68,43 @@ class MemberServiceTest extends IntegrationTest {
                             "testProfileImageUrl",
                             MemberRole.USER,
                             MemberStatus.NORMAL);
+        }
+    }
+
+    @Nested
+    class FCM_토큰을_저장할_때 {
+
+        @AfterEach
+        void cleanUp() {
+            redisCleaner.flushAll();
+        }
+
+        @Test
+        void 유효한_요청이면_토큰이_Redis_Set에_저장된다() {
+            // given
+            FcmTokenSaveRequest request = new FcmTokenSaveRequest("testFcmToken");
+
+            // when
+            memberService.saveFcmToken(request);
+
+            // then
+            assertThat(redisTemplate.opsForSet().members("fcmToken:1")).contains("testFcmToken");
+        }
+
+        @Test
+        void 여러_디바이스_토큰을_저장하면_모두_Redis_Set에_저장된다() {
+            // given
+            FcmTokenSaveRequest request1 = new FcmTokenSaveRequest("testFcmToken1");
+            FcmTokenSaveRequest request2 = new FcmTokenSaveRequest("testFcmToken2");
+
+            // when
+            memberService.saveFcmToken(request1);
+            memberService.saveFcmToken(request2);
+
+            // then
+            assertThat(redisTemplate.opsForSet().members("fcmToken:1"))
+                    .contains("testFcmToken1", "testFcmToken2");
+            assertThat(redisTemplate.opsForSet().size(("fcmToken:1"))).isEqualTo(2);
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
@@ -93,7 +93,8 @@ class NotificationServiceTest extends IntegrationTest {
             List<Long> receiverIds = List.of(2L, 3L);
 
             // when
-            notificationService.sendAlbumDeleteNotification(albumId, senderId, receiverIds);
+            notificationService.sendAlbumDeleteNotification(
+                    albumId, senderId, "hostNickname", "testAlbum", receiverIds);
 
             // then
             List<Notification> notifications = notificationRepository.findAll();

--- a/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
@@ -1,0 +1,117 @@
+package org.cherrypic.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.RedisCleaner;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.notification.repository.NotificationRepository;
+import org.cherrypic.domain.notification.service.FcmService;
+import org.cherrypic.domain.notification.service.NotificationService;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.notification.entity.Notification;
+import org.cherrypic.notification.enums.NotificationType;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class NotificationServiceTest extends IntegrationTest {
+
+    @Autowired private RedisCleaner redisCleaner;
+    @Autowired private StringRedisTemplate redisTemplate;
+
+    @Autowired private NotificationService notificationService;
+    @Autowired private NotificationRepository notificationRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private AlbumRepository albumRepository;
+    @Autowired private ParticipantRepository participantRepository;
+
+    @MockitoBean private MemberUtil memberUtil;
+    @MockitoBean private FcmService fcmService;
+
+    @Nested
+    class 앨범_삭제_푸시_알림을_보낼_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "hostNickname",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            Member member3 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId3", "testOauthProvider3"),
+                            "testNickname3",
+                            "testProfileImageUrl3");
+            memberRepository.saveAll(List.of(member1, member2, member3));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album = Album.createAlbum("testAlbum", "testURL", AlbumPlan.BASIC, false);
+            albumRepository.save(album);
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album, ParticipantRole.STANDARD);
+            Participant participant3 =
+                    Participant.createParticipant(member3, album, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            redisTemplate.opsForSet().add("fcmToken:2", "testFcmToken2");
+        }
+
+        @AfterEach
+        void cleanUp() {
+            redisCleaner.flushAll();
+        }
+
+        @Test
+        void 방장을_제외한_모든_참가자의_알림을_저장하고_FCM_토큰이_있는_참가자에게만_알림을_발송한다() {
+            // given
+            Long albumId = 1L;
+            Long senderId = 1L;
+            List<Long> receiverIds = List.of(2L, 3L);
+
+            // when
+            notificationService.sendAlbumDeleteNotification(albumId, senderId, receiverIds);
+
+            // then
+            List<Notification> notifications = notificationRepository.findAll();
+            assertThat(notifications)
+                    .extracting(
+                            n -> n.getReceiver().getId(),
+                            n -> n.getAlbum().getId(),
+                            n -> n.getSender().getId(),
+                            Notification::getType)
+                    .containsExactlyInAnyOrder(
+                            tuple(2L, 1L, 1L, NotificationType.ALBUM),
+                            tuple(3L, 1L, 1L, NotificationType.ALBUM));
+
+            verify(fcmService)
+                    .sendGroupMessageAsync(
+                            eq(List.of("testFcmToken2")),
+                            eq("앨범 삭제 안내"),
+                            eq("hostNickname님이 testAlbum 앨범을 삭제하려고 합니다. 이미지를 백업한 후 앨범에서 나가주세요."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
@@ -112,7 +112,8 @@ class NotificationServiceTest extends IntegrationTest {
                     .sendGroupMessageAsync(
                             eq(List.of("testFcmToken2")),
                             eq("앨범 삭제 안내"),
-                            eq("hostNickname님이 testAlbum 앨범을 삭제하려고 합니다. 이미지를 백업한 후 앨범에서 나가주세요."));
+                            eq(
+                                    "hostNickname님이 testAlbum 앨범을 삭제하려고 합니다. 중요한 사진은 미리 다운로드받은 뒤 앨범에서 나가주세요."));
         }
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -13,6 +13,7 @@ import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.image.entity.Image;
+import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.subscription.entity.Subscription;
@@ -40,6 +41,9 @@ public class Album extends BaseTimeEntity {
 
     @OneToOne(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private Subscription subscription;
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Notification> notifications = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Event> events = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/notification/entity/Notification.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/notification/entity/Notification.java
@@ -31,6 +31,10 @@ public class Notification extends BaseTimeEntity {
     @JoinColumn(name = "album_id")
     private Album album;
 
+    @NotNull private String title;
+
+    @NotNull private String content;
+
     @NotNull
     @Enumerated(EnumType.STRING)
     private NotificationType type;

--- a/cherrypic-domain/src/main/java/org/cherrypic/notification/entity/Notification.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/notification/entity/Notification.java
@@ -1,0 +1,37 @@
+package org.cherrypic.notification.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.common.model.BaseTimeEntity;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.notification.enums.NotificationType;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id")
+    private Member sender;
+
+    @ManyToOne
+    @JoinColumn(name = "receiver_id")
+    private Member receiver;
+
+    @ManyToOne
+    @JoinColumn(name = "album_id")
+    private Album album;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/notification/enums/NotificationType.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/notification/enums/NotificationType.java
@@ -1,0 +1,13 @@
+package org.cherrypic.notification.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+    ALBUM("앨범"),
+    ;
+
+    private final String value;
+}

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -108,6 +108,8 @@ CREATE TABLE notification (
                              sender_id BIGINT NOT NULL,
                              receiver_id BIGINT NOT NULL,
                              album_id BIGINT,
+                             title VARCHAR(30) NOT NULL,
+                             content VARCHAR(100) NOT NULL,
                              type VARCHAR(20) NOT NULL CHECK (type IN ('ALBUM')),
                              created_at DATETIME(6) NOT NULL,
                              updated_at DATETIME(6) NOT NULL,

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -101,3 +101,17 @@ CREATE TABLE participant (
                              CONSTRAINT fk_participant_member FOREIGN KEY (member_id) REFERENCES member (id),
                              CONSTRAINT fk_participant_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
+
+
+CREATE TABLE notification (
+                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                             sender_id BIGINT NOT NULL,
+                             receiver_id BIGINT NOT NULL,
+                             album_id BIGINT,
+                             type VARCHAR(20) NOT NULL CHECK (type IN ('ALBUM')),
+                             created_at DATETIME(6) NOT NULL,
+                             updated_at DATETIME(6) NOT NULL,
+                             CONSTRAINT fk_notification_sender FOREIGN KEY (sender_id) REFERENCES member (id),
+                             CONSTRAINT fk_notification_receiver FOREIGN KEY (receiver_id) REFERENCES member (id),
+                             CONSTRAINT fk_notification_album FOREIGN KEY (album_id) REFERENCES album (id)
+);

--- a/cherrypic-infrastructure/build.gradle
+++ b/cherrypic-infrastructure/build.gradle
@@ -18,4 +18,6 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 
 	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+
+	implementation 'com.google.firebase:firebase-admin:9.4.3'
 }

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/fcm/FcmConfig.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/fcm/FcmConfig.java
@@ -1,0 +1,38 @@
+package org.cherrypic.fcm;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.certification}")
+    private String fcmCertification;
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseOptions options =
+                        FirebaseOptions.builder()
+                                .setCredentials(
+                                        GoogleCredentials.fromStream(
+                                                new ByteArrayInputStream(
+                                                        fcmCertification.getBytes(
+                                                                StandardCharsets.UTF_8))))
+                                .build();
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (Exception e) {
+            log.error("FcmInitializationException: message={}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #104 

---
## 📌 작업 내용 및 특이사항
* FCM 토큰 등록 API를 구현했습니다.
  * 멀티 디바이스 환경 지원을 위해 Redis Set에 저장하여 중복을 제거하고 멱등성을 보장합니다.
  * 회원별 키로 관리하여 각 기기의 토큰을 함께 보관합니다.
  * 토큰 제거는 추후 알림 토글 변경 기능 반영하면서 추가할 예정입니다.
* FCM 초기화 설정을 추가했습니다. (서비스 계정 기반 FirebaseApp 구성)
* FCM 발송 서비스를 추가했습니다. (단일/그룹 비동기 전송)
* 알림 테이블을 추가했습니다. (발송과 별개로 알림 내역을 보관하여 사용자 알림 화면 조회가 가능하도록 했습니다.)
* 앨범 삭제 시 이벤트를 발행하도록 변경했습니다.
  * 삭제 시도 차단 로직과 알림 전송을 분리하고, 컨트롤러 응답 시간을 막지 않기 위함입니다.
* 이벤트 리스너 실행 전략을 다음과 같이 구성했습니다.
  * 비동기 처리: 요청/응답 흐름을 막지 않도록 별도 스레드에서 실행합니다.
  * 롤백 이후 실행: 삭제 차단이 트랜잭션 롤백으로 확정된 뒤에만 동작합니다.
  * 새 트랜잭션 사용: 알림 저장, 발송은 독립 트랜잭션으로 커밋되어 도메인 롤백의 영향(취소)을 받지 않습니다.
* 알림을 한 번에 저장하는 벌크 쿼리를 추가했습니다. (INSERT ... SELECT, 호스트 제외 모든 참가자 대상)
  * N회 INSERT 대신 한 번의 쿼리로 처리해 성능을 높였습니다.

---
## 📚 참고사항
* 앨범 삭제의 경우 30분마다 가능하도록 하여 동일한 알림이 반복 발송되고 내역에 중복 저장되는 상황을 방지할 예정이었습니다.  
* 다만, 동일한 알림이 이미 존재하는 경우 발송하지 않는 방식이 있어 추후 적용을 검토하겠습니다. (예: 동일 앨범·수신자·타입 조합이 일정 시간 내에 이미 존재하면 발송을 건너뛰도록 처리)