### PR TITLE
feat: 이벤트에 이미지 추가하기 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
-import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
+import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -58,10 +58,11 @@ public class EventController {
         return eventService.getAlbumEvents(albumId, lastEventId, size, direction);
     }
 
-    @PatchMapping("/include")
+    @PostMapping("/{eventId}/add-images")
     @Operation(summary = "이벤트에 이미지 추가", description = "앨범의 이미지를 이벤트로 추가합니다.")
-    public ResponseEntity<Void> eventInclude(@Valid @RequestBody EventIncludeRequest request) {
-        eventService.includeEvent(request);
+    public ResponseEntity<Void> imagesAdd(
+            @PathVariable Long eventId, @Valid @RequestBody EventImageAddRequest request) {
+        eventService.addImages(eventId, request);
         return ResponseEntity.noContent().build();
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -58,7 +58,7 @@ public class EventController {
         return eventService.getAlbumEvents(albumId, lastEventId, size, direction);
     }
 
-    @GetMapping
+    @PatchMapping("/include")
     @Operation(summary = "이벤트에 이미지 추가", description = "앨범의 이미지를 이벤트로 추가합니다.")
     public ResponseEntity<Void> eventInclude(@Valid @RequestBody EventIncludeRequest request) {
         eventService.includeEvent(request);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
+import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -55,6 +56,13 @@ public class EventController {
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
         return eventService.getAlbumEvents(albumId, lastEventId, size, direction);
+    }
+
+    @GetMapping
+    @Operation(summary = "이벤트에 이미지 추가", description = "앨범의 이미지를 이벤트로 추가합니다.")
+    public ResponseEntity<Void> eventInclude(@Valid @RequestBody EventIncludeRequest request) {
+        eventService.includeEvent(request);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{eventId}")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
@@ -2,13 +2,9 @@ package org.cherrypic.domain.event.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record EventIncludeRequest(
-        @NotNull(message = "이벤트 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이미지를 추가할 이벤트 ID", example = "1")
-                Long eventId,
+public record EventImageAddRequest(
         @NotEmpty(message = "추가할 이미지 ID는 비워둘 수 없습니다.")
                 @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "(1,2,3,4)")
                 List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public record EventImageAddRequest(
         @NotEmpty(message = "추가할 이미지 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "(1,2,3,4)")
+                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = " [1,2,3,4]")
                 List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public record EventImageAddRequest(
         @NotEmpty(message = "추가할 이미지 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = " [1,2,3,4]")
+                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "[1,2,3,4]")
                 List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventIncludeRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventIncludeRequest.java
@@ -1,0 +1,14 @@
+package org.cherrypic.domain.event.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record EventIncludeRequest(
+        @NotNull(message = "이벤트 ID는 비워둘 수 없습니다.")
+                @Schema(description = "이미지를 추가할 이벤트 ID", example = "1")
+                Long eventId,
+        @NotEmpty(message = "추가할 이미지 ID는 비워둘 수 없습니다.")
+                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "(1,2,3,4)")
+                List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.event.service;
 
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
-import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
+import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -19,5 +19,5 @@ public interface EventService {
 
     void deleteEvent(Long eventId);
 
-    void includeEvent(EventIncludeRequest request);
+    void addImages(Long eventId, EventImageAddRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
@@ -1,6 +1,7 @@
 package org.cherrypic.domain.event.service;
 
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
+import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -17,4 +18,6 @@ public interface EventService {
             Long albumId, Long lastEventId, int size, SortDirection direction);
 
     void deleteEvent(Long eventId);
+
+    void includeEvent(EventIncludeRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -101,8 +101,8 @@ public class EventServiceImpl implements EventService {
         final List<Image> images = getAllImagesById(request.imageIds());
 
         validateParticipantAuthority(currentMember, event.getAlbum());
-        validateImageEvent(images);
         validateImageAlbum(images, event);
+        validateImageEvent(images);
 
         List<String> keys =
                 images.stream().map(img -> img.getId() + ":" + img.getVersion()).toList();

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -152,15 +152,14 @@ public class EventServiceImpl implements EventService {
     }
 
     private void validateImageAlbum(List<Image> images, Event event) {
-        images.stream()
-                .filter(
-                        image ->
-                                !Objects.equals(image.getAlbum().getId(), event.getAlbum().getId()))
-                .findAny()
-                .ifPresent(
-                        img -> {
-                            throw new BaseCustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM);
-                        });
+        Long albumId = event.getAlbum().getId();
+        if (images.stream()
+                .anyMatch(
+                        img ->
+                                img.getAlbum() == null
+                                        || !Objects.equals(img.getAlbum().getId(), albumId))) {
+            throw new BaseCustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM);
+        }
     }
 
     private List<Image> getAllImagesById(List<Long> imageIds) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -100,7 +100,6 @@ public class EventServiceImpl implements EventService {
         final Event event = getEventById(eventId);
         final List<Image> images = getAllImagesById(request.imageIds());
 
-        validateImageConcurrency(images);
         validateParticipantAuthority(currentMember, event.getAlbum());
         validateImageEvent(images);
         validateImageAlbum(images, event);
@@ -170,15 +169,5 @@ public class EventServiceImpl implements EventService {
                 .filter(images -> images.size() == imageIds.size())
                 .orElseThrow(
                         () -> new BaseCustomException(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND));
-    }
-
-    private void validateImageConcurrency(List<Image> images) {
-        List<String> keys =
-                images.stream().map(img -> img.getId() + ":" + img.getVersion()).toList();
-
-        boolean allMatch = imageRepository.checkImageVersionByKeys(keys, keys.size());
-        if (!allMatch) {
-            throw new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_CONFLICT);
-        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -96,9 +96,11 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public void includeEvent(EventIncludeRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
         final Event event = getEventById(request.eventId());
         final List<Image> images = getAllImagesById(request.imageIds());
 
+        validateParticipantAuthority(currentMember, event.getAlbum());
         validateImageEvent(images);
         validateImageAlbum(images, event);
 
@@ -152,7 +154,7 @@ public class EventServiceImpl implements EventService {
                 .ifPresent(
                         img -> {
                             throw new BaseCustomException(
-                                    ImageErrorCode.SOME_IMAGES_NOT_FROM_ALBUM);
+                                    ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM);
                         });
     }
 
@@ -160,6 +162,6 @@ public class EventServiceImpl implements EventService {
         return Optional.of(imageRepository.findAllById(imageIds))
                 .filter(images -> images.size() == imageIds.size())
                 .orElseThrow(
-                        () -> new BaseCustomException(ImageErrorCode.SOME_IMAGES_WERE_NOT_FOUND));
+                        () -> new BaseCustomException(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -107,8 +107,8 @@ public class EventServiceImpl implements EventService {
         List<String> keys =
                 images.stream().map(img -> img.getId() + ":" + img.getVersion()).toList();
 
-        int updated = imageRepository.bulkChangeImageEventWithVersionCheck(keys, eventId);
-        if (updated != request.imageIds().size()) {
+        int updatedImages = imageRepository.bulkChangeImageEventWithVersionCheck(keys, eventId);
+        if (updatedImages != request.imageIds().size()) {
             throw new BaseCustomException(ImageErrorCode.CONFLICTING_IMAGES);
         }
     }
@@ -142,13 +142,9 @@ public class EventServiceImpl implements EventService {
     }
 
     private void validateImageEvent(List<Image> images) {
-        images.stream()
-                .filter(image -> image.getEvent() != null)
-                .findAny()
-                .ifPresent(
-                        img -> {
-                            throw new BaseCustomException(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT);
-                        });
+        if (images.stream().anyMatch(img -> img.getEvent() != null)) {
+            throw new BaseCustomException(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT);
+        }
     }
 
     private void validateImageAlbum(List<Image> images, Event event) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -105,7 +105,10 @@ public class EventServiceImpl implements EventService {
         validateImageEvent(images);
         validateImageAlbum(images, event);
 
-        int updated = imageRepository.bulkChangeImageEvent(request.imageIds(), eventId);
+        List<String> keys =
+                images.stream().map(img -> img.getId() + ":" + img.getVersion()).toList();
+
+        int updated = imageRepository.bulkChangeImageEventWithVersionCheck(keys, eventId);
         if (updated != request.imageIds().size()) {
             throw new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_CONFLICT);
         }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -9,7 +9,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
-import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
+import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -95,16 +95,16 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
-    public void includeEvent(EventIncludeRequest request) {
+    public void addImages(Long eventId, EventImageAddRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Event event = getEventById(request.eventId());
+        final Event event = getEventById(eventId);
         final List<Image> images = getAllImagesById(request.imageIds());
 
         validateParticipantAuthority(currentMember, event.getAlbum());
         validateImageEvent(images);
         validateImageAlbum(images, event);
 
-        imageRepository.bulkChangeImageEvent(request.imageIds(), request.eventId());
+        imageRepository.bulkChangeImageEvent(request.imageIds(), eventId);
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -100,11 +100,15 @@ public class EventServiceImpl implements EventService {
         final Event event = getEventById(eventId);
         final List<Image> images = getAllImagesById(request.imageIds());
 
+        validateImageConcurrency(images);
         validateParticipantAuthority(currentMember, event.getAlbum());
         validateImageEvent(images);
         validateImageAlbum(images, event);
 
-        imageRepository.bulkChangeImageEvent(request.imageIds(), eventId);
+        int updated = imageRepository.bulkChangeImageEvent(request.imageIds(), eventId);
+        if (updated != request.imageIds().size()) {
+            throw new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_CONFLICT);
+        }
     }
 
     private Album getAlbumById(Long albumId) {
@@ -163,5 +167,15 @@ public class EventServiceImpl implements EventService {
                 .filter(images -> images.size() == imageIds.size())
                 .orElseThrow(
                         () -> new BaseCustomException(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND));
+    }
+
+    private void validateImageConcurrency(List<Image> images) {
+        List<String> keys =
+                images.stream().map(img -> img.getId() + ":" + img.getVersion()).toList();
+
+        boolean allMatch = imageRepository.checkImageVersionByKeys(keys, keys.size());
+        if (!allMatch) {
+            throw new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_CONFLICT);
+        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -109,7 +109,7 @@ public class EventServiceImpl implements EventService {
 
         int updated = imageRepository.bulkChangeImageEventWithVersionCheck(keys, eventId);
         if (updated != request.imageIds().size()) {
-            throw new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_CONFLICT);
+            throw new BaseCustomException(ImageErrorCode.CONFLICTING_IMAGES);
         }
     }
 
@@ -147,7 +147,7 @@ public class EventServiceImpl implements EventService {
                 .findAny()
                 .ifPresent(
                         img -> {
-                            throw new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_EVENT);
+                            throw new BaseCustomException(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT);
                         });
     }
 
@@ -159,15 +159,13 @@ public class EventServiceImpl implements EventService {
                 .findAny()
                 .ifPresent(
                         img -> {
-                            throw new BaseCustomException(
-                                    ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM);
+                            throw new BaseCustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM);
                         });
     }
 
     private List<Image> getAllImagesById(List<Long> imageIds) {
         return Optional.of(imageRepository.findAllById(imageIds))
                 .filter(images -> images.size() == imageIds.size())
-                .orElseThrow(
-                        () -> new BaseCustomException(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND));
+                .orElseThrow(() -> new BaseCustomException(ImageErrorCode.IMAGES_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -1,11 +1,15 @@
 package org.cherrypic.domain.event.service;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.exception.AlbumException;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
+import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -13,11 +17,15 @@ import org.cherrypic.domain.event.dto.response.EventUpdateResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.repository.EventRepository;
+import org.cherrypic.domain.image.exception.ImageErrorCode;
+import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.exception.BaseCustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
@@ -35,6 +43,7 @@ public class EventServiceImpl implements EventService {
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
     private final EventRepository eventRepository;
+    private final ImageRepository imageRepository;
 
     @Override
     public EventCreateResponse createEvent(EventCreateRequest request) {
@@ -85,6 +94,17 @@ public class EventServiceImpl implements EventService {
         eventRepository.delete(event);
     }
 
+    @Override
+    public void includeEvent(EventIncludeRequest request) {
+        final Event event = getEventById(request.eventId());
+        final List<Image> images = getAllImagesById(request.imageIds());
+
+        validateImageEvent(images);
+        validateImageAlbum(images, event);
+
+        imageRepository.bulkChangeImageEvent(request.imageIds(), request.eventId());
+    }
+
     private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)
@@ -111,5 +131,35 @@ public class EventServiceImpl implements EventService {
         if (isLimited) {
             throw new EventException(AlbumErrorCode.LIMITED_AUTHORITY);
         }
+    }
+
+    private void validateImageEvent(List<Image> images) {
+        images.stream()
+                .filter(image -> image.getEvent() != null)
+                .findAny()
+                .ifPresent(
+                        img -> {
+                            throw new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_EVENT);
+                        });
+    }
+
+    private void validateImageAlbum(List<Image> images, Event event) {
+        images.stream()
+                .filter(
+                        image ->
+                                !Objects.equals(image.getAlbum().getId(), event.getAlbum().getId()))
+                .findAny()
+                .ifPresent(
+                        img -> {
+                            throw new BaseCustomException(
+                                    ImageErrorCode.SOME_IMAGES_NOT_FROM_ALBUM);
+                        });
+    }
+
+    private List<Image> getAllImagesById(List<Long> imageIds) {
+        return Optional.of(imageRepository.findAllById(imageIds))
+                .filter(images -> images.size() == imageIds.size())
+                .orElseThrow(
+                        () -> new BaseCustomException(ImageErrorCode.SOME_IMAGES_WERE_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -164,8 +164,11 @@ public class EventServiceImpl implements EventService {
     }
 
     private List<Image> getAllImagesById(List<Long> imageIds) {
-        return Optional.of(imageRepository.findAllById(imageIds))
-                .filter(images -> images.size() == imageIds.size())
+
+        List<Long> distinctIds = imageIds.stream().filter(Objects::nonNull).distinct().toList();
+
+        return Optional.of(imageRepository.findAllById(distinctIds))
+                .filter(list -> list.size() == distinctIds.size())
                 .orElseThrow(() -> new BaseCustomException(ImageErrorCode.IMAGES_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -1,0 +1,16 @@
+package org.cherrypic.domain.image.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum ImageErrorCode implements BaseErrorCode {
+    SOME_IMAGES_WERE_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
+    SOME_IMAGES_HAS_EVENT(400, "이미 이벤트에 소속된 이미지를 포함하고 있습니다."),
+    SOME_IMAGES_NOT_FROM_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -9,7 +9,8 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum ImageErrorCode implements BaseErrorCode {
     SOME_IMAGES_ARE_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
     SOME_IMAGES_HAS_EVENT(400, "이미 이벤트에 소속된 이미지를 포함하고 있습니다."),
-    SOME_IMAGES_NOT_FROM_CURRENT_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다.");
+    SOME_IMAGES_NOT_FROM_CURRENT_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
+    SOME_IMAGES_HAS_CONFLICT(409, "다른 요청에서 조작된 이미지를 포함하고 있습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -7,9 +7,9 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum ImageErrorCode implements BaseErrorCode {
-    SOME_IMAGES_WERE_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
+    SOME_IMAGES_ARE_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
     SOME_IMAGES_HAS_EVENT(400, "이미 이벤트에 소속된 이미지를 포함하고 있습니다."),
-    SOME_IMAGES_NOT_FROM_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다.");
+    SOME_IMAGES_NOT_FROM_CURRENT_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -7,10 +7,10 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum ImageErrorCode implements BaseErrorCode {
-    SOME_IMAGES_ARE_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
-    SOME_IMAGES_HAS_EVENT(400, "이미 이벤트에 소속된 이미지를 포함하고 있습니다."),
-    SOME_IMAGES_NOT_FROM_CURRENT_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
-    SOME_IMAGES_HAS_CONFLICT(409, "다른 요청에서 조작된 이미지를 포함하고 있습니다.");
+    IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
+    IMAGES_ASSIGNED_TO_EVENT(400, "이미 이벤트에 소속된 이미지를 포함하고 있습니다."),
+    IMAGES_FROM_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
+    CONFLICTING_IMAGES(409, "다른 요청에서 조작된 이미지를 포함하고 있습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -6,25 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
     List<Image> findAllById(Iterable<Long> imageIds);
 
-    @Query(
-            """
-    select case
-             when count(i) = :expectedSize then true
-             else false
-           end
-    from Image i
-    where function('concat', i.id, ':', i.version) in :keys
-    """)
-    boolean checkImageVersionByKeys(
-            @Param("keys") List<String> keys, @Param("expectedSize") long expectedSize);
-
-    @Transactional
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query(
             value =
                     """

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -6,19 +6,36 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
     List<Image> findAllById(Iterable<Long> imageIds);
 
+    @Query(
+            """
+    select case
+             when count(i) = :expectedSize then true
+             else false
+           end
+    from Image i
+    where function('concat', i.id, ':', i.version) in :keys
+    """)
+    boolean checkImageVersionByKeys(
+            @Param("keys") List<String> keys, @Param("expectedSize") long expectedSize);
+
+    @Transactional
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
             value =
                     """
-            UPDATE image
-               SET event_id = :eventId
-             WHERE id IN (:imageIds)
-            """,
+      UPDATE image
+         SET event_id   = :eventId,
+             version    = version + 1,
+             updated_at = CURRENT_TIMESTAMP(6)
+       WHERE id IN (:imageIds)
+       AND (event_id IS NULL OR event_id = :eventId)
+    """,
             nativeQuery = true)
-    void bulkChangeImageEvent(
+    int bulkChangeImageEvent(
             @Param("imageIds") List<Long> imageIds, @Param("eventId") Long eventId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -32,10 +32,10 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
          SET event_id   = :eventId,
              version    = version + 1,
              updated_at = CURRENT_TIMESTAMP(6)
-       WHERE id IN (:imageIds)
-       AND (event_id IS NULL OR event_id = :eventId)
+       WHERE CONCAT(id, ':', version) IN (:keys)
+         AND (event_id IS NULL OR event_id = :eventId)
     """,
             nativeQuery = true)
-    int bulkChangeImageEvent(
-            @Param("imageIds") List<Long> imageIds, @Param("eventId") Long eventId);
+    int bulkChangeImageEventWithVersionCheck(
+            @Param("keys") List<String> keys, @Param("eventId") Long eventId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -1,6 +1,24 @@
 package org.cherrypic.domain.image.repository;
 
+import java.util.List;
 import org.cherrypic.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {}
+public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
+    List<Image> findAllById(Iterable<Long> imageIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            value =
+                    """
+            UPDATE image
+               SET event_id = :eventId
+             WHERE id IN (:imageIds)
+            """,
+            nativeQuery = true)
+    void bulkChangeImageEvent(
+            @Param("imageIds") List<Long> imageIds, @Param("eventId") Long eventId);
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -623,7 +623,7 @@ public class EventControllerTest {
             perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_ARE_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.code").value("IMAGES_NOT_FOUND"))
                     .andExpect(jsonPath("$.data.message").value("존재하지 않는 이미지를 포함하고 있습니다."));
         }
 
@@ -667,7 +667,7 @@ public class EventControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_HAS_EVENT"))
+                    .andExpect(jsonPath("$.data.code").value("IMAGES_ASSIGNED_TO_EVENT"))
                     .andExpect(jsonPath("$.data.message").value("이미 이벤트에 소속된 이미지를 포함하고 있습니다."));
         }
 
@@ -689,7 +689,7 @@ public class EventControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_NOT_FROM_CURRENT_ALBUM"))
+                    .andExpect(jsonPath("$.data.code").value("IMAGES_FROM_OTHER_ALBUM"))
                     .andExpect(jsonPath("$.data.message").value("앨범 소속이 아닌 이미지를 포함하고 있습니다."));
         }
 
@@ -730,7 +730,7 @@ public class EventControllerTest {
             perform.andExpect(status().isConflict())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
-                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_HAS_CONFLICT"))
+                    .andExpect(jsonPath("$.data.code").value("CONFLICTING_IMAGES"))
                     .andExpect(jsonPath("$.data.message").value("다른 요청에서 조작된 이미지를 포함하고 있습니다."));
         }
     }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.controller.EventController;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
-import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
+import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -568,13 +568,13 @@ public class EventControllerTest {
         @Test
         void 유효한_요청이면_이벤트에_이미지를_추가하고_NO_CONTENT_로_반환한다() throws Exception {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
-            willDoNothing().given(eventService).includeEvent(request);
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
+            willDoNothing().given(eventService).addImages(1L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/events/include")
+                            post("/events/1/add-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -586,15 +586,15 @@ public class EventControllerTest {
         @Test
         void 존재하지_않는_이벤트에_추가하면_예외가_발생한다() throws Exception {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
             willThrow(new EventException(EventErrorCode.EVENT_NOT_FOUND))
                     .given(eventService)
-                    .includeEvent(request);
+                    .addImages(1L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/events/include")
+                            post("/events/1/add-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -608,15 +608,15 @@ public class EventControllerTest {
         @Test
         void 존재하지_않는_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(999L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(999L));
             willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND))
                     .given(eventService)
-                    .includeEvent(request);
+                    .addImages(1L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/events/include")
+                            post("/events/1/add-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -630,15 +630,15 @@ public class EventControllerTest {
         @Test
         void LIMITED_권한의_사용자가_이벤트에_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
             willThrow(new EventException(AlbumErrorCode.LIMITED_AUTHORITY))
                     .given(eventService)
-                    .includeEvent(request);
+                    .addImages(1L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/events/include")
+                            post("/events/1/add-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -652,15 +652,15 @@ public class EventControllerTest {
         @Test
         void 이미_이벤트에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
             willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_EVENT))
                     .given(eventService)
-                    .includeEvent(request);
+                    .addImages(1L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/events/include")
+                            post("/events/1/add-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -674,15 +674,15 @@ public class EventControllerTest {
         @Test
         void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
             willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM))
                     .given(eventService)
-                    .includeEvent(request);
+                    .addImages(1L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/events/include")
+                            post("/events/1/add-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -694,33 +694,14 @@ public class EventControllerTest {
         }
 
         @Test
-        void 이벤트_ID를_입력하지_않은_경우_예외가_발생한다() throws Exception {
-            // given
-            EventIncludeRequest request = new EventIncludeRequest(null, List.of(1L));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            patch("/events/include")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("이벤트 ID는 비워둘 수 없습니다."));
-        }
-
-        @Test
         void 추가할_이미지를_입력하지_않은_경우_예외가_발생한다() throws Exception {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of());
+            EventImageAddRequest request = new EventImageAddRequest(List.of());
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/events/include")
+                            post("/events/1/add-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -711,5 +711,27 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("추가할 이미지 ID는 비워둘 수 없습니다."));
         }
+
+        @Test
+        void 앨범에_이미지를_추가하던_와중_다른_사람이_해당_이미지를_조작하면_예외가_발생한다() throws Exception {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
+            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_CONFLICT))
+                    .given(eventService)
+                    .addImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/add-images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
+                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_HAS_CONFLICT"))
+                    .andExpect(jsonPath("$.data.message").value("다른 요청에서 조작된 이미지를 포함하고 있습니다."));
+        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.controller.EventController;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
+import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -19,6 +20,8 @@ import org.cherrypic.domain.event.dto.response.EventUpdateResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.service.EventService;
+import org.cherrypic.domain.image.exception.ImageErrorCode;
+import org.cherrypic.exception.BaseCustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.junit.jupiter.api.Nested;
@@ -556,6 +559,176 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
                     .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 이벤트_이미지_추가_요청_시 {
+
+        @Test
+        void 유효한_요청이면_이벤트에_이미지를_추가하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            willDoNothing().given(eventService).includeEvent(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 존재하지_않는_이벤트에_추가하면_예외가_발생한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            willThrow(new EventException(EventErrorCode.EVENT_NOT_FOUND))
+                    .given(eventService)
+                    .includeEvent(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
+        }
+
+        @Test
+        void 존재하지_않는_이미지를_추가하면_예외가_발생한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(999L));
+            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND))
+                    .given(eventService)
+                    .includeEvent(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_ARE_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("존재하지 않는 이미지를 포함하고 있습니다."));
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_이벤트에_이미지를_추가하면_예외가_발생한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            willThrow(new EventException(AlbumErrorCode.LIMITED_AUTHORITY))
+                    .given(eventService)
+                    .includeEvent(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Test
+        void 이미_이벤트에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_EVENT))
+                    .given(eventService)
+                    .includeEvent(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_HAS_EVENT"))
+                    .andExpect(jsonPath("$.data.message").value("이미 이벤트에 소속된 이미지를 포함하고 있습니다."));
+        }
+
+        @Test
+        void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L));
+            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM))
+                    .given(eventService)
+                    .includeEvent(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("SOME_IMAGES_NOT_FROM_CURRENT_ALBUM"))
+                    .andExpect(jsonPath("$.data.message").value("앨범 소속이 아닌 이미지를 포함하고 있습니다."));
+        }
+
+        @Test
+        void 이벤트_ID를_입력하지_않은_경우_예외가_발생한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(null, List.of(1L));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이벤트 ID는 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 추가할_이미지를_입력하지_않은_경우_예외가_발생한다() throws Exception {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of());
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/include")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("추가할 이미지 ID는 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -694,25 +694,6 @@ public class EventControllerTest {
         }
 
         @Test
-        void 추가할_이미지를_입력하지_않은_경우_예외가_발생한다() throws Exception {
-            // given
-            EventImageAddRequest request = new EventImageAddRequest(List.of());
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/events/1/add-images")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("추가할 이미지 ID는 비워둘 수 없습니다."));
-        }
-
-        @Test
         void 앨범에_이미지를_추가하던_와중_다른_사람이_해당_이미지를_조작하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
@@ -732,6 +713,27 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
                     .andExpect(jsonPath("$.data.code").value("CONFLICTING_IMAGES"))
                     .andExpect(jsonPath("$.data.message").value("다른 요청에서 조작된 이미지를 포함하고 있습니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        void 추가할_이미지를_입력하지_않은_경우_예외가_발생한다(List<Long> input) throws Exception {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(input);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/add-images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("추가할 이미지 ID는 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -609,7 +609,7 @@ public class EventControllerTest {
         void 존재하지_않는_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(999L));
-            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND))
+            willThrow(new BaseCustomException(ImageErrorCode.IMAGES_NOT_FOUND))
                     .given(eventService)
                     .addImages(1L, request);
 
@@ -653,7 +653,7 @@ public class EventControllerTest {
         void 이미_이벤트에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
-            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_EVENT))
+            willThrow(new BaseCustomException(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT))
                     .given(eventService)
                     .addImages(1L, request);
 
@@ -675,7 +675,7 @@ public class EventControllerTest {
         void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
-            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM))
+            willThrow(new BaseCustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM))
                     .given(eventService)
                     .addImages(1L, request);
 
@@ -716,7 +716,7 @@ public class EventControllerTest {
         void 앨범에_이미지를_추가하던_와중_다른_사람이_해당_이미지를_조작하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
-            willThrow(new BaseCustomException(ImageErrorCode.SOME_IMAGES_HAS_CONFLICT))
+            willThrow(new BaseCustomException(ImageErrorCode.CONFLICTING_IMAGES))
                     .given(eventService)
                     .addImages(1L, request);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -514,5 +514,37 @@ public class EventServiceTest extends IntegrationTest {
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM.getMessage());
         }
+
+        @Test
+        void 앨범에_이미지를_추가하던_와중_다른_사람이_해당_이미지를_조작하면_예외가_발생한다() throws Exception {
+            // given:
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
+
+            var barrier = new java.util.concurrent.CyclicBarrier(2);
+            var es = java.util.concurrent.Executors.newFixedThreadPool(2);
+
+            // when & then
+            var f1 =
+                    es.submit(
+                            () -> {
+                                barrier.await();
+                                imageRepository.bulkChangeImageEvent(List.of(4L), 2L);
+                                return null;
+                            });
+
+            var f2 =
+                    es.submit(
+                            () -> {
+                                barrier.await();
+                                f1.get();
+
+                                assertThatThrownBy(() -> eventService.addImages(1L, request))
+                                        .isInstanceOf(BaseCustomException.class)
+                                        .hasMessage(
+                                                ImageErrorCode.SOME_IMAGES_HAS_CONFLICT
+                                                        .getMessage());
+                                return null;
+                            });
+        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -11,7 +11,7 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
-import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
+import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -450,10 +450,10 @@ public class EventServiceTest extends IntegrationTest {
         @Test
         void 유효한_요청이면_이벤트에_이미지를_추가한다() {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L, 4L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
 
             // when
-            eventService.includeEvent(request);
+            eventService.addImages(1L, request);
 
             // then
             List<Image> images = imageRepository.findAllById(List.of(1L, 4L));
@@ -463,10 +463,10 @@ public class EventServiceTest extends IntegrationTest {
         @Test
         void 존재하지_않는_이벤트에_추가하면_예외가_발생한다() {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(999L, List.of(1L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
 
             // when & then
-            assertThatThrownBy(() -> eventService.includeEvent(request))
+            assertThatThrownBy(() -> eventService.addImages(999L, request))
                     .isInstanceOf(EventException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
         }
@@ -474,10 +474,10 @@ public class EventServiceTest extends IntegrationTest {
         @Test
         void 존재하지_않는_이미지를_추가하면_예외가_발생한다() {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L, 999L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 999L));
 
             // when & then
-            assertThatThrownBy(() -> eventService.includeEvent(request))
+            assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND.getMessage());
         }
@@ -485,10 +485,10 @@ public class EventServiceTest extends IntegrationTest {
         @Test
         void LIMITED_권한의_사용자가_이벤트에_이미지를_추가하면_예외가_발생한다() {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(2L, List.of(3L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(3L));
 
             // when & then
-            assertThatThrownBy(() -> eventService.includeEvent(request))
+            assertThatThrownBy(() -> eventService.addImages(2L, request))
                     .isInstanceOf(EventException.class)
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
@@ -496,10 +496,10 @@ public class EventServiceTest extends IntegrationTest {
         @Test
         void 이미_이벤트에_속한_이미지를_추가하면_예외가_발생한다() {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(2L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(2L));
 
             // when & then
-            assertThatThrownBy(() -> eventService.includeEvent(request))
+            assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(ImageErrorCode.SOME_IMAGES_HAS_EVENT.getMessage());
         }
@@ -507,10 +507,10 @@ public class EventServiceTest extends IntegrationTest {
         @Test
         void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() {
             // given
-            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(3L));
+            EventImageAddRequest request = new EventImageAddRequest(List.of(3L));
 
             // when & then
-            assertThatThrownBy(() -> eventService.includeEvent(request))
+            assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -11,16 +11,19 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
+import org.cherrypic.domain.event.dto.request.EventIncludeRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.exception.EventException;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.event.service.EventService;
+import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.exception.BaseCustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
@@ -407,6 +410,95 @@ public class EventServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(response.content().size()).isZero(),
                     () -> assertThat(response.isLast()).isTrue());
+        }
+    }
+
+    @Nested
+    class 이벤트에_이미지를_추가할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+
+            Event event1 = Event.createEvent(album1, "testTitle1", "testCoverUrl1");
+            Event event2 = Event.createEvent(album2, "testTitle2", "testCoverUrl2");
+            eventRepository.saveAll(List.of(event1, event2));
+
+            Image image1 = Image.createImage(album1, null, 1L, "testUrl", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, event1, 1L, "testUrl2", LocalDateTime.now());
+            Image image3 = Image.createImage(album2, null, 1L, "testUrl2", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3));
+        }
+
+        @Test
+        void 존재하지_않는_앨범에_추가하면_예외가_발생한다() {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(999L, List.of(1L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.includeEvent(request))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 존재하지_않는_이미지를_추가하면_예외가_발생한다() {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L, 999L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.includeEvent(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_이벤트에_이미지를_추가하면_예외가_발생한다() {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(2L, List.of(3L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.includeEvent(request))
+                    .isInstanceOf(EventException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 다른_이벤트에_속한_이미지를_추가하면_예외가_발생한다() {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(2L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.includeEvent(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(ImageErrorCode.SOME_IMAGES_HAS_EVENT.getMessage());
+        }
+
+        @Test
+        void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(3L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.includeEvent(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -442,12 +442,26 @@ public class EventServiceTest extends IntegrationTest {
 
             Image image1 = Image.createImage(album1, null, 1L, "testUrl", LocalDateTime.now());
             Image image2 = Image.createImage(album1, event1, 1L, "testUrl2", LocalDateTime.now());
-            Image image3 = Image.createImage(album2, null, 1L, "testUrl2", LocalDateTime.now());
-            imageRepository.saveAll(List.of(image1, image2, image3));
+            Image image3 = Image.createImage(album2, null, 1L, "testUrl3", LocalDateTime.now());
+            Image image4 = Image.createImage(album1, null, 1L, "testUrl4", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3, image4));
         }
 
         @Test
-        void 존재하지_않는_앨범에_추가하면_예외가_발생한다() {
+        void 유효한_요청이면_이벤트에_이미지를_추가한다() {
+            // given
+            EventIncludeRequest request = new EventIncludeRequest(1L, List.of(1L, 4L));
+
+            // when
+            eventService.includeEvent(request);
+
+            // then
+            List<Image> images = imageRepository.findAllById(List.of(1L, 4L));
+            assertThat(images).extracting("event.id").containsExactly(1L, 1L);
+        }
+
+        @Test
+        void 존재하지_않는_이벤트에_추가하면_예외가_발생한다() {
             // given
             EventIncludeRequest request = new EventIncludeRequest(999L, List.of(1L));
 
@@ -480,7 +494,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 다른_이벤트에_속한_이미지를_추가하면_예외가_발생한다() {
+        void 이미_이벤트에_속한_이미지를_추가하면_예외가_발생한다() {
             // given
             EventIncludeRequest request = new EventIncludeRequest(1L, List.of(2L));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -479,7 +479,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ImageErrorCode.SOME_IMAGES_ARE_NOT_FOUND.getMessage());
+                    .hasMessage(ImageErrorCode.IMAGES_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -501,7 +501,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ImageErrorCode.SOME_IMAGES_HAS_EVENT.getMessage());
+                    .hasMessage(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT.getMessage());
         }
 
         @Test
@@ -512,7 +512,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ImageErrorCode.SOME_IMAGES_NOT_FROM_CURRENT_ALBUM.getMessage());
+                    .hasMessage(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM.getMessage());
         }
 
         @Test
@@ -541,9 +541,7 @@ public class EventServiceTest extends IntegrationTest {
 
                                 assertThatThrownBy(() -> eventService.addImages(1L, request))
                                         .isInstanceOf(BaseCustomException.class)
-                                        .hasMessage(
-                                                ImageErrorCode.SOME_IMAGES_HAS_CONFLICT
-                                                        .getMessage());
+                                        .hasMessage(ImageErrorCode.CONFLICTING_IMAGES.getMessage());
                                 return null;
                             });
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -528,7 +528,8 @@ public class EventServiceTest extends IntegrationTest {
                     es.submit(
                             () -> {
                                 barrier.await();
-                                imageRepository.bulkChangeImageEvent(List.of(4L), 2L);
+                                imageRepository.bulkChangeImageEventWithVersionCheck(
+                                        List.of("1:1"), 2L);
                                 return null;
                             });
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -34,6 +34,10 @@ public class Image extends BaseTimeEntity {
 
     private LocalDateTime generatedAt;
 
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Image(Album album, Event event, Long memberId, String url, LocalDateTime generatedAt) {
         this.album = album;

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -34,9 +34,7 @@ public class Image extends BaseTimeEntity {
 
     private LocalDateTime generatedAt;
 
-    @Version
-    @Column(name = "version", nullable = false)
-    private long version;
+    @Version @NotNull private long version;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Image(Album album, Event event, Long memberId, String url, LocalDateTime generatedAt) {

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -73,6 +73,7 @@ CREATE TABLE image (
                        event_id BIGINT,
                        url VARCHAR(255) NOT NULL,
                        generated_at DATETIME,
+                       version BIGINT NOT NULL DEFAULT 0,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,
                        CONSTRAINT fk_image_album FOREIGN KEY (album_id) REFERENCES album (id),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #108 

---
## 📌 작업 내용 및 특이사항
- 이벤트에 이미지를 추가하는 API를 구현했습니다.
- 일괄적으로 필드를 바꾸는 것이기 때문에 이미지 개수에 대한 제한은 주지 않았습니다.
- 이미 생성된 이벤트에 이미지를 추가하는 흐름으로 구현되었습니다.
- 낙관적락을 적용해서 동시성 문제를 제어했습니다
- bulk update와 함께 사용하기 위해 bulk update 로직에서 개수와 version을 체크합니다.

---
## 📚 참고사항
- BaseCustomException으로 리팩토링 되는 것을 고려해 구현했습니다.