### PR TITLE
feat: 참가자 강퇴 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ sonarqube {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/**, **/*Application*.java, **/*Config*.java,' +
                 '**/*Dto*.java, **/*Request*.java, **/*Response*.java, **/*Exception*.java, **/*ErrorCode*.java, **/*Validator*.java,' +
-                '**/*FcmService*.java, **/EventImage.java'
+                '**/*FcmService*.java, **/EventImage.java, **/Notification.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -25,7 +25,9 @@ public enum AlbumErrorCode implements BaseErrorCode {
     SUBSCRIPTION_ACTIVE(400, "구독 중인 앨범은 삭제할 수 없습니다."),
 
     HOST_LEAVE_NOT_ALLOWED(403, "방장은 앨범을 나갈 수 없습니다."),
-    ;
+    HOST_SELF_KICK_NOT_ALLOWED(400, "방장은 자기 자신을 강퇴할 수 없습니다."),
+
+    PARTICIPANT_NOT_IN_ALBUM(400, "해당 참가자는 이 앨범에 속해 있지 않습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
@@ -24,4 +24,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("senderId") Long senderId,
             @Param("title") String title,
             @Param("content") String content);
+
+    void deleteByReceiverIdAndAlbumId(Long receiverId, Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
@@ -24,4 +24,12 @@ public class ParticipantController {
         participantService.leaveAlbum(albumId);
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/{participantId}")
+    @Operation(summary = "참가자 강퇴", description = "앨범 방장이 특정 참가자를 강퇴합니다.")
+    public ResponseEntity<Void> participantKick(
+            @PathVariable Long albumId, @PathVariable Long participantId) {
+        participantService.kickParticipant(albumId, participantId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
@@ -2,4 +2,6 @@ package org.cherrypic.domain.participant.service;
 
 public interface ParticipantService {
     void leaveAlbum(Long albumId);
+
+    void kickParticipant(Long albumId, Long participantId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.util.MemberUtil;
@@ -40,6 +41,24 @@ public class ParticipantServiceImpl implements ParticipantService {
         }
     }
 
+    @Override
+    public void kickParticipant(Long albumId, Long participantId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+        final Participant requester =
+                getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
+        final Participant target = getParticipantById(participantId);
+
+        validateAlbumHost(requester);
+        validateSelfKick(requester, target);
+        validateParticipantBelongsToAlbum(target, album);
+
+        try {
+            participantRepository.delete(target);
+        } catch (ObjectOptimisticLockingFailureException ignored) {
+        }
+    }
+
     private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)
@@ -52,9 +71,33 @@ public class ParticipantServiceImpl implements ParticipantService {
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
     }
 
+    private Participant getParticipantById(Long participantId) {
+        return participantRepository
+                .findById(participantId)
+                .orElseThrow(() -> new CustomException(ParticipantErrorCode.PARTICIPANT_NOT_FOUND));
+    }
+
     private void validateNotAlbumHost(Participant participant) {
         if (participant.getRole() == ParticipantRole.HOST) {
             throw new CustomException(AlbumErrorCode.HOST_LEAVE_NOT_ALLOWED);
+        }
+    }
+
+    private void validateAlbumHost(Participant participant) {
+        if (participant.getRole() != ParticipantRole.HOST) {
+            throw new CustomException(AlbumErrorCode.NOT_ALBUM_HOST);
+        }
+    }
+
+    private void validateSelfKick(Participant requester, Participant target) {
+        if (requester.getId().equals(target.getId())) {
+            throw new CustomException(AlbumErrorCode.HOST_SELF_KICK_NOT_ALLOWED);
+        }
+    }
+
+    private void validateParticipantBelongsToAlbum(Participant target, Album album) {
+        if (!target.getAlbum().getId().equals(album.getId())) {
+            throw new CustomException(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.notification.repository.NotificationRepository;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.exception.CustomException;
@@ -24,6 +25,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
     private final ParticipantRepository participantRepository;
     private final AlbumRepository albumRepository;
+    private final NotificationRepository notificationRepository;
 
     @Override
     public void leaveAlbum(Long albumId) {
@@ -37,6 +39,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         try {
             participantRepository.delete(participant);
+            notificationRepository.deleteByReceiverIdAndAlbumId(currentMember.getId(), albumId);
         } catch (ObjectOptimisticLockingFailureException ignored) {
         }
     }
@@ -55,6 +58,8 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         try {
             participantRepository.delete(target);
+            notificationRepository.deleteByReceiverIdAndAlbumId(
+                    target.getMember().getId(), album.getId());
         } catch (ObjectOptimisticLockingFailureException ignored) {
         }
     }

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -167,7 +167,7 @@ class ParticipantControllerTest {
         }
 
         @Test
-        void 강퇴_요청자와_강퇴_대상이_동일한_경우_예외가_발생한다() throws Exception {
+        void 앨범_방장이_자기_자신을_강퇴하려는_경우_예외가_발생한다() throws Exception {
             // given
             willThrow(new CustomException(AlbumErrorCode.HOST_SELF_KICK_NOT_ALLOWED))
                     .given(participantService)

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.participant.controller.ParticipantController;
+import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.exception.CustomException;
 import org.junit.jupiter.api.Nested;
@@ -31,7 +32,7 @@ class ParticipantControllerTest {
     @MockitoBean private ParticipantService participantService;
 
     @Nested
-    class 앨범을_나가기_요청_시 {
+    class 앨범_나가기_요청_시 {
 
         @Test
         void 유효한_요청이면_참가자를_앨범에서_삭제하고_NO_CONTENT_로_반환한다() throws Exception {
@@ -95,6 +96,125 @@ class ParticipantControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                     .andExpect(jsonPath("$.data.code").value("HOST_LEAVE_NOT_ALLOWED"))
                     .andExpect(jsonPath("$.data.message").value("방장은 앨범을 나갈 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 참가자_강퇴_요청_시 {
+
+        @Test
+        void 유효한_요청이면_앨범_방장이_참가자를_강퇴하여_앨범에서_제거하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            willDoNothing().given(participantService).kickParticipant(1L, 1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/1"));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(participantService)
+                    .kickParticipant(1L, 1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/1"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 강퇴_요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(participantService)
+                    .kickParticipant(1L, 1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/1"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 강퇴_요청자가_앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST))
+                    .given(participantService)
+                    .kickParticipant(1L, 1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/1"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void 강퇴_요청자와_강퇴_대상이_동일한_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.HOST_SELF_KICK_NOT_ALLOWED))
+                    .given(participantService)
+                    .kickParticipant(1L, 1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/1"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("HOST_SELF_KICK_NOT_ALLOWED"))
+                    .andExpect(jsonPath("$.data.message").value("방장은 자기 자신을 강퇴할 수 없습니다."));
+        }
+
+        @Test
+        void 강퇴_대상_참가자가_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(ParticipantErrorCode.PARTICIPANT_NOT_FOUND))
+                    .given(participantService)
+                    .kickParticipant(1L, 1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/1"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("PARTICIPANT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("참가자를 찾을 수 없습니다."));
+        }
+
+        @Test
+        void 강퇴_대상이_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM))
+                    .given(participantService)
+                    .kickParticipant(1L, 1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/participants/1"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("PARTICIPANT_NOT_IN_ALBUM"))
+                    .andExpect(jsonPath("$.data.message").value("해당 참가자는 이 앨범에 속해 있지 않습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -11,6 +11,7 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.notification.repository.NotificationRepository;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.participant.service.ParticipantService;
@@ -19,6 +20,8 @@ import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.notification.entity.Notification;
+import org.cherrypic.notification.enums.NotificationType;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.junit.jupiter.api.*;
@@ -33,6 +36,7 @@ class ParticipantServiceTest extends IntegrationTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private ParticipantRepository participantRepository;
+    @Autowired private NotificationRepository notificationRepository;
 
     @MockitoBean private MemberUtil memberUtil;
 
@@ -41,13 +45,19 @@ class ParticipantServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            Member member =
+            Member member1 =
                     Member.createMember(
                             OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
                             "testNickname1",
                             "testProfileImageUrl1");
-            memberRepository.save(member);
-            given(memberUtil.getCurrentMember()).willReturn(member);
+            memberRepository.save(member1);
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.save(member2);
+            given(memberUtil.getCurrentMember()).willReturn(member1);
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
@@ -55,19 +65,45 @@ class ParticipantServiceTest extends IntegrationTest {
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
-                    Participant.createParticipant(member, album1, ParticipantRole.STANDARD);
+                    Participant.createParticipant(member1, album1, ParticipantRole.STANDARD);
             Participant participant2 =
-                    Participant.createParticipant(member, album3, ParticipantRole.HOST);
-            participantRepository.saveAll(List.of(participant1, participant2));
+                    Participant.createParticipant(member1, album3, ParticipantRole.HOST);
+            Participant participant3 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Notification.createNotification(
+                    member2, member1, album1, "testTitle", "testContent", NotificationType.ALBUM);
+            Notification.createNotification(
+                    member1, member2, album1, "testTitle", "testContent", NotificationType.ALBUM);
         }
 
         @Test
-        void 유효한_요청이면_참가자가_앨범에서_삭제된다() {
+        void 유효한_요청이면_참가자와_그에게_전달된_앨범_알림이_삭제된다() {
             // when
             participantService.leaveAlbum(1L);
 
             // then
-            assertThat(participantRepository.findById(1L).isPresent()).isFalse();
+            Album album =
+                    transactionUtil.getResult(
+                            () -> {
+                                Album loadedAlbum = albumRepository.findById(1L).get();
+                                loadedAlbum.getParticipants().size();
+                                loadedAlbum.getNotifications().size();
+                                return loadedAlbum;
+                            });
+            List<Participant> participants = album.getParticipants();
+            List<Notification> notifications = album.getNotifications();
+
+            Assertions.assertAll(
+                    () ->
+                            assertThat(participants)
+                                    .extracting(Participant::getId)
+                                    .doesNotContain(1L),
+                    () ->
+                            assertThat(notifications)
+                                    .extracting(Notification::getId)
+                                    .doesNotContain(1L));
         }
 
         @Test
@@ -128,10 +164,15 @@ class ParticipantServiceTest extends IntegrationTest {
                     Participant.createParticipant(member1, album2, ParticipantRole.STANDARD);
             participantRepository.saveAll(
                     List.of(participant1, participant2, participant3, participant4));
+
+            Notification.createNotification(
+                    member1, member2, album1, "testTitle", "testContent", NotificationType.ALBUM);
+            Notification.createNotification(
+                    member2, member1, album2, "testTitle", "testContent", NotificationType.ALBUM);
         }
 
         @Test
-        void 유효한_요청이면_앨범_방장이_참가자를_강퇴하여_앨범에서_제거한다() {
+        void 유효한_요청이면_참가자가_강퇴되고_그에게_전달된_앨범_알림이_삭제된다() {
             // when
             participantService.kickParticipant(1L, 2L);
 
@@ -141,11 +182,21 @@ class ParticipantServiceTest extends IntegrationTest {
                             () -> {
                                 Album loadedAlbum = albumRepository.findById(1L).get();
                                 loadedAlbum.getParticipants().size();
+                                loadedAlbum.getNotifications().size();
                                 return loadedAlbum;
                             });
             List<Participant> participants = album.getParticipants();
+            List<Notification> notifications = album.getNotifications();
 
-            assertThat(participants).extracting(Participant::getId).doesNotContain(2L);
+            Assertions.assertAll(
+                    () ->
+                            assertThat(participants)
+                                    .extracting(Participant::getId)
+                                    .doesNotContain(2L),
+                    () ->
+                            assertThat(notifications)
+                                    .extracting(Notification::getId)
+                                    .doesNotContain(1L));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -173,7 +173,7 @@ class ParticipantServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 강퇴_요청자와_강퇴_대상이_동일한_경우_예외가_발생한다() {
+        void 앨범_방장이_자기_자신을_강퇴하려는_경우_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> participantService.kickParticipant(1L, 1L))
                     .isInstanceOf(CustomException.class)

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -72,10 +72,31 @@ class ParticipantServiceTest extends IntegrationTest {
                     Participant.createParticipant(member2, album1, ParticipantRole.HOST);
             participantRepository.saveAll(List.of(participant1, participant2, participant3));
 
-            Notification.createNotification(
-                    member2, member1, album1, "testTitle", "testContent", NotificationType.ALBUM);
-            Notification.createNotification(
-                    member1, member2, album1, "testTitle", "testContent", NotificationType.ALBUM);
+            Notification notification1 =
+                    Notification.createNotification(
+                            member2,
+                            member1,
+                            album1,
+                            "testTitle1",
+                            "testContent1",
+                            NotificationType.ALBUM);
+            Notification notification2 =
+                    Notification.createNotification(
+                            member2,
+                            member1,
+                            album1,
+                            "testTitle2",
+                            "testContent2",
+                            NotificationType.ALBUM);
+            Notification notification3 =
+                    Notification.createNotification(
+                            member1,
+                            member2,
+                            album1,
+                            "testTitle3",
+                            "testContent3",
+                            NotificationType.ALBUM);
+            notificationRepository.saveAll(List.of(notification1, notification2, notification3));
         }
 
         @Test
@@ -165,10 +186,23 @@ class ParticipantServiceTest extends IntegrationTest {
             participantRepository.saveAll(
                     List.of(participant1, participant2, participant3, participant4));
 
-            Notification.createNotification(
-                    member1, member2, album1, "testTitle", "testContent", NotificationType.ALBUM);
-            Notification.createNotification(
-                    member2, member1, album2, "testTitle", "testContent", NotificationType.ALBUM);
+            Notification notification1 =
+                    Notification.createNotification(
+                            member1,
+                            member2,
+                            album1,
+                            "testTitle1",
+                            "testContent1",
+                            NotificationType.ALBUM);
+            Notification notification2 =
+                    Notification.createNotification(
+                            member2,
+                            member1,
+                            album2,
+                            "testTitle2",
+                            "testContent2",
+                            NotificationType.ALBUM);
+            notificationRepository.saveAll(List.of(notification1, notification2));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -11,10 +11,12 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.participant.entity.Participant;
@@ -24,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class ParticipantServiceTest extends IntegrationTest {
+
+    @Autowired private TransactionUtil transactionUtil;
 
     @Autowired private ParticipantService participantService;
     @Autowired private MemberRepository memberRepository;
@@ -88,6 +92,108 @@ class ParticipantServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> participantService.leaveAlbum(3L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.HOST_LEAVE_NOT_ALLOWED.getMessage());
+        }
+    }
+
+    @Nested
+    class 참가자를_강퇴할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.STANDARD);
+            Participant participant3 =
+                    Participant.createParticipant(member2, album2, ParticipantRole.HOST);
+            Participant participant4 =
+                    Participant.createParticipant(member1, album2, ParticipantRole.STANDARD);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4));
+        }
+
+        @Test
+        void 유효한_요청이면_앨범_방장이_참가자를_강퇴하여_앨범에서_제거한다() {
+            // when
+            participantService.kickParticipant(1L, 2L);
+
+            // then
+            Album album =
+                    transactionUtil.getResult(
+                            () -> {
+                                Album loadedAlbum = albumRepository.findById(1L).get();
+                                loadedAlbum.getParticipants().size();
+                                return loadedAlbum;
+                            });
+            List<Participant> participants = album.getParticipants();
+
+            assertThat(participants).extracting(Participant::getId).doesNotContain(2L);
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.kickParticipant(999L, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 강퇴_요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.kickParticipant(3L, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 강퇴_요청자가_앨범_방장이_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.kickParticipant(2L, 3L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void 강퇴_요청자와_강퇴_대상이_동일한_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.kickParticipant(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.HOST_SELF_KICK_NOT_ALLOWED.getMessage());
+        }
+
+        @Test
+        void 강퇴_대상_참가자가_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.kickParticipant(1L, 999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ParticipantErrorCode.PARTICIPANT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 강퇴_대상이_앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> participantService.kickParticipant(1L, 3L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM.getMessage());
         }
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/notification/entity/Notification.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/notification/entity/Notification.java
@@ -3,6 +3,7 @@ package org.cherrypic.notification.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
@@ -38,4 +39,37 @@ public class Notification extends BaseTimeEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     private NotificationType type;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Notification(
+            Member sender,
+            Member receiver,
+            Album album,
+            String title,
+            String content,
+            NotificationType type) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.album = album;
+        this.title = title;
+        this.content = content;
+        this.type = type;
+    }
+
+    public static Notification createNotification(
+            Member sender,
+            Member receiver,
+            Album album,
+            String title,
+            String content,
+            NotificationType type) {
+        return Notification.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .album(album)
+                .title(title)
+                .content(content)
+                .type(type)
+                .build();
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #117 

---
## 📌 작업 내용 및 특이사항
* 앨범 방장이 특정 참가자를 강퇴할 수 있는 기능을 구현했습니다.
* 방장이 참가자를 강퇴하는 도중, 해당 참가자가 직접 앨범을 나가는 동시성 상황에서 ObjectOptimisticLockingFailureException이 발생할 수 있으며, 이 경우 이미 참가자가 삭제된 것으로 간주하고 예외를 무시하여 멱등하게 처리하도록 하였습니다.
* 참가자 퇴장 또는 강퇴가 발생하면, 해당 참가자는 더 이상 앨범의 소속이 아니므로 관련 알림 내역을 모두 삭제하도록 처리하였습니다.