### PR TITLE
feat: 앨범 나가기 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -23,6 +23,8 @@ public enum AlbumErrorCode implements BaseErrorCode {
 
     OTHER_PARTICIPANTS_EXIST(400, "다른 참가자가 남아 있어 앨범을 삭제할 수 없습니다."),
     SUBSCRIPTION_ACTIVE(400, "구독 중인 앨범은 삭제할 수 없습니다."),
+
+    HOST_LEAVE_NOT_ALLOWED(403, "방장은 앨범을 나갈 수 없습니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
@@ -1,0 +1,27 @@
+package org.cherrypic.domain.participant.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.participant.service.ParticipantService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/albums/{albumId}/participants")
+@RequiredArgsConstructor
+@Tag(name = "6. 참가자 API", description = "앨범의 참가자 관련 API입니다.")
+public class ParticipantController {
+
+    private final ParticipantService participantService;
+
+    @DeleteMapping("/me")
+    @Operation(summary = "앨범 나가기", description = "앨범에서 나갑니다.")
+    public ResponseEntity<Void> albumLeave(@PathVariable Long albumId) {
+        participantService.leaveAlbum(albumId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
@@ -1,0 +1,5 @@
+package org.cherrypic.domain.participant.service;
+
+public interface ParticipantService {
+    void leaveAlbum(Long albumId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -1,0 +1,56 @@
+package org.cherrypic.domain.participant.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ParticipantServiceImpl implements ParticipantService {
+
+    private final MemberUtil memberUtil;
+
+    private final ParticipantRepository participantRepository;
+    private final AlbumRepository albumRepository;
+
+    @Override
+    public void leaveAlbum(Long albumId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        final Participant participant =
+                getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
+
+        validateNotAlbumHost(participant);
+
+        participantRepository.delete(participant);
+    }
+
+    private Album getAlbumById(Long albumId) {
+        return albumRepository
+                .findById(albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+
+    private Participant getParticipantByMemberIdAndAlbumId(Long memberId, Long albumId) {
+        return participantRepository
+                .findByMemberIdAndAlbumId(memberId, albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
+    private void validateNotAlbumHost(Participant participant) {
+        if (participant.getRole() == ParticipantRole.HOST) {
+            throw new CustomException(AlbumErrorCode.HOST_LEAVE_NOT_ALLOWED);
+        }
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -10,6 +10,7 @@ import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +34,10 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         validateNotAlbumHost(participant);
 
-        participantRepository.delete(participant);
+        try {
+            participantRepository.delete(participant);
+        } catch (ObjectOptimisticLockingFailureException ignored) {
+        }
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -1,0 +1,100 @@
+package org.cherrypic.participant.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.domain.album.dto.response.*;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.participant.controller.ParticipantController;
+import org.cherrypic.domain.participant.service.ParticipantService;
+import org.cherrypic.exception.CustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(ParticipantController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ParticipantControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private ParticipantService participantService;
+
+    @Nested
+    class 앨범을_나가기_요청_시 {
+
+        @Test
+        void 유효한_요청이면_참가자를_앨범에서_삭제하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            willDoNothing().given(participantService).leaveAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/me"));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(participantService)
+                    .leaveAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/me"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(participantService)
+                    .leaveAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/me"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범_방장인_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.HOST_LEAVE_NOT_ALLOWED))
+                    .given(participantService)
+                    .leaveAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/me"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("HOST_LEAVE_NOT_ALLOWED"))
+                    .andExpect(jsonPath("$.data.message").value("방장은 앨범을 나갈 수 없습니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -1,0 +1,100 @@
+package org.cherrypic.participant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.participant.service.ParticipantService;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class ParticipantServiceTest extends IntegrationTest {
+
+    @Autowired private ParticipantService participantService;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private AlbumRepository albumRepository;
+    @Autowired private ParticipantRepository participantRepository;
+
+    @MockitoBean private MemberUtil memberUtil;
+
+    @Nested
+    class 앨범을_나갈_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.STANDARD);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.HOST);
+            Participant participant3 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+        }
+
+        @Test
+        void 유효한_요청이면_참가자가_앨범에서_삭제된다() {
+            // when
+            participantService.leaveAlbum(1L);
+
+            // then
+            assertThat(participantRepository.findById(1L).isPresent()).isFalse();
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.leaveAlbum(999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.leaveAlbum(2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 앨범_방장인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.leaveAlbum(3L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.HOST_LEAVE_NOT_ALLOWED.getMessage());
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -37,18 +37,13 @@ class ParticipantServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            Member member1 =
+            Member member =
                     Member.createMember(
                             OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
                             "testNickname1",
                             "testProfileImageUrl1");
-            Member member2 =
-                    Member.createMember(
-                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
-                            "testNickname2",
-                            "testProfileImageUrl2");
-            memberRepository.saveAll(List.of(member1, member2));
-            given(memberUtil.getCurrentMember()).willReturn(member1);
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
@@ -56,12 +51,10 @@ class ParticipantServiceTest extends IntegrationTest {
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
-                    Participant.createParticipant(member1, album1, ParticipantRole.STANDARD);
+                    Participant.createParticipant(member, album1, ParticipantRole.STANDARD);
             Participant participant2 =
-                    Participant.createParticipant(member2, album1, ParticipantRole.HOST);
-            Participant participant3 =
-                    Participant.createParticipant(member1, album3, ParticipantRole.HOST);
-            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+                    Participant.createParticipant(member, album3, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2));
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #100 

---
## 📌 작업 내용 및 특이사항
* 앨범에서 참가자가 나가는 기능을 구현했습니다. 
* 방장은 앨범에서 나갈 수 없도록 예외 처리를 추가했습니다.
  * 방장이 나가버리면 남아 있는 참가자들이 앨범 삭제 권한을 갖지 못하게 되어, 더 이상 관리할 수 없는 유령 앨범이 생성될 수 있습니다.
  * 따라서 방장은 앨범 삭제만 가능합니다.
* 본인이 앨범을 나가는 도중 방장이 참가자를 강퇴하는 요청이 겹치는 동시성 상황에서 ObjectOptimisticLockingFailureException 발생 시, 이미 삭제된 것으로 간주하고 예외를 무시하여 멱등하게 처리하도록 하였습니다.
 
---
## 📚 참고사항
* 참가자 엔드포인트(/albums/{albumId}/participants)를 ParticipantController로 분리했는데, 매핑 테이블 성격이라 AlbumController에 합치는 것이 더 자연스러울지 고민됩니다. 현재 구조가 괜찮은지 리뷰 시 확인 부탁드립니다.
