### PR TITLE
refactor:  EventImage 관리 방식 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ sonarqube {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/**, **/*Application*.java, **/*Config*.java,' +
                 '**/*Dto*.java, **/*Request*.java, **/*Response*.java, **/*Exception*.java, **/*ErrorCode*.java, **/*Validator*.java,' +
-                '**/*FcmService*.java'
+                '**/*FcmService*.java, **/EventImage.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
@@ -2,9 +2,9 @@ package org.cherrypic.domain.event.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import java.util.List;
+import java.util.Set;
 
 public record EventImageAddRequest(
         @NotEmpty(message = "추가할 이미지 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "[1,2,3,4]")
-                List<Long> imageIds) {}
+                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "{1,2,3,4}")
+                Set<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public record EventImageAddRequest(
         @NotEmpty(message = "추가할 이미지 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "{1,2,3,4}")
+                @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "[1,2,3,4]")
                 List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageAddRequest.java
@@ -2,9 +2,9 @@ package org.cherrypic.domain.event.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import java.util.Set;
+import java.util.List;
 
 public record EventImageAddRequest(
         @NotEmpty(message = "추가할 이미지 ID는 비워둘 수 없습니다.")
                 @Schema(description = "이벤트에 추가할 이미지들의 ID", example = "{1,2,3,4}")
-                Set<Long> imageIds) {}
+                List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -8,7 +8,6 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(404, "존재하지 않는 이벤트입니다."),
-    EVENT_DOESNT_BELONG_TO_ALBUM(400, "앨범에 해당 이벤트가 존재하지 않습니다."),
     EVENT_DELETED(409, "이벤트 관련 작업중 이벤트가 삭제되었습니다.");
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -8,7 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(404, "존재하지 않는 이벤트입니다."),
-    EVENT_DELETED(409, "이벤트 관련 작업중 이벤트가 삭제되었습니다.");
+    EVENT_DELETED(409, "이벤트 관련 작업 중 이벤트가 삭제되었습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -8,7 +8,8 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(404, "존재하지 않는 이벤트입니다."),
-    EVENT_DOESNT_BELONG_TO_ALBUM(400, "앨범에 해당 이벤트가 존재하지 않습니다.");
+    EVENT_DOESNT_BELONG_TO_ALBUM(400, "앨범에 해당 이벤트가 존재하지 않습니다."),
+    EVENT_DELETED(409, "이벤트 관련 작업중 이벤트가 삭제되었습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepositoryImpl.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.event.repository;
 
 import static org.cherrypic.event.entity.QEvent.event;
-import static org.cherrypic.image.entity.QImage.image;
+import static org.cherrypic.event.entity.QEventImage.eventImage;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -33,10 +33,10 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
                                         event.id,
                                         event.title,
                                         event.coverUrl,
-                                        image.count().intValue()))
+                                        eventImage.id.count().intValue()))
                         .from(event)
-                        .leftJoin(image)
-                        .on(image.event.eq(event))
+                        .leftJoin(eventImage)
+                        .on(eventImage.event.eq(event))
                         .where(
                                 event.album.id.eq(albumId),
                                 lastEventIdCondition(lastEventId, direction))

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -117,16 +117,15 @@ public class EventServiceImpl implements EventService {
             eventImageRepository.saveAllAndFlush(eventImages);
         } catch (DataIntegrityViolationException e) {
             String constraint = getMySqlConstraint(e);
-
             if ("fk_event_image_event".equalsIgnoreCase(constraint)) {
                 throw new CustomException(EventErrorCode.EVENT_DELETED);
             }
             if ("fk_event_image_image".equalsIgnoreCase(constraint)) {
                 throw new CustomException(ImageErrorCode.IMAGE_DELETED);
             }
-            if ("uk_event_image_event_id_image_id".equalsIgnoreCase(constraint)
-                    || "1062".equals(constraint)) {
+            if ("uk_event_image_event_id_image_id".equalsIgnoreCase(constraint)) {
                 addImages(eventId, request);
+                return;
             }
             throw new CustomException(ImageErrorCode.IMAGE_CONFLICT);
         }
@@ -180,16 +179,15 @@ public class EventServiceImpl implements EventService {
         Throwable t = ex;
         while (t != null) {
             if (t instanceof java.sql.SQLIntegrityConstraintViolationException sql) {
-                // MySQL UK 위반: errorCode=1062, FK 위반: errorCode=1452
                 String msg = sql.getMessage();
                 if (msg != null) {
-                    // 메시지에 제약명 포함됨
-                    if (msg.contains("fk_event_image_event")) return "fk_event_image_event";
-                    if (msg.contains("fk_event_image_image")) return "fk_event_image_image";
-                    if (msg.contains("uk_event_image_event_id_image_id"))
+                    String lower = msg.toLowerCase();
+                    if (lower.contains("fk_event_image_event")) return "fk_event_image_event";
+                    if (lower.contains("fk_event_image_image")) return "fk_event_image_image";
+                    if (lower.contains("uk_event_image_event_id_image_id"))
                         return "uk_event_image_event_id_image_id";
                 }
-                return String.valueOf(sql.getErrorCode());
+                return String.valueOf(sql.getErrorCode()); // fallback
             }
             t = t.getCause();
         }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -28,6 +28,7 @@ import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,7 +113,23 @@ public class EventServiceImpl implements EventService {
         List<EventImage> eventImages =
                 images.stream().map(image -> EventImage.createEventImage(event, image)).toList();
 
-        eventImageRepository.saveAll(eventImages);
+        try {
+            eventImageRepository.saveAllAndFlush(eventImages);
+        } catch (DataIntegrityViolationException e) {
+            String constraint = getMySqlConstraint(e);
+
+            if ("fk_event_image_event".equalsIgnoreCase(constraint)) {
+                throw new CustomException(EventErrorCode.EVENT_DELETED);
+            }
+            if ("fk_event_image_image".equalsIgnoreCase(constraint)) {
+                throw new CustomException(ImageErrorCode.IMAGE_DELETED);
+            }
+            if ("uk_event_image_event_id_image_id".equalsIgnoreCase(constraint)
+                    || "1062".equals(constraint)) {
+                addImages(eventId, request);
+            }
+            throw new CustomException(ImageErrorCode.IMAGE_CONFLICT);
+        }
     }
 
     private Album getAlbumById(Long albumId) {
@@ -157,5 +174,25 @@ public class EventServiceImpl implements EventService {
 
     private List<Image> getAllUnmappedImagesById(Long eventId, List<Long> imageIds) {
         return imageRepository.findAllUnmappedToEvent(eventId, imageIds);
+    }
+
+    private String getMySqlConstraint(Throwable ex) {
+        Throwable t = ex;
+        while (t != null) {
+            if (t instanceof java.sql.SQLIntegrityConstraintViolationException sql) {
+                // MySQL UK 위반: errorCode=1062, FK 위반: errorCode=1452
+                String msg = sql.getMessage();
+                if (msg != null) {
+                    // 메시지에 제약명 포함됨
+                    if (msg.contains("fk_event_image_event")) return "fk_event_image_event";
+                    if (msg.contains("fk_event_image_image")) return "fk_event_image_image";
+                    if (msg.contains("uk_event_image_event_id_image_id"))
+                        return "uk_event_image_event_id_image_id";
+                }
+                return String.valueOf(sql.getErrorCode());
+            }
+            t = t.getCause();
+        }
+        return null;
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -30,6 +30,8 @@ import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Slice;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -96,6 +98,10 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
+    @Retryable(
+            retryFor = {DataIntegrityViolationException.class},
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 0))
     public void addImages(Long eventId, EventImageAddRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Event event = getEventById(eventId);
@@ -124,8 +130,7 @@ public class EventServiceImpl implements EventService {
                 throw new CustomException(ImageErrorCode.IMAGE_DELETED);
             }
             if ("uk_event_image_event_id_image_id".equalsIgnoreCase(constraint)) {
-                addImages(eventId, request);
-                return;
+                throw e;
             }
             throw new CustomException(ImageErrorCode.IMAGE_CONFLICT);
         }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.event.service;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -99,11 +99,14 @@ public class EventServiceImpl implements EventService {
         final Member currentMember = memberUtil.getCurrentMember();
         final Event event = getEventById(eventId);
 
-        validateParticipantAuthority(currentMember, event.getAlbum());
-        validateAllImageExistence(request.imageIds());
-        validateAllImageAlbum(request.imageIds(), eventId);
+        List<Long> distinctImageIds =
+                request.imageIds().stream().filter(Objects::nonNull).distinct().toList();
 
-        List<Image> images = getAllUnmappedImagesById(eventId, request.imageIds());
+        validateParticipantAuthority(currentMember, event.getAlbum());
+        validateAllImageExistence(distinctImageIds);
+        validateAllImageAlbum(distinctImageIds, eventId);
+
+        List<Image> images = getAllUnmappedImagesById(eventId, distinctImageIds);
         if (images.isEmpty()) return; // 사용자가 모두 해당 event에 이미 속하는 사진만 고른 경우
 
         List<EventImage> eventImages =
@@ -140,19 +143,19 @@ public class EventServiceImpl implements EventService {
         }
     }
 
-    private void validateAllImageAlbum(Set<Long> imageIds, Long albumId) {
+    private void validateAllImageAlbum(List<Long> imageIds, Long albumId) {
         if (imageRepository.countByIdInAndAlbumId(imageIds, albumId) != imageIds.size()) {
             throw new CustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM);
         }
     }
 
-    private void validateAllImageExistence(Set<Long> imageIds) {
+    private void validateAllImageExistence(List<Long> imageIds) {
         if (imageRepository.countByIdIn(imageIds) != imageIds.size()) {
             throw new CustomException(ImageErrorCode.IMAGES_NOT_FOUND);
         }
     }
 
-    private List<Image> getAllUnmappedImagesById(Long eventId, Set<Long> imageIds) {
+    private List<Image> getAllUnmappedImagesById(Long eventId, List<Long> imageIds) {
         return imageRepository.findAllUnmappedToEvent(eventId, imageIds);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -1,8 +1,7 @@
 package org.cherrypic.domain.event.service;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -16,9 +15,11 @@ import org.cherrypic.domain.event.dto.response.EventUpdateResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
+import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -42,6 +43,7 @@ public class EventServiceImpl implements EventService {
     private final ParticipantRepository participantRepository;
     private final EventRepository eventRepository;
     private final ImageRepository imageRepository;
+    private final EventImageRepository eventImageRepository;
 
     @Override
     public EventCreateResponse createEvent(EventCreateRequest request) {
@@ -96,19 +98,18 @@ public class EventServiceImpl implements EventService {
     public void addImages(Long eventId, EventImageAddRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Event event = getEventById(eventId);
-        final List<Image> images = getAllImagesById(request.imageIds());
 
         validateParticipantAuthority(currentMember, event.getAlbum());
-        validateImageAlbum(images, event);
-        validateImageEvent(images);
+        validateAllImageExistence(request.imageIds());
+        validateAllImageAlbum(request.imageIds(), eventId);
 
-        List<String> keys =
-                images.stream().map(img -> img.getId() + ":" + img.getVersion()).toList();
+        List<Image> images = getAllUnmappedImagesById(eventId, request.imageIds());
+        if (images.isEmpty()) return; // 사용자가 모두 해당 event에 이미 속하는 사진만 고른 경우
 
-        int updatedImages = imageRepository.bulkChangeImageEventWithVersionCheck(keys, eventId);
-        if (updatedImages != request.imageIds().size()) {
-            throw new CustomException(ImageErrorCode.CONFLICTING_IMAGES);
-        }
+        List<EventImage> eventImages =
+                images.stream().map(image -> EventImage.createEventImage(event, image)).toList();
+
+        eventImageRepository.saveAll(eventImages);
     }
 
     private Album getAlbumById(Long albumId) {
@@ -139,29 +140,19 @@ public class EventServiceImpl implements EventService {
         }
     }
 
-    private void validateImageEvent(List<Image> images) {
-        if (images.stream().anyMatch(img -> img.getEvent() != null)) {
-            throw new CustomException(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT);
-        }
-    }
-
-    private void validateImageAlbum(List<Image> images, Event event) {
-        Long albumId = event.getAlbum().getId();
-        if (images.stream()
-                .anyMatch(
-                        img ->
-                                img.getAlbum() == null
-                                        || !Objects.equals(img.getAlbum().getId(), albumId))) {
+    private void validateAllImageAlbum(Set<Long> imageIds, Long albumId) {
+        if (imageRepository.countByIdInAndAlbumId(imageIds, albumId) != imageIds.size()) {
             throw new CustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM);
         }
     }
 
-    private List<Image> getAllImagesById(List<Long> imageIds) {
+    private void validateAllImageExistence(Set<Long> imageIds) {
+        if (imageRepository.countByIdIn(imageIds) != imageIds.size()) {
+            throw new CustomException(ImageErrorCode.IMAGES_NOT_FOUND);
+        }
+    }
 
-        List<Long> distinctIds = imageIds.stream().filter(Objects::nonNull).distinct().toList();
-
-        return Optional.of(imageRepository.findAllById(distinctIds))
-                .filter(list -> list.size() == distinctIds.size())
-                .orElseThrow(() -> new CustomException(ImageErrorCode.IMAGES_NOT_FOUND));
+    private List<Image> getAllUnmappedImagesById(Long eventId, Set<Long> imageIds) {
+        return imageRepository.findAllUnmappedToEvent(eventId, imageIds);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -53,11 +53,11 @@ public class ImageController {
             @RequestParam Long eventId,
             @Parameter(description = "이전 페이지의 마지막 이벤트 이미지 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
-                    Long lastImageId,
+                    Long lastEventImageId,
             @Parameter(description = "페이지당 조회할 이미지의 수") @RequestParam @PageSize Integer size,
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
-        return imageService.getEventImages(eventId, lastImageId, size, direction);
+        return imageService.getEventImages(eventId, lastEventImageId, size, direction);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -33,7 +33,7 @@ public class ImageController {
         return imageService.createMemberProfileImageUploadUrl(request);
     }
 
-    @GetMapping("/album/images")
+    @GetMapping("/albums/images")
     @Operation(summary = "앨범 이미지 목록 조회", description = "앨범의 이미지 목록을 조회합니다.")
     public SliceResponse<AlbumImageListResponse> albumImagesGet(
             @RequestParam Long albumId,
@@ -47,7 +47,7 @@ public class ImageController {
         return imageService.getAlbumImages(albumId, lastImageId, size, direction);
     }
 
-    @GetMapping("/event/images")
+    @GetMapping("/events/images")
     @Operation(summary = "이벤트 이미지 목록 조회", description = "이벤트 이미지 목록을 조회합니다.")
     public SliceResponse<EventImageListResponse> eventImagesGet(
             @RequestParam Long eventId,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -6,7 +6,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
-import org.cherrypic.domain.image.dto.response.ImageListResponse;
+import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
+import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.global.annotation.PageSize;
@@ -32,11 +33,10 @@ public class ImageController {
         return imageService.createMemberProfileImageUploadUrl(request);
     }
 
-    @GetMapping("/images")
-    @Operation(summary = "사진 목록 조회", description = "사진 목록을 조회합니다.")
-    public SliceResponse<ImageListResponse> imagesGet(
+    @GetMapping("/album/images")
+    @Operation(summary = "앨범 이미지 목록 조회", description = "앨범의 이미지 목록을 조회합니다.")
+    public SliceResponse<AlbumImageListResponse> albumImagesGet(
             @RequestParam Long albumId,
-            @RequestParam(required = false) Long eventId,
             @Parameter(description = "이전 페이지의 마지막 이미지 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastImageId,
@@ -44,6 +44,20 @@ public class ImageController {
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
-        return imageService.getImages(albumId, eventId, lastImageId, size, direction);
+        return imageService.getAlbumImages(albumId, lastImageId, size, direction);
+    }
+
+    @GetMapping("/event/images")
+    @Operation(summary = "이벤트 이미지 목록 조회", description = "이벤트 이미지 목록을 조회합니다.")
+    public SliceResponse<EventImageListResponse> eventImagesGet(
+            @RequestParam Long eventId,
+            @Parameter(description = "이전 페이지의 마지막 이벤트 이미지 ID (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    Long lastImageId,
+            @Parameter(description = "페이지당 조회할 이미지의 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
+                    @RequestParam(defaultValue = "DESC")
+                    SortDirection direction) {
+        return imageService.getEventImages(eventId, lastImageId, size, direction);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/AlbumImageListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/AlbumImageListResponse.java
@@ -2,6 +2,6 @@ package org.cherrypic.domain.image.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record ImageListResponse(
+public record AlbumImageListResponse(
         @Schema(description = "이미지 ID", example = "1") Long imageId,
         @Schema(description = "이미지 url", example = "https://example.jpg") String imageUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/EventImageListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/EventImageListResponse.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record EventImageListResponse(
+        @Schema(description = "이벤트 이미지 ID", example = "1") Long eventImageId,
+        @Schema(description = "이벤트 이미지 url", example = "https://example.jpg") String imageUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -9,8 +9,8 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
     IMAGES_FROM_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
-    IMAGE_DELETED(409, "이미지 관련 작업중 이미지가 삭제되었습니다."),
-    IMAGE_CONFLICT(409, "이미지 동시성 문제 발생");
+    IMAGE_DELETED(409, "이미지 관련 작업 중 이미지가 삭제되었습니다."),
+    IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -8,7 +8,9 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
-    IMAGES_FROM_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다.");
+    IMAGES_FROM_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
+    IMAGE_DELETED(409, "이미지 관련 작업중 이미지가 삭제되었습니다."),
+    IMAGE_CONFLICT(409, "이미지 동시성 문제 발생");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -8,9 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
-    IMAGES_ASSIGNED_TO_EVENT(400, "이미 이벤트에 소속된 이미지를 포함하고 있습니다."),
-    IMAGES_FROM_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
-    CONFLICTING_IMAGES(409, "다른 요청에서 조작된 이미지를 포함하고 있습니다.");
+    IMAGES_FROM_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/EventImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/EventImageRepository.java
@@ -1,0 +1,11 @@
+package org.cherrypic.domain.image.repository;
+
+import java.util.List;
+import org.cherrypic.event.entity.EventImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventImageRepository extends JpaRepository<EventImage, Long> {
+    long countByEventId(Long eventId);
+
+    List<EventImage> findByEventIdAndImageIdInOrderByImageId(Long eventId, List<Long> imageIds);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/EventImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/EventImageRepository.java
@@ -1,11 +1,6 @@
 package org.cherrypic.domain.image.repository;
 
-import java.util.List;
 import org.cherrypic.event.entity.EventImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventImageRepository extends JpaRepository<EventImage, Long> {
-    long countByEventId(Long eventId);
-
-    List<EventImage> findByEventIdAndImageIdInOrderByImageId(Long eventId, List<Long> imageIds);
-}
+public interface EventImageRepository extends JpaRepository<EventImage, Long> {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
     List<Image> findAllById(Iterable<Long> imageIds);
 
-    long countByIdIn(Iterable<Long> ids);
+    long countByIdIn(List<Long> ids);
 
-    long countByIdInAndAlbumId(Iterable<Long> imageIds, Long albumId);
+    long countByIdInAndAlbumId(List<Long> imageIds, Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -3,25 +3,11 @@ package org.cherrypic.domain.image.repository;
 import java.util.List;
 import org.cherrypic.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
     List<Image> findAllById(Iterable<Long> imageIds);
 
-    @Modifying(clearAutomatically = true)
-    @Query(
-            value =
-                    """
-      UPDATE image
-         SET event_id   = :eventId,
-             version    = version + 1,
-             updated_at = CURRENT_TIMESTAMP(6)
-       WHERE CONCAT(id, ':', version) IN (:keys)
-         AND (event_id IS NULL OR event_id = :eventId)
-    """,
-            nativeQuery = true)
-    int bulkChangeImageEventWithVersionCheck(
-            @Param("keys") List<String> keys, @Param("eventId") Long eventId);
+    long countByIdIn(Iterable<Long> ids);
+
+    long countByIdInAndAlbumId(Iterable<Long> imageIds, Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
@@ -14,5 +14,5 @@ public interface ImageRepositoryCustom {
     Slice<AlbumImageListResponse> findAllByAlbumId(
             Long albumId, Long lastImageId, int size, SortDirection direction);
 
-    List<Image> findAllUnmappedToEvent(Long eventId, Iterable<Long> imageIds);
+    List<Image> findAllUnmappedToEvent(Long eventId, List<Long> imageIds);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
@@ -1,13 +1,18 @@
 package org.cherrypic.domain.image.repository;
 
-import org.cherrypic.domain.image.dto.response.ImageListResponse;
+import java.util.List;
+import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
+import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.image.entity.Image;
 import org.springframework.data.domain.Slice;
 
 public interface ImageRepositoryCustom {
-    Slice<ImageListResponse> findAllByEventId(
+    Slice<EventImageListResponse> findAllByEventId(
             Long eventId, Long lastImageId, int size, SortDirection direction);
 
-    Slice<ImageListResponse> findAllByAlbumId(
+    Slice<AlbumImageListResponse> findAllByAlbumId(
             Long albumId, Long lastImageId, int size, SortDirection direction);
+
+    List<Image> findAllUnmappedToEvent(Long eventId, Iterable<Long> imageIds);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -65,7 +65,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
     }
 
     @Override
-    public List<Image> findAllUnmappedToEvent(Long eventId, Iterable<Long> imageIds) {
+    public List<Image> findAllUnmappedToEvent(Long eventId, List<Long> imageIds) {
 
         return queryFactory
                 .selectFrom(image)

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.image.repository;
 
+import static org.cherrypic.event.entity.QEventImage.eventImage;
 import static org.cherrypic.image.entity.QImage.image;
 
 import com.querydsl.core.types.Projections;
@@ -7,8 +8,10 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.domain.image.dto.response.ImageListResponse;
+import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
+import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.image.entity.Image;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -21,17 +24,18 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<ImageListResponse> findAllByEventId(
+    public Slice<EventImageListResponse> findAllByEventId(
             Long eventId, Long lastImageId, int size, SortDirection direction) {
 
-        List<ImageListResponse> results =
+        List<EventImageListResponse> results =
                 queryFactory
                         .select(
                                 Projections.constructor(
-                                        ImageListResponse.class, image.id, image.url))
-                        .from(image)
+                                        EventImageListResponse.class, eventImage.id, image.url))
+                        .from(eventImage)
+                        .join(eventImage.image, image)
                         .where(
-                                image.event.id.eq(eventId),
+                                eventImage.event.id.eq(eventId),
                                 lastImageIdCondition(lastImageId, direction))
                         .orderBy(direction == SortDirection.DESC ? image.id.desc() : image.id.asc())
                         .limit(size + 1)
@@ -41,14 +45,14 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
     }
 
     @Override
-    public Slice<ImageListResponse> findAllByAlbumId(
+    public Slice<AlbumImageListResponse> findAllByAlbumId(
             Long albumId, Long lastImageId, int size, SortDirection direction) {
 
-        List<ImageListResponse> results =
+        List<AlbumImageListResponse> results =
                 queryFactory
                         .select(
                                 Projections.constructor(
-                                        ImageListResponse.class, image.id, image.url))
+                                        AlbumImageListResponse.class, image.id, image.url))
                         .from(image)
                         .where(
                                 image.album.id.eq(albumId),
@@ -60,6 +64,17 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
         return checkLastPage(size, results);
     }
 
+    @Override
+    public List<Image> findAllUnmappedToEvent(Long eventId, Iterable<Long> imageIds) {
+
+        return queryFactory
+                .selectFrom(image)
+                .leftJoin(eventImage)
+                .on(eventImage.image.id.eq(image.id).and(eventImage.event.id.eq(eventId)))
+                .where(image.id.in(imageIds), eventImage.id.isNull())
+                .fetch();
+    }
+
     private BooleanExpression lastImageIdCondition(Long imageId, SortDirection direction) {
         if (imageId == null) {
             return null;
@@ -68,7 +83,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
         return direction == SortDirection.DESC ? image.id.lt(imageId) : image.id.gt(imageId);
     }
 
-    private Slice<ImageListResponse> checkLastPage(int pageSize, List<ImageListResponse> results) {
+    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
         boolean hasNext = false;
 
         if (results.size() > pageSize) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -1,7 +1,8 @@
 package org.cherrypic.domain.image.service;
 
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
-import org.cherrypic.domain.image.dto.response.ImageListResponse;
+import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
+import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -9,6 +10,9 @@ import org.cherrypic.global.pagination.SortDirection;
 public interface ImageService {
     PresignedUrlResponse createMemberProfileImageUploadUrl(MemberProfileImageUploadRequest request);
 
-    SliceResponse<ImageListResponse> getImages(
-            Long albumId, Long eventId, Long lastImageId, int size, SortDirection direction);
+    SliceResponse<AlbumImageListResponse> getAlbumImages(
+            Long albumId, Long lastImageId, int size, SortDirection direction);
+
+    SliceResponse<EventImageListResponse> getEventImages(
+            Long eventId, Long lastImageId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -156,10 +156,4 @@ public class ImageServiceImpl implements ImageService {
                 .findByMemberIdAndAlbumId(memberId, albumId)
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
     }
-
-    private void validateAlbumEvent(Album album, Event event) {
-        if (!event.getAlbum().getId().equals(album.getId())) {
-            throw new CustomException(EventErrorCode.EVENT_DOESNT_BELONG_TO_ALBUM);
-        }
-    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -15,7 +15,8 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
-import org.cherrypic.domain.image.dto.response.ImageListResponse;
+import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
+import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
@@ -60,22 +61,27 @@ public class ImageServiceImpl implements ImageService {
 
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<ImageListResponse> getImages(
-            Long albumId, Long eventId, Long lastImageId, int size, SortDirection direction) {
+    public SliceResponse<AlbumImageListResponse> getAlbumImages(
+            Long albumId, Long lastImageId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Album album = getAlbumById(albumId);
+
+        getAlbumById(albumId);
         getParticipantByMemberIdAndAlbumId(currentMember.getId(), albumId);
 
-        if (eventId != null) {
-            final Event event = getEventById(eventId);
-            validateAlbumEvent(album, event);
-            Slice<ImageListResponse> result =
-                    imageRepository.findAllByEventId(eventId, lastImageId, size, direction);
-            return SliceResponse.from(result);
-        }
-
-        Slice<ImageListResponse> result =
+        Slice<AlbumImageListResponse> result =
                 imageRepository.findAllByAlbumId(albumId, lastImageId, size, direction);
+        return SliceResponse.from(result);
+    }
+
+    @Override
+    public SliceResponse<EventImageListResponse> getEventImages(
+            Long eventId, Long lastImageId, int size, SortDirection direction) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Event event = getEventById(eventId);
+        getParticipantByMemberIdAndAlbumId(currentMember.getId(), event.getAlbum().getId());
+
+        Slice<EventImageListResponse> result =
+                imageRepository.findAllByEventId(eventId, lastImageId, size, direction);
         return SliceResponse.from(result);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -64,9 +64,9 @@ public class ImageServiceImpl implements ImageService {
     public SliceResponse<AlbumImageListResponse> getAlbumImages(
             Long albumId, Long lastImageId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
 
-        getAlbumById(albumId);
-        getParticipantByMemberIdAndAlbumId(currentMember.getId(), albumId);
+        getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
 
         Slice<AlbumImageListResponse> result =
                 imageRepository.findAllByAlbumId(albumId, lastImageId, size, direction);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -74,6 +74,7 @@ public class ImageServiceImpl implements ImageService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public SliceResponse<EventImageListResponse> getEventImages(
             Long eventId, Long lastImageId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();

--- a/cherrypic-api/src/main/java/org/cherrypic/global/config/retry/RetryConfig.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/config/retry/RetryConfig.java
@@ -1,0 +1,8 @@
+package org.cherrypic.global.config.retry;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {}

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -649,28 +649,6 @@ public class EventControllerTest {
         }
 
         @Test
-        void 이미_이벤트에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
-            // given
-            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
-            willThrow(new CustomException(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT))
-                    .given(eventService)
-                    .addImages(1L, request);
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/events/1/add-images")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("IMAGES_ASSIGNED_TO_EVENT"))
-                    .andExpect(jsonPath("$.data.message").value("이미 이벤트에 소속된 이미지를 포함하고 있습니다."));
-        }
-
-        @Test
         void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
@@ -690,28 +668,6 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("IMAGES_FROM_OTHER_ALBUM"))
                     .andExpect(jsonPath("$.data.message").value("앨범 소속이 아닌 이미지를 포함하고 있습니다."));
-        }
-
-        @Test
-        void 앨범에_이미지를_추가하던_와중_다른_사람이_해당_이미지를_조작하면_예외가_발생한다() throws Exception {
-            // given
-            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
-            willThrow(new CustomException(ImageErrorCode.CONFLICTING_IMAGES))
-                    .given(eventService)
-                    .addImages(1L, request);
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/events/1/add-images")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
-                    .andExpect(jsonPath("$.data.code").value("CONFLICTING_IMAGES"))
-                    .andExpect(jsonPath("$.data.message").value("다른 요청에서 조작된 이미지를 포함하고 있습니다."));
         }
 
         @ParameterizedTest

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -553,7 +553,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 추가하고자_하는_이미지가_삭제되는_동시성_충돌_시_예외를_반환한다() {
+        void 추가하고자_하는_이미지가_삭제되는_동시성_충돌_시_예외가_발생한다() {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
 
@@ -571,6 +571,7 @@ public class EventServiceTest extends IntegrationTest {
                             })
                     .when(eventImageRepository)
                     .saveAllAndFlush(anyList());
+
             // when & then
             assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(CustomException.class)
@@ -578,7 +579,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 추가하고자_하는_이벤트가_삭제되는_동시성_충돌_시_예외를_반환한다() {
+        void 추가하고자_하는_이벤트가_삭제되는_동시성_충돌_시_예외가_발생한다() {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -18,10 +18,12 @@ import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.event.service.EventService;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
+import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -50,6 +52,7 @@ public class EventServiceTest extends IntegrationTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private ParticipantRepository participantRepository;
     @Autowired private ImageRepository imageRepository;
+    @Autowired private EventImageRepository eventImageRepository;
 
     @MockitoBean MemberUtil memberUtil;
 
@@ -250,14 +253,6 @@ public class EventServiceTest extends IntegrationTest {
             Event event1 = Event.createEvent(album1, "testEvent1", "testEventCoverUrl1");
             Event event2 = Event.createEvent(album2, "testEvent2", "testEventCoverUrl2");
             eventRepository.saveAll(List.of(event1, event2));
-
-            Image image1 =
-                    Image.createImage(album1, null, 1L, "testImageUrl1", LocalDateTime.now());
-            Image image2 =
-                    Image.createImage(album1, null, 1L, "testImageUrl2", LocalDateTime.now());
-            Image image3 =
-                    Image.createImage(album1, null, 1L, "testImageUrl3", LocalDateTime.now());
-            imageRepository.saveAll(List.of(image1, image2, image3));
         }
 
         @Test
@@ -325,9 +320,13 @@ public class EventServiceTest extends IntegrationTest {
             Event event2 = Event.createEvent(album1, "testTitle2", "testCoverUrl2");
             eventRepository.saveAll(List.of(event1, event2));
 
-            Image image1 = Image.createImage(album1, event1, 1L, "testUrl", LocalDateTime.now());
-            Image image2 = Image.createImage(album1, event1, 1L, "testUrl2", LocalDateTime.now());
+            Image image1 = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
             imageRepository.saveAll(List.of(image1, image2));
+
+            EventImage eventImage1 = EventImage.createEventImage(event1, image1);
+            EventImage eventImage2 = EventImage.createEventImage(event1, image2);
+            eventImageRepository.saveAll(List.of(eventImage1, eventImage2));
         }
 
         @Test
@@ -439,11 +438,14 @@ public class EventServiceTest extends IntegrationTest {
             Event event2 = Event.createEvent(album2, "testTitle2", "testCoverUrl2");
             eventRepository.saveAll(List.of(event1, event2));
 
-            Image image1 = Image.createImage(album1, null, 1L, "testUrl", LocalDateTime.now());
-            Image image2 = Image.createImage(album1, event1, 1L, "testUrl2", LocalDateTime.now());
-            Image image3 = Image.createImage(album2, null, 1L, "testUrl3", LocalDateTime.now());
-            Image image4 = Image.createImage(album1, null, 1L, "testUrl4", LocalDateTime.now());
+            Image image1 = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
+            Image image3 = Image.createImage(album2, 1L, "testUrl3", LocalDateTime.now());
+            Image image4 = Image.createImage(album1, 1L, "testUrl4", LocalDateTime.now());
             imageRepository.saveAll(List.of(image1, image2, image3, image4));
+
+            EventImage eventImage = EventImage.createEventImage(event1, image2);
+            eventImageRepository.save(eventImage);
         }
 
         @Test
@@ -455,8 +457,10 @@ public class EventServiceTest extends IntegrationTest {
             eventService.addImages(1L, request);
 
             // then
-            List<Image> images = imageRepository.findAllById(List.of(1L, 4L));
-            assertThat(images).extracting("event.id").containsExactly(1L, 1L);
+            List<EventImage> eventImages = eventImageRepository.findAllById(List.of(2L, 3L));
+            assertThat(eventImages)
+                    .extracting("event.id", "image.id")
+                    .containsExactly(tuple(1L, 1L), tuple(1L, 4L));
         }
 
         @Test
@@ -493,56 +497,15 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 이미_이벤트에_속한_이미지를_추가하면_예외가_발생한다() {
+        void 이미_해당_이벤트에_속한_이미지를_똑같은_이벤트에_추가해도_중복으로_추가되지_않는다() {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(2L));
 
-            // when & then
-            assertThatThrownBy(() -> eventService.addImages(1L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ImageErrorCode.IMAGES_ASSIGNED_TO_EVENT.getMessage());
-        }
+            // when
+            eventService.addImages(1L, request);
 
-        @Test
-        void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() {
-            // given
-            EventImageAddRequest request = new EventImageAddRequest(List.of(3L));
-
-            // when & then
-            assertThatThrownBy(() -> eventService.addImages(1L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM.getMessage());
-        }
-
-        @Test
-        void 앨범에_이미지를_추가하던_와중_다른_사람이_해당_이미지를_조작하면_예외가_발생한다() throws Exception {
-            // given:
-            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
-
-            var barrier = new java.util.concurrent.CyclicBarrier(2);
-            var es = java.util.concurrent.Executors.newFixedThreadPool(2);
-
-            // when & then
-            var f1 =
-                    es.submit(
-                            () -> {
-                                barrier.await();
-                                imageRepository.bulkChangeImageEventWithVersionCheck(
-                                        List.of("1:1"), 2L);
-                                return null;
-                            });
-
-            var f2 =
-                    es.submit(
-                            () -> {
-                                barrier.await();
-                                f1.get();
-
-                                assertThatThrownBy(() -> eventService.addImages(1L, request))
-                                        .isInstanceOf(CustomException.class)
-                                        .hasMessage(ImageErrorCode.CONFLICTING_IMAGES.getMessage());
-                                return null;
-                            });
+            // then
+            assertThat(eventImageRepository.findById(2L).isPresent()).isFalse();
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -1,10 +1,15 @@
 package org.cherrypic.event.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 
+import jakarta.persistence.EntityManager;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumPlan;
@@ -39,7 +44,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 public class EventServiceTest extends IntegrationTest {
 
@@ -52,7 +59,8 @@ public class EventServiceTest extends IntegrationTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private ParticipantRepository participantRepository;
     @Autowired private ImageRepository imageRepository;
-    @Autowired private EventImageRepository eventImageRepository;
+    @MockitoSpyBean private EventImageRepository eventImageRepository;
+    @Autowired private EntityManager em;
 
     @MockitoBean MemberUtil memberUtil;
 
@@ -506,6 +514,117 @@ public class EventServiceTest extends IntegrationTest {
 
             // then
             assertThat(eventImageRepository.findById(2L).isPresent()).isFalse();
+        }
+
+        @Test
+        void 추가하고자_하는_이미지가_이미_추가된_동시성_충돌_시_재실행_된다() {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
+
+            AtomicBoolean firstCall = new AtomicBoolean(true);
+            doAnswer(
+                            invocation -> {
+                                if (firstCall.getAndSet(false)) {
+                                    var sqlEx =
+                                            new SQLIntegrityConstraintViolationException(
+                                                    "Duplicate entry '1-4' for key 'uk_event_image_event_id_image_id'",
+                                                    "23000",
+                                                    1062);
+                                    throw new DataIntegrityViolationException(
+                                            "constraint violation", sqlEx);
+                                } else {
+                                    List<EventImage> args = invocation.getArgument(0);
+                                    args.forEach(em::persist);
+                                    em.flush();
+                                    return args;
+                                }
+                            })
+                    .when(eventImageRepository)
+                    .saveAllAndFlush(anyList());
+
+            // when
+            eventService.addImages(1L, request);
+
+            // then
+            List<EventImage> eventImages = eventImageRepository.findAllById(List.of(2L, 3L));
+            assertThat(eventImages)
+                    .extracting("event.id", "image.id")
+                    .containsExactly(tuple(1L, 1L), tuple(1L, 4L));
+        }
+
+        @Test
+        void 추가하고자_하는_이미지가_삭제되는_동시성_충돌_시_예외를_반환한다() {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
+
+            doAnswer(
+                            invocation -> {
+                                var sqlEx =
+                                        new SQLIntegrityConstraintViolationException(
+                                                "Cannot add or update a child row: a foreign key constraint fails "
+                                                        + "(`testdb`.`event_image`, CONSTRAINT `fk_event_image_image` FOREIGN KEY (`image_id`) "
+                                                        + "REFERENCES `image` (`id`))",
+                                                "23000",
+                                                1452);
+                                throw new DataIntegrityViolationException(
+                                        "constraint violation", sqlEx);
+                            })
+                    .when(eventImageRepository)
+                    .saveAllAndFlush(anyList());
+            // when & then
+            assertThatThrownBy(() -> eventService.addImages(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ImageErrorCode.IMAGE_DELETED.getMessage());
+        }
+
+        @Test
+        void 추가하고자_하는_이벤트가_삭제되는_동시성_충돌_시_예외를_반환한다() {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
+
+            doAnswer(
+                            invocation -> {
+                                var sqlEx =
+                                        new SQLIntegrityConstraintViolationException(
+                                                "Cannot add or update a child row: a foreign key constraint fails "
+                                                        + "(`testdb`.`event_image`, CONSTRAINT `fk_event_image_event` FOREIGN KEY (`event_id`) "
+                                                        + "REFERENCES `event` (`id`))",
+                                                "23000",
+                                                1452);
+                                throw new DataIntegrityViolationException(
+                                        "constraint violation", sqlEx);
+                            })
+                    .when(eventImageRepository)
+                    .saveAllAndFlush(anyList());
+
+            // when & then
+            assertThatThrownBy(() -> eventService.addImages(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EventErrorCode.EVENT_DELETED.getMessage());
+        }
+
+        @Test
+        void 예상하지_못한_DB_동시성_에러_발생시_예외가_발생한다() {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));
+
+            doAnswer(
+                            invocation -> {
+                                var sqlEx =
+                                        new SQLIntegrityConstraintViolationException(
+                                                "random test SQL constraint message that does not contain known constraint names",
+                                                "23000",
+                                                9999);
+                                throw new DataIntegrityViolationException(
+                                        "constraint violation", sqlEx);
+                            })
+                    .when(eventImageRepository)
+                    .saveAllAndFlush(anyList());
+
+            // when & then
+            assertThatThrownBy(() -> eventService.addImages(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ImageErrorCode.IMAGE_CONFLICT.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -12,7 +12,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.image.controller.ImageController;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
-import org.cherrypic.domain.image.dto.response.ImageListResponse;
+import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.service.ImageService;
@@ -101,12 +101,12 @@ class ImageControllerTest {
         @Test
         void 정렬_조건이_ASC이면_ImageId를_오름차순으로_응답한다() throws Exception {
             // given
-            List<ImageListResponse> images =
+            List<AlbumImageListResponse> images =
                     List.of(
-                            new ImageListResponse(1L, "testImageUrl1"),
-                            new ImageListResponse(2L, "testImageUrl2"));
+                            new AlbumImageListResponse(1L, "testImageUrl1"),
+                            new AlbumImageListResponse(2L, "testImageUrl2"));
 
-            given(imageService.getImages(1L, 1L, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
@@ -130,12 +130,12 @@ class ImageControllerTest {
         @Test
         void 정렬_조건이_DESC이면_imageId를_내림차순으로_응답한다() throws Exception {
             // given
-            List<ImageListResponse> images =
+            List<AlbumImageListResponse> images =
                     List.of(
-                            new ImageListResponse(2L, "testImageUrl2"),
-                            new ImageListResponse(1L, "testImageUrl1"));
+                            new AlbumImageListResponse(2L, "testImageUrl2"),
+                            new AlbumImageListResponse(1L, "testImageUrl1"));
 
-            given(imageService.getImages(1L, 1L, null, 2, SortDirection.DESC))
+            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
@@ -158,9 +158,10 @@ class ImageControllerTest {
         @Test
         void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
             // given
-            List<ImageListResponse> images = List.of(new ImageListResponse(1L, "testImageUrl1"));
+            List<AlbumImageListResponse> images =
+                    List.of(new AlbumImageListResponse(1L, "testImageUrl1"));
 
-            given(imageService.getImages(1L, 1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, 1L, null, 1, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
@@ -182,12 +183,12 @@ class ImageControllerTest {
         @Test
         void 마지막_페이지가_아닌_경우_isLast를_false로_응답한다() throws Exception {
             // given
-            List<ImageListResponse> images =
+            List<AlbumImageListResponse> images =
                     List.of(
-                            new ImageListResponse(1L, "testImageUrl1"),
-                            new ImageListResponse(2L, "testImageUrl2"));
+                            new AlbumImageListResponse(1L, "testImageUrl1"),
+                            new AlbumImageListResponse(2L, "testImageUrl2"));
 
-            given(imageService.getImages(1L, 1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, 1L, null, 1, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, false));
 
             // when & then
@@ -210,9 +211,9 @@ class ImageControllerTest {
         @Test
         void 이미지가_없는_경우_빈_리스트를_응답한다() throws Exception {
             // given
-            List<ImageListResponse> images = List.of();
+            List<AlbumImageListResponse> images = List.of();
 
-            given(imageService.getImages(1L, 1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, 1L, null, 1, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
@@ -234,7 +235,7 @@ class ImageControllerTest {
         @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getImages(999L, null, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(999L, null, null, 2, SortDirection.ASC))
                     .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
             // when & then
@@ -255,7 +256,7 @@ class ImageControllerTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getImages(1L, null, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, null, 2, SortDirection.ASC))
                     .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
@@ -276,7 +277,7 @@ class ImageControllerTest {
         @Test
         void 이벤트가_존재하지_않을_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getImages(1L, 1L, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC))
                     .willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND));
 
             // when & then
@@ -298,7 +299,7 @@ class ImageControllerTest {
         @Test
         void 이벤트가_앨범에_속하지_않는_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getImages(1L, 1L, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC))
                     .willThrow(new CustomException(EventErrorCode.EVENT_DOESNT_BELONG_TO_ALBUM));
 
             // when & then

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -13,6 +13,7 @@ import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.image.controller.ImageController;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
+import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.service.ImageService;
@@ -96,25 +97,24 @@ class ImageControllerTest {
     }
 
     @Nested
-    class 이미지_목록_조회_요청시 {
+    class 앨범_이미지_목록_조회_요청시 {
 
         @Test
-        void 정렬_조건이_ASC이면_ImageId를_오름차순으로_응답한다() throws Exception {
+        void 정렬_조건이_ASC이면_imageId를_오름차순으로_응답한다() throws Exception {
             // given
             List<AlbumImageListResponse> images =
                     List.of(
                             new AlbumImageListResponse(1L, "testImageUrl1"),
                             new AlbumImageListResponse(2L, "testImageUrl2"));
 
-            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
+                            get("/albums/images")
                                     .param("albumId", "1")
-                                    .param("eventId", "1")
                                     .param("size", "2")
                                     .param("direction", "ASC"));
 
@@ -124,7 +124,6 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.data.content[0].imageId").value(1))
                     .andExpect(jsonPath("$.data.content[1].imageId").value(2))
                     .andExpect(jsonPath("$.data.isLast").value(true));
-            ;
         }
 
         @Test
@@ -135,15 +134,14 @@ class ImageControllerTest {
                             new AlbumImageListResponse(2L, "testImageUrl2"),
                             new AlbumImageListResponse(1L, "testImageUrl1"));
 
-            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.DESC))
+            given(imageService.getAlbumImages(1L, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
+                            get("/albums/images")
                                     .param("albumId", "1")
-                                    .param("eventId", "1")
                                     .param("size", "2")
                                     .param("direction", "DESC"));
 
@@ -161,15 +159,14 @@ class ImageControllerTest {
             List<AlbumImageListResponse> images =
                     List.of(new AlbumImageListResponse(1L, "testImageUrl1"));
 
-            given(imageService.getAlbumImages(1L, 1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 1, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
+                            get("/albums/images")
                                     .param("albumId", "1")
-                                    .param("eventId", "1")
                                     .param("size", "1")
                                     .param("direction", "ASC"));
 
@@ -188,15 +185,14 @@ class ImageControllerTest {
                             new AlbumImageListResponse(1L, "testImageUrl1"),
                             new AlbumImageListResponse(2L, "testImageUrl2"));
 
-            given(imageService.getAlbumImages(1L, 1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 1, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, false));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
+                            get("/albums/images")
                                     .param("albumId", "1")
-                                    .param("eventId", "1")
                                     .param("size", "1")
                                     .param("direction", "ASC"));
 
@@ -213,15 +209,14 @@ class ImageControllerTest {
             // given
             List<AlbumImageListResponse> images = List.of();
 
-            given(imageService.getAlbumImages(1L, 1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 1, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
+                            get("/albums/images")
                                     .param("albumId", "1")
-                                    .param("eventId", "1")
                                     .param("size", "1")
                                     .param("direction", "ASC"));
 
@@ -235,13 +230,13 @@ class ImageControllerTest {
         @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getAlbumImages(999L, null, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(999L, null, 2, SortDirection.ASC))
                     .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
+                            get("/albums/images")
                                     .param("albumId", "999")
                                     .param("size", "2")
                                     .param("direction", "ASC"));
@@ -256,13 +251,13 @@ class ImageControllerTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getAlbumImages(1L, null, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 2, SortDirection.ASC))
                     .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
+                            get("/albums/images")
                                     .param("albumId", "1")
                                     .param("size", "2")
                                     .param("direction", "ASC"));
@@ -274,17 +269,185 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "-999", "0"})
+        void 페이지_크기를_0_이하로_설정하면_예외가_발생한다(String pageSize) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/images")
+                                    .param("albumId", "1")
+                                    .param("size", pageSize)
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ConstraintViolationException"))
+                    .andExpect(jsonPath("$.data.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
+        void 존재하지_않는_정렬_기준을_입력한_경우_예외가_발생한다(String sort) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/images")
+                                    .param("albumId", "1")
+                                    .param("size", "1")
+                                    .param("direction", sort));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 이벤트_이미지_목록_조회_요청시 {
+
+        @Test
+        void 정렬_조건이_ASC이면_eventImageId를_오름차순으로_응답한다() throws Exception {
+            // given
+            List<EventImageListResponse> eventImages =
+                    List.of(
+                            new EventImageListResponse(1L, "testImageUrl1"),
+                            new EventImageListResponse(2L, "testImageUrl2"));
+
+            given(imageService.getEventImages(1L, null, 2, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(eventImages, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/events/images")
+                                    .param("eventId", "1")
+                                    .param("size", "2")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].eventImageId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].eventImageId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+            ;
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_eventImageId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<EventImageListResponse> eventImages =
+                    List.of(
+                            new EventImageListResponse(2L, "testImageUrl2"),
+                            new EventImageListResponse(1L, "testImageUrl1"));
+
+            given(imageService.getEventImages(1L, null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(eventImages, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/events/images")
+                                    .param("eventId", "1")
+                                    .param("size", "2")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].eventImageId").value(2))
+                    .andExpect(jsonPath("$.data.content[1].eventImageId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
+            // given
+            List<EventImageListResponse> eventImages =
+                    List.of(new EventImageListResponse(1L, "testImageUrl1"));
+
+            given(imageService.getEventImages(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(eventImages, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/events/images")
+                                    .param("eventId", "1")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].eventImageId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_응답한다() throws Exception {
+            // given
+            List<EventImageListResponse> eventImages =
+                    List.of(
+                            new EventImageListResponse(1L, "testImageUrl1"),
+                            new EventImageListResponse(2L, "testImageUrl2"));
+
+            given(imageService.getEventImages(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(eventImages, false));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/events/images")
+                                    .param("eventId", "1")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].eventImageId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].eventImageId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(false));
+        }
+
+        @Test
+        void 이벤트_이미지가_없는_경우_빈_리스트를_응답한다() throws Exception {
+            // given
+            List<EventImageListResponse> eventImages = List.of();
+
+            given(imageService.getEventImages(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(eventImages, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/events/images")
+                                    .param("eventId", "1")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content").isEmpty())
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
         @Test
         void 이벤트가_존재하지_않을_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC))
+            given(imageService.getEventImages(1L, null, 2, SortDirection.ASC))
                     .willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
-                                    .param("albumId", "1")
+                            get("/events/images")
                                     .param("eventId", "1")
                                     .param("size", "2")
                                     .param("direction", "ASC"));
@@ -297,25 +460,24 @@ class ImageControllerTest {
         }
 
         @Test
-        void 이벤트가_앨범에_속하지_않는_경우_예외가_발생한다() throws Exception {
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC))
-                    .willThrow(new CustomException(EventErrorCode.EVENT_DOESNT_BELONG_TO_ALBUM));
+            given(imageService.getEventImages(1L, null, 2, SortDirection.ASC))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
-                                    .param("albumId", "1")
+                            get("/events/images")
                                     .param("eventId", "1")
                                     .param("size", "2")
                                     .param("direction", "ASC"));
 
-            perform.andExpect(status().isBadRequest())
+            perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("EVENT_DOESNT_BELONG_TO_ALBUM"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 해당 이벤트가 존재하지 않습니다."));
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
         }
 
         @ParameterizedTest
@@ -324,8 +486,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
-                                    .param("albumId", "1")
+                            get("/events/images")
                                     .param("eventId", "1")
                                     .param("size", pageSize)
                                     .param("direction", "ASC"));
@@ -343,8 +504,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/images")
-                                    .param("albumId", "1")
+                            get("/events/images")
                                     .param("eventId", "1")
                                     .param("size", "1")
                                     .param("direction", sort));

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -13,7 +13,7 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
-import org.cherrypic.domain.image.dto.response.ImageListResponse;
+import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.repository.ImageRepository;
@@ -117,8 +117,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 정렬_조건이_ASC이면_imageId를_오름차순으로_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, null, null, 3, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, null, null, 3, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(1L, 2L, 3L);
@@ -127,8 +127,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 정렬_조건이_DESC면_imageId를_내림차순으로_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, null, null, 3, SortDirection.DESC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, null, null, 3, SortDirection.DESC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(3L, 2L, 1L);
@@ -137,8 +137,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void imageId를_입력하면_다음_Image_부터_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, null, 1L, 2, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, null, 1L, 2, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(2L, 3L);
@@ -147,8 +147,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범에_이미지가_없는_경우_빈_리스트를_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(2L, null, null, 3, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(2L, null, null, 3, SortDirection.ASC);
 
             // when & then
             Assertions.assertAll(
@@ -159,8 +159,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, null, null, 3, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, null, null, 3, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
@@ -171,7 +171,10 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getImages(999L, null, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () ->
+                                    imageService.getAlbumImages(
+                                            999L, null, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -179,7 +182,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getImages(3L, null, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () -> imageService.getAlbumImages(3L, null, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -219,8 +223,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 정렬_조건이_ASC이면_imageId를_오름차순으로_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, 1L, null, 2, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(1L, 2L);
@@ -229,8 +233,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 정렬_조건이_DESC면_imageId를_내림차순으로_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, 1L, null, 2, SortDirection.DESC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.DESC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(2L, 1L);
@@ -239,8 +243,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void imageId를_입력하면_다음_Image_부터_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, 1L, 1L, 1, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, 1L, 1L, 1, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(2L);
@@ -249,8 +253,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 이벤트에_이미지가_없는_경우_빈_리스트를_조회한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, 2L, 1L, 2, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, 2L, 1L, 2, SortDirection.ASC);
 
             // when & then
             Assertions.assertAll(
@@ -261,8 +265,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
-            SliceResponse<ImageListResponse> response =
-                    imageService.getImages(1L, 1L, null, 2, SortDirection.ASC);
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
@@ -273,7 +277,10 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getImages(999L, null, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () ->
+                                    imageService.getAlbumImages(
+                                            999L, null, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -281,7 +288,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getImages(2L, null, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () -> imageService.getAlbumImages(2L, null, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -289,7 +297,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 이벤트가_존재하지_않을_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getImages(1L, 999L, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () -> imageService.getAlbumImages(1L, 999L, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
         }
@@ -297,7 +306,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 이벤트가_앨범에_속하지_않는_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getImages(1L, 3L, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () -> imageService.getAlbumImages(1L, 3L, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(EventErrorCode.EVENT_DOESNT_BELONG_TO_ALBUM.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -14,13 +14,16 @@ import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
+import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -47,6 +50,7 @@ class ImageServiceTest extends IntegrationTest {
     @Autowired private ImageRepository imageRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private EventImageRepository eventImageRepository;
 
     @Nested
     class Presigned_URL을_생성할_때 {
@@ -103,22 +107,23 @@ class ImageServiceTest extends IntegrationTest {
                     Participant.createParticipant(member, album2, ParticipantRole.HOST);
             participantRepository.saveAll(List.of(participant1, participant2));
 
-            Event event1 = Event.createEvent(album1, "testTitle1", "testCoverUrl1");
-            Event event2 = Event.createEvent(album1, "testTitle2", "testCoverUrl2");
-            Event event3 = Event.createEvent(album1, "testTitle3", "testCoverUrl3");
-            eventRepository.saveAll(List.of(event1, event2, event3));
+            Event event = Event.createEvent(album1, "testTitle1", "testCoverUrl1");
+            eventRepository.save(event);
 
-            Image image1 = Image.createImage(album1, event1, 1L, "testUrl", LocalDateTime.now());
-            Image image2 = Image.createImage(album1, event2, 1L, "testUrl2", LocalDateTime.now());
-            Image image3 = Image.createImage(album1, null, 1L, "testUrl2", LocalDateTime.now());
+            Image image1 = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
+            Image image3 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
             imageRepository.saveAll(List.of(image1, image2, image3));
+
+            EventImage eventImage = EventImage.createEventImage(event, image1);
+            eventImageRepository.save(eventImage);
         }
 
         @Test
         void 정렬_조건이_ASC이면_imageId를_오름차순으로_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, null, null, 3, SortDirection.ASC);
+                    imageService.getAlbumImages(1L, null, 3, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(1L, 2L, 3L);
@@ -128,7 +133,7 @@ class ImageServiceTest extends IntegrationTest {
         void 정렬_조건이_DESC면_imageId를_내림차순으로_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, null, null, 3, SortDirection.DESC);
+                    imageService.getAlbumImages(1L, null, 3, SortDirection.DESC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(3L, 2L, 1L);
@@ -138,7 +143,7 @@ class ImageServiceTest extends IntegrationTest {
         void imageId를_입력하면_다음_Image_부터_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, null, 1L, 2, SortDirection.ASC);
+                    imageService.getAlbumImages(1L, 1L, 2, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(2L, 3L);
@@ -148,7 +153,7 @@ class ImageServiceTest extends IntegrationTest {
         void 앨범에_이미지가_없는_경우_빈_리스트를_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(2L, null, null, 3, SortDirection.ASC);
+                    imageService.getAlbumImages(2L, null, 3, SortDirection.ASC);
 
             // when & then
             Assertions.assertAll(
@@ -160,7 +165,7 @@ class ImageServiceTest extends IntegrationTest {
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, null, null, 3, SortDirection.ASC);
+                    imageService.getAlbumImages(1L, null, 3, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
@@ -171,10 +176,7 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(
-                            () ->
-                                    imageService.getAlbumImages(
-                                            999L, null, null, 2, SortDirection.ASC))
+            assertThatThrownBy(() -> imageService.getAlbumImages(999L, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -182,8 +184,7 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(
-                            () -> imageService.getAlbumImages(3L, null, null, 2, SortDirection.ASC))
+            assertThatThrownBy(() -> imageService.getAlbumImages(3L, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -215,46 +216,50 @@ class ImageServiceTest extends IntegrationTest {
             Event event3 = Event.createEvent(album2, "testTitle3", "testCoverUrl3");
             eventRepository.saveAll(List.of(event1, event2, event3));
 
-            Image image1 = Image.createImage(album1, event1, 1L, "testUrl", LocalDateTime.now());
-            Image image2 = Image.createImage(album1, event1, 1L, "testUrl2", LocalDateTime.now());
+            Image image1 = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
             imageRepository.saveAll(List.of(image1, image2));
+
+            EventImage eventImage1 = EventImage.createEventImage(event1, image1);
+            EventImage eventImage2 = EventImage.createEventImage(event1, image2);
+            eventImageRepository.saveAll(List.of(eventImage1, eventImage2));
         }
 
         @Test
-        void 정렬_조건이_ASC이면_imageId를_오름차순으로_조회한다() {
+        void 정렬_조건이_ASC이면_eventImageId를_오름차순으로_조회한다() {
             // when
-            SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC);
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(1L, null, 2, SortDirection.ASC);
 
             // then
-            assertThat(response.content()).extracting("imageId").containsExactly(1L, 2L);
+            assertThat(response.content()).extracting("eventImageId").containsExactly(1L, 2L);
         }
 
         @Test
-        void 정렬_조건이_DESC면_imageId를_내림차순으로_조회한다() {
+        void 정렬_조건이_DESC면_eventImageId를_내림차순으로_조회한다() {
             // when
-            SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.DESC);
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(1L, null, 2, SortDirection.DESC);
 
             // then
-            assertThat(response.content()).extracting("imageId").containsExactly(2L, 1L);
+            assertThat(response.content()).extracting("eventImageId").containsExactly(2L, 1L);
         }
 
         @Test
-        void imageId를_입력하면_다음_Image_부터_조회한다() {
+        void imageId를_입력하면_다음_eventImage_부터_조회한다() {
             // when
-            SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, 1L, 1L, 1, SortDirection.ASC);
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(1L, 1L, 1, SortDirection.ASC);
 
             // then
-            assertThat(response.content()).extracting("imageId").containsExactly(2L);
+            assertThat(response.content()).extracting("eventImageId").containsExactly(2L);
         }
 
         @Test
         void 이벤트에_이미지가_없는_경우_빈_리스트를_조회한다() {
             // when
-            SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, 2L, 1L, 2, SortDirection.ASC);
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(2L, null, 2, SortDirection.ASC);
 
             // when & then
             Assertions.assertAll(
@@ -265,8 +270,8 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
-            SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, 1L, null, 2, SortDirection.ASC);
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(1L, null, 2, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
@@ -275,21 +280,9 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 앨범이_존재하지_않을_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(
-                            () ->
-                                    imageService.getAlbumImages(
-                                            999L, null, null, 2, SortDirection.ASC))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
-        }
-
-        @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(
-                            () -> imageService.getAlbumImages(2L, null, null, 2, SortDirection.ASC))
+            assertThatThrownBy(() -> imageService.getEventImages(3L, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -297,19 +290,9 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 이벤트가_존재하지_않을_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(
-                            () -> imageService.getAlbumImages(1L, 999L, null, 2, SortDirection.ASC))
+            assertThatThrownBy(() -> imageService.getEventImages(999L, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 이벤트가_앨범에_속하지_않는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(
-                            () -> imageService.getAlbumImages(1L, 3L, null, 2, SortDirection.ASC))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(EventErrorCode.EVENT_DOESNT_BELONG_TO_ALBUM.getMessage());
         }
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
@@ -31,7 +31,7 @@ public class EventImage extends BaseTimeEntity {
         this.image = image;
     }
 
-    private static EventImage createEventImage(Event event, Image image) {
+    public static EventImage createEventImage(Event event, Image image) {
         return EventImage.builder().event(event).image(image).build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
@@ -10,6 +10,12 @@ import org.cherrypic.image.entity.Image;
 
 @Getter
 @Entity
+@Table(
+        name = "event_image",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_event_image_event_id_image_id",
+                        columnNames = {"event_id", "image_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventImage extends BaseTimeEntity {
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
@@ -1,0 +1,37 @@
+package org.cherrypic.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.cherrypic.common.model.BaseTimeEntity;
+import org.cherrypic.image.entity.Image;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private EventImage(Event event, Image image) {
+        this.event = event;
+        this.image = image;
+    }
+
+    private static EventImage createEventImage(Event event, Image image) {
+        return EventImage.builder().event(event).image(image).build();
+    }
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/event/entity/EventImage.java
@@ -10,12 +10,6 @@ import org.cherrypic.image.entity.Image;
 
 @Getter
 @Entity
-@Table(
-        name = "event_image",
-        uniqueConstraints =
-                @UniqueConstraint(
-                        name = "uk_event_image_event_id_image_id",
-                        columnNames = {"event_id", "image_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventImage extends BaseTimeEntity {
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
-import org.cherrypic.event.entity.Event;
 
 @Getter
 @Entity
@@ -24,10 +23,6 @@ public class Image extends BaseTimeEntity {
     @JoinColumn(name = "album_id")
     private Album album;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
-
     @NotNull private Long memberId;
 
     @NotNull private String url;
@@ -37,19 +32,17 @@ public class Image extends BaseTimeEntity {
     @Version @NotNull private long version;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Image(Album album, Event event, Long memberId, String url, LocalDateTime generatedAt) {
+    private Image(Album album, Long memberId, String url, LocalDateTime generatedAt) {
         this.album = album;
-        this.event = event;
         this.memberId = memberId;
         this.url = url;
         this.generatedAt = generatedAt;
     }
 
     public static Image createImage(
-            Album album, Event event, Long memberId, String url, LocalDateTime generatedAt) {
+            Album album, Long memberId, String url, LocalDateTime generatedAt) {
         return Image.builder()
                 .album(album)
-                .event(event)
                 .memberId(memberId)
                 .url(url)
                 .generatedAt(generatedAt)

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -29,8 +29,6 @@ public class Image extends BaseTimeEntity {
 
     private LocalDateTime generatedAt;
 
-    @Version @NotNull private long version;
-
     @Builder(access = AccessLevel.PRIVATE)
     private Image(Album album, Long memberId, String url, LocalDateTime generatedAt) {
         this.album = album;

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -70,16 +70,23 @@ CREATE TABLE image (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        member_id BIGINT NOT NULL,
                        album_id BIGINT NOT NULL,
-                       event_id BIGINT,
                        url VARCHAR(255) NOT NULL,
                        generated_at DATETIME,
                        version BIGINT NOT NULL DEFAULT 0,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,
-                       CONSTRAINT fk_image_album FOREIGN KEY (album_id) REFERENCES album (id),
-                       CONSTRAINT fk_image_event FOREIGN KEY (event_id) REFERENCES event (id)
+                       CONSTRAINT fk_image_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
 
+CREATE TABLE event_image (
+                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                             event_id BIGINT,
+                             image_id BIGINT,
+                             created_at DATETIME(6) NOT NULL,
+                             updated_at DATETIME(6) NOT NULL,
+                             CONSTRAINT fk_event_image_event FOREIGN KEY (event_id) REFERENCES event(id),
+                             CONSTRAINT fk_event_image_image FOREIGN KEY (image_id) REFERENCES image(id)
+);
 
 CREATE TABLE favorites (
                            id BIGINT AUTO_INCREMENT PRIMARY KEY,

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -84,7 +84,8 @@ CREATE TABLE event_image (
                              created_at DATETIME(6) NOT NULL,
                              updated_at DATETIME(6) NOT NULL,
                              CONSTRAINT fk_event_image_event FOREIGN KEY (event_id) REFERENCES event(id),
-                             CONSTRAINT fk_event_image_image FOREIGN KEY (image_id) REFERENCES image(id)
+                             CONSTRAINT fk_event_image_image FOREIGN KEY (image_id) REFERENCES image(id),
+                             CONSTRAINT uk_event_image_event_id_image_id UNIQUE (event_id, image_id)
 );
 
 CREATE TABLE favorites (

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -72,7 +72,6 @@ CREATE TABLE image (
                        album_id BIGINT NOT NULL,
                        url VARCHAR(255) NOT NULL,
                        generated_at DATETIME,
-                       version BIGINT NOT NULL DEFAULT 0,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,
                        CONSTRAINT fk_image_album FOREIGN KEY (album_id) REFERENCES album (id)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #116 

---
## 📌 작업 내용 및 특이사항
- EventImage 매핑 테이블을 복원했습니다.
- 이로 인해서 하나의 이미지는 여러 이벤트로 분류될 수 있습니다.
- 이런 이유로 기존에 존재하던 앨범 이미지 조회 API가 앨범 전체 이미지 조회와 이벤트 이미지 조회 API로 수정되었습니다.
- 이벤트에 이미지를 추가하는 로직은 이미 추가된 경우 중복으로 추가되지 않도록 구현되었습니다.

---
## 📚 참고사항
- Event에 이미지 추가 로직에서 이미 추가된 Image는 중복으로 추가하지 않고 넘어가도록 구현했습니다.
- 선행하는 validation에서 잡히면 그대로 진행되지만, EventImage 생성 시점에 동시성 문제가 발생하면 에러가 터지고 API가 재호출 되도록 구현했습니다.
- 이 방식을 사용하면 재호출 당시에 똑같은 동시성 문제가 발생하지 않는 이상 이미 추가된 이미지를 제외하고 추가합니다.