### PR TITLE
feat: 이벤트 이미지 제거 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
 import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
+import org.cherrypic.domain.event.dto.request.EventImageRemoveRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -63,6 +64,14 @@ public class EventController {
     public ResponseEntity<Void> imagesAdd(
             @PathVariable Long eventId, @Valid @RequestBody EventImageAddRequest request) {
         eventService.addImages(eventId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{eventId}/remove-images")
+    @Operation(summary = "이벤트에 이미지 제거", description = "앨범의 이미지를 이벤트에서 제거합니다.")
+    public ResponseEntity<Void> imagesRemove(
+            @PathVariable Long eventId, @Valid @RequestBody EventImageRemoveRequest request) {
+        eventService.removeImages(eventId, request);
         return ResponseEntity.noContent().build();
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -67,7 +67,7 @@ public class EventController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/{eventId}/remove-images")
+    @DeleteMapping("/{eventId}/remove-images")
     @Operation(summary = "이벤트에 이미지 제거", description = "앨범의 이미지를 이벤트에서 제거합니다.")
     public ResponseEntity<Void> imagesRemove(
             @PathVariable Long eventId, @Valid @RequestBody EventImageRemoveRequest request) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageRemoveRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/dto/request/EventImageRemoveRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.event.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record EventImageRemoveRequest(
+        @NotEmpty(message = "제거할 이벤트 이미지 ID는 비워둘 수 없습니다.")
+                @Schema(description = "이벤트에서 제거할 이벤트 이미지 ID", example = "[1,2,3,4]")
+                List<Long> eventImageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -8,7 +8,9 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(404, "존재하지 않는 이벤트입니다."),
-    EVENT_DELETED(409, "이벤트 관련 작업 중 이벤트가 삭제되었습니다.");
+    EVENT_DELETED(409, "이벤트 관련 작업 중 이벤트가 삭제되었습니다."),
+
+    EVENT_IMAGE_NOT_FROM_EVENT(400, "이벤트에 소속된 이벤트 이미지가 아닙니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -10,7 +10,7 @@ public enum EventErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(404, "존재하지 않는 이벤트입니다."),
     EVENT_DELETED(409, "이벤트 관련 작업 중 이벤트가 삭제되었습니다."),
 
-    EVENT_IMAGE_NOT_FROM_EVENT(400, "이벤트에 소속된 이벤트 이미지가 아닙니다.");
+    EVENT_IMAGE_NOT_IN_EVENT(400, "해당 이미지는 이벤트에 속해 있지 않습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventService.java
@@ -2,6 +2,7 @@ package org.cherrypic.domain.event.service;
 
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
 import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
+import org.cherrypic.domain.event.dto.request.EventImageRemoveRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -20,4 +21,6 @@ public interface EventService {
     void deleteEvent(Long eventId);
 
     void addImages(Long eventId, EventImageAddRequest request);
+
+    void removeImages(Long eventId, EventImageRemoveRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -8,6 +8,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
 import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
+import org.cherrypic.domain.event.dto.request.EventImageRemoveRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -136,6 +137,24 @@ public class EventServiceImpl implements EventService {
         }
     }
 
+    @Override
+    public void removeImages(Long eventId, EventImageRemoveRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Event event = getEventById(eventId);
+
+        validateParticipantAuthority(currentMember, event.getAlbum());
+
+        List<Long> distinctEventImagesIds =
+                request.eventImageIds().stream().filter(Objects::nonNull).distinct().toList();
+
+        List<EventImage> eventImages = eventImageRepository.findAllById(distinctEventImagesIds);
+        if (eventImages.isEmpty()) return; // 이미 모두 삭제된 경우
+
+        validateEventImageFromEvents(eventImages, event);
+
+        eventImageRepository.deleteAllInBatch(eventImages);
+    }
+
     private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)
@@ -173,6 +192,15 @@ public class EventServiceImpl implements EventService {
     private void validateAllImageExistence(List<Long> imageIds) {
         if (imageRepository.countByIdIn(imageIds) != imageIds.size()) {
             throw new CustomException(ImageErrorCode.IMAGES_NOT_FOUND);
+        }
+    }
+
+    private void validateEventImageFromEvents(List<EventImage> eventImages, Event event) {
+        boolean containsNotFromEvent =
+                eventImages.stream().anyMatch(ei -> !ei.getEvent().getId().equals(event.getId()));
+
+        if (containsNotFromEvent) {
+            throw new CustomException(EventErrorCode.EVENT_IMAGE_NOT_FROM_EVENT);
         }
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -200,7 +200,7 @@ public class EventServiceImpl implements EventService {
                 eventImages.stream().anyMatch(ei -> !ei.getEvent().getId().equals(event.getId()));
 
         if (containsNotFromEvent) {
-            throw new CustomException(EventErrorCode.EVENT_IMAGE_NOT_FROM_EVENT);
+            throw new CustomException(EventErrorCode.EVENT_IMAGE_NOT_IN_EVENT);
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -13,6 +13,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.controller.EventController;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
 import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
+import org.cherrypic.domain.event.dto.request.EventImageRemoveRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventCreateResponse;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
@@ -689,6 +690,116 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("추가할 이미지 ID는 비워둘 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 이벤트_이미지_제거_요청_시 {
+
+        @Test
+        void 유효한_요청이면_이벤트에_이미지를_제거하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L));
+            willDoNothing().given(eventService).removeImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/remove-images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 존재하지_않는_이벤트를_입력하면_예외가_발생한다() throws Exception {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L));
+            willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND))
+                    .given(eventService)
+                    .removeImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/remove-images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_이벤트_이미지를_삭제하면_예외가_발생한다() throws Exception {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L));
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(eventService)
+                    .removeImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/remove-images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_이벤트_이미지를_삭제하면_예외가_발생한다() throws Exception {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L));
+            willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY))
+                    .given(eventService)
+                    .removeImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/remove-images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Test
+        void 이벤트와_EventImage의_이벤트가_일치하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L));
+            willThrow(new CustomException(EventErrorCode.EVENT_IMAGE_NOT_FROM_EVENT))
+                    .given(eventService)
+                    .removeImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/remove-images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("EVENT_IMAGE_NOT_FROM_EVENT"))
+                    .andExpect(jsonPath("$.data.message").value("이벤트에 소속된 이벤트 이미지가 아닙니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -705,7 +705,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/remove-images")
+                            delete("/events/1/remove-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -725,7 +725,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/remove-images")
+                            delete("/events/1/remove-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -747,7 +747,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/remove-images")
+                            delete("/events/1/remove-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -769,7 +769,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/remove-images")
+                            delete("/events/1/remove-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -791,7 +791,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/remove-images")
+                            delete("/events/1/remove-images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -784,7 +784,7 @@ public class EventControllerTest {
         void 이벤트와_EventImage의_이벤트가_일치하지_않는_경우_예외가_발생한다() throws Exception {
             // given
             EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L));
-            willThrow(new CustomException(EventErrorCode.EVENT_IMAGE_NOT_FROM_EVENT))
+            willThrow(new CustomException(EventErrorCode.EVENT_IMAGE_NOT_IN_EVENT))
                     .given(eventService)
                     .removeImages(1L, request);
 
@@ -798,8 +798,8 @@ public class EventControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("EVENT_IMAGE_NOT_FROM_EVENT"))
-                    .andExpect(jsonPath("$.data.message").value("이벤트에 소속된 이벤트 이미지가 아닙니다."));
+                    .andExpect(jsonPath("$.data.code").value("EVENT_IMAGE_NOT_IN_EVENT"))
+                    .andExpect(jsonPath("$.data.message").value("해당 이미지는 이벤트에 속해 있지 않습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -725,7 +725,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.removeImages(1L, request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(EventErrorCode.EVENT_IMAGE_NOT_FROM_EVENT.getMessage());
+                    .hasMessage(EventErrorCode.EVENT_IMAGE_NOT_IN_EVENT.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -17,6 +17,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
 import org.cherrypic.domain.event.dto.request.EventImageAddRequest;
+import org.cherrypic.domain.event.dto.request.EventImageRemoveRequest;
 import org.cherrypic.domain.event.dto.request.EventUpdateRequest;
 import org.cherrypic.domain.event.dto.response.EventListResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -626,6 +627,105 @@ public class EventServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ImageErrorCode.IMAGE_CONFLICT.getMessage());
+        }
+    }
+
+    @Nested
+    class 이벤트에_이미지를_제거할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+
+            Event event1 = Event.createEvent(album1, "testTitle1", "testCoverUrl1");
+            Event event2 = Event.createEvent(album2, "testTitle2", "testCoverUrl2");
+            Event event3 = Event.createEvent(album3, "testTitle3", "testCoverUrl3");
+            Event event4 = Event.createEvent(album1, "testTitle4", "testCoverUrl4");
+            eventRepository.saveAll(List.of(event1, event2, event3, event4));
+
+            Image image1 = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
+            Image image3 = Image.createImage(album2, 1L, "testUrl3", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3));
+
+            EventImage eventImage1 = EventImage.createEventImage(event1, image1);
+            EventImage eventImage2 = EventImage.createEventImage(event1, image2);
+            EventImage eventImage3 = EventImage.createEventImage(event4, image3);
+
+            eventImageRepository.saveAll(List.of(eventImage1, eventImage2, eventImage3));
+        }
+
+        @Test
+        void 유효한_요청이면_이벤트_이미지가_삭제된다() {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L, 2L));
+
+            // when
+            eventService.removeImages(1L, request);
+
+            // then
+            assertThat(eventImageRepository.findAllById(List.of(1L, 2L))).isEmpty();
+        }
+
+        @Test
+        void 존재하지_않는_이벤트를_입력하면_예외가_발생한다() {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.removeImages(999L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_이벤트_이미지를_삭제하면_예외가_발생한다() {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.removeImages(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_이벤트_이미지를_삭제하면_예외가_발생한다() {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(3L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.removeImages(2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 이벤트와_EventImage의_이벤트가_일치하지_않는_경우_예외가_발생한다() {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(3L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.removeImages(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EventErrorCode.EVENT_IMAGE_NOT_FROM_EVENT.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #120 

---
## 📌 작업 내용 및 특이사항
- 이벤트에서 EventImage를 제거하는 API를 구현했습니다.
- 이벤트에 이미지를 추가하는 것과 유사한 validation을 거치게 됩니다.
- deleteAllInBatch를 통해서 동시성 이슈가 발생하지 않기 때문에 별도로 동시성 문제를 점검하지 않았습니다.

---
## 📚 참고사항
- 이미지를 찾아오기 전에 권한에 대한 검증을 먼저하고 싶었고, 그런 이유로 validation이 서로 이격되어 있습니다.