### PR TITLE
refactor: 이미지 도메인 API endpoint & 초대 코드 지속 시간 리팩토링

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/InvitationLinkService.java
@@ -10,14 +10,14 @@ public class InvitationLinkService {
 
     private static final String INVITATION_LINK_PREFIX =
             "https://dev-api.cherrypic.today/albums/join?albumId=%d&code=%s";
-    private static final int INVITATION_LINK_DURATION = 30;
+    private static final int INVITATION_LINK_DURATION_HOURS = 24;
     private static final int UUID_LENGTH = 8;
 
     public InvitationCode createInvitationCode(Long albumId) {
         return InvitationCode.builder()
                 .albumId(albumId)
                 .code(UUID.randomUUID().toString().substring(0, UUID_LENGTH))
-                .ttl(Duration.ofMinutes(INVITATION_LINK_DURATION).getSeconds())
+                .ttl(Duration.ofHours(INVITATION_LINK_DURATION_HOURS).getSeconds())
                 .build();
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/controller/EventController.java
@@ -59,7 +59,7 @@ public class EventController {
         return eventService.getAlbumEvents(albumId, lastEventId, size, direction);
     }
 
-    @PostMapping("/{eventId}/add-images")
+    @PostMapping("/{eventId}/images")
     @Operation(summary = "이벤트에 이미지 추가", description = "앨범의 이미지를 이벤트로 추가합니다.")
     public ResponseEntity<Void> imagesAdd(
             @PathVariable Long eventId, @Valid @RequestBody EventImageAddRequest request) {
@@ -67,7 +67,7 @@ public class EventController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{eventId}/remove-images")
+    @DeleteMapping("/{eventId}/images")
     @Operation(summary = "이벤트에 이미지 제거", description = "앨범의 이미지를 이벤트에서 제거합니다.")
     public ResponseEntity<Void> imagesRemove(
             @PathVariable Long eventId, @Valid @RequestBody EventImageRemoveRequest request) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/exception/EventErrorCode.java
@@ -10,7 +10,7 @@ public enum EventErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(404, "존재하지 않는 이벤트입니다."),
     EVENT_DELETED(409, "이벤트 관련 작업 중 이벤트가 삭제되었습니다."),
 
-    EVENT_IMAGE_NOT_IN_EVENT(400, "해당 이미지는 이벤트에 속해 있지 않습니다.");
+    EVENT_IMAGES_NOT_IN_EVENT(400, "이벤트에 속해 있지 않은 이벤트 이미지가 포함되어 있습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -150,7 +150,7 @@ public class EventServiceImpl implements EventService {
         List<EventImage> eventImages = eventImageRepository.findAllById(distinctEventImagesIds);
         if (eventImages.isEmpty()) return; // 이미 모두 삭제된 경우
 
-        validateEventImageFromEvents(eventImages, event);
+        validateEventImageInEvents(eventImages, event);
 
         eventImageRepository.deleteAllInBatch(eventImages);
     }
@@ -195,7 +195,7 @@ public class EventServiceImpl implements EventService {
         }
     }
 
-    private void validateEventImageFromEvents(List<EventImage> eventImages, Event event) {
+    private void validateEventImageInEvents(List<EventImage> eventImages, Event event) {
         boolean containsNotFromEvent =
                 eventImages.stream().anyMatch(ei -> !ei.getEvent().getId().equals(event.getId()));
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -150,7 +150,7 @@ public class EventServiceImpl implements EventService {
         List<EventImage> eventImages = eventImageRepository.findAllById(distinctEventImagesIds);
         if (eventImages.isEmpty()) return; // 이미 모두 삭제된 경우
 
-        validateEventImageInEvents(eventImages, event);
+        validateEventImagesInEvent(eventImages, event);
 
         eventImageRepository.deleteAllInBatch(eventImages);
     }
@@ -185,7 +185,7 @@ public class EventServiceImpl implements EventService {
 
     private void validateAllImageAlbum(List<Long> imageIds, Long albumId) {
         if (imageRepository.countByIdInAndAlbumId(imageIds, albumId) != imageIds.size()) {
-            throw new CustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM);
+            throw new CustomException(ImageErrorCode.IMAGES_IN_OTHER_ALBUM);
         }
     }
 
@@ -195,12 +195,12 @@ public class EventServiceImpl implements EventService {
         }
     }
 
-    private void validateEventImageInEvents(List<EventImage> eventImages, Event event) {
+    private void validateEventImagesInEvent(List<EventImage> eventImages, Event event) {
         boolean containsNotFromEvent =
                 eventImages.stream().anyMatch(ei -> !ei.getEvent().getId().equals(event.getId()));
 
         if (containsNotFromEvent) {
-            throw new CustomException(EventErrorCode.EVENT_IMAGE_NOT_IN_EVENT);
+            throw new CustomException(EventErrorCode.EVENT_IMAGES_NOT_IN_EVENT);
         }
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -196,10 +196,10 @@ public class EventServiceImpl implements EventService {
     }
 
     private void validateEventImagesInEvent(List<EventImage> eventImages, Event event) {
-        boolean containsNotFromEvent =
+        boolean containsNotInEvent =
                 eventImages.stream().anyMatch(ei -> !ei.getEvent().getId().equals(event.getId()));
 
-        if (containsNotFromEvent) {
+        if (containsNotInEvent) {
             throw new CustomException(EventErrorCode.EVENT_IMAGES_NOT_IN_EVENT);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -33,10 +33,10 @@ public class ImageController {
         return imageService.createMemberProfileImageUploadUrl(request);
     }
 
-    @GetMapping("/albums/images")
+    @GetMapping("/albums/{albumId}/images")
     @Operation(summary = "앨범 이미지 목록 조회", description = "앨범의 이미지 목록을 조회합니다.")
     public SliceResponse<AlbumImageListResponse> albumImagesGet(
-            @RequestParam Long albumId,
+            @PathVariable Long albumId,
             @Parameter(description = "이전 페이지의 마지막 이미지 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastImageId,
@@ -47,10 +47,10 @@ public class ImageController {
         return imageService.getAlbumImages(albumId, lastImageId, size, direction);
     }
 
-    @GetMapping("/events/images")
+    @GetMapping("/events/{eventId}/images")
     @Operation(summary = "이벤트 이미지 목록 조회", description = "이벤트 이미지 목록을 조회합니다.")
     public SliceResponse<EventImageListResponse> eventImagesGet(
-            @RequestParam Long eventId,
+            @PathVariable Long eventId,
             @Parameter(description = "이전 페이지의 마지막 이벤트 이미지 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastEventImageId,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -8,7 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
-    IMAGES_FROM_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
+    IMAGES_IN_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
     IMAGE_DELETED(409, "이미지 관련 작업 중 이미지가 삭제되었습니다."),
     IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류");
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -615,7 +615,7 @@ class AlbumServiceTest extends IntegrationTest {
             InvitationCode createdCode = invitationCodeRepository.findById(1L).orElseThrow();
             assertThat(createdCode)
                     .extracting("albumId", "code", "ttl")
-                    .containsExactly(1L, createdCode.getCode(), 1800L);
+                    .containsExactly(1L, createdCode.getCode(), 86400L);
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -574,7 +574,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/add-images")
+                            post("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -594,7 +594,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/add-images")
+                            post("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -616,7 +616,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/add-images")
+                            post("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -638,7 +638,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/add-images")
+                            post("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -660,7 +660,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/add-images")
+                            post("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -681,7 +681,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/add-images")
+                            post("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -705,7 +705,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            delete("/events/1/remove-images")
+                            delete("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -725,7 +725,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            delete("/events/1/remove-images")
+                            delete("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -747,7 +747,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            delete("/events/1/remove-images")
+                            delete("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -769,7 +769,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            delete("/events/1/remove-images")
+                            delete("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -791,7 +791,7 @@ public class EventControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            delete("/events/1/remove-images")
+                            delete("/events/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -653,7 +653,7 @@ public class EventControllerTest {
         void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
-            willThrow(new CustomException(ImageErrorCode.IMAGES_FROM_OTHER_ALBUM))
+            willThrow(new CustomException(ImageErrorCode.IMAGES_IN_OTHER_ALBUM))
                     .given(eventService)
                     .addImages(1L, request);
 
@@ -667,7 +667,7 @@ public class EventControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("IMAGES_FROM_OTHER_ALBUM"))
+                    .andExpect(jsonPath("$.data.code").value("IMAGES_IN_OTHER_ALBUM"))
                     .andExpect(jsonPath("$.data.message").value("앨범 소속이 아닌 이미지를 포함하고 있습니다."));
         }
 
@@ -784,7 +784,7 @@ public class EventControllerTest {
         void 이벤트와_EventImage의_이벤트가_일치하지_않는_경우_예외가_발생한다() throws Exception {
             // given
             EventImageRemoveRequest request = new EventImageRemoveRequest(List.of(1L));
-            willThrow(new CustomException(EventErrorCode.EVENT_IMAGE_NOT_IN_EVENT))
+            willThrow(new CustomException(EventErrorCode.EVENT_IMAGES_NOT_IN_EVENT))
                     .given(eventService)
                     .removeImages(1L, request);
 
@@ -798,8 +798,9 @@ public class EventControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("EVENT_IMAGE_NOT_IN_EVENT"))
-                    .andExpect(jsonPath("$.data.message").value("해당 이미지는 이벤트에 속해 있지 않습니다."));
+                    .andExpect(jsonPath("$.data.code").value("EVENT_IMAGES_NOT_IN_EVENT"))
+                    .andExpect(
+                            jsonPath("$.data.message").value("이벤트에 속해 있지 않은 이벤트 이미지가 포함되어 있습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -518,6 +518,17 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 앨범_속하지_않은_이미지를_추가하면_예외가_발생한다() {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(3L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.addImages(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ImageErrorCode.IMAGES_IN_OTHER_ALBUM.getMessage());
+        }
+
+        @Test
         void 추가하고자_하는_이미지가_이미_추가된_동시성_충돌_시_재실행_된다() {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L, 4L));

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -725,7 +725,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.removeImages(1L, request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(EventErrorCode.EVENT_IMAGE_NOT_IN_EVENT.getMessage());
+                    .hasMessage(EventErrorCode.EVENT_IMAGES_NOT_IN_EVENT.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -113,10 +113,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
-                                    .param("size", "2")
-                                    .param("direction", "ASC"));
+                            get("/albums/1/images").param("size", "2").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -140,10 +137,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
-                                    .param("size", "2")
-                                    .param("direction", "DESC"));
+                            get("/albums/1/images").param("size", "2").param("direction", "DESC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -165,10 +159,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
-                                    .param("size", "1")
-                                    .param("direction", "ASC"));
+                            get("/albums/1/images").param("size", "1").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -191,10 +182,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
-                                    .param("size", "1")
-                                    .param("direction", "ASC"));
+                            get("/albums/1/images").param("size", "1").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -215,10 +203,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
-                                    .param("size", "1")
-                                    .param("direction", "ASC"));
+                            get("/albums/1/images").param("size", "1").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -236,10 +221,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "999")
-                                    .param("size", "2")
-                                    .param("direction", "ASC"));
+                            get("/albums/999/images").param("size", "2").param("direction", "ASC"));
 
             perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
@@ -257,10 +239,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
-                                    .param("size", "2")
-                                    .param("direction", "ASC"));
+                            get("/albums/1/images").param("size", "2").param("direction", "ASC"));
 
             perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
@@ -275,8 +254,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
+                            get("/albums/1/images")
                                     .param("size", pageSize)
                                     .param("direction", "ASC"));
 
@@ -293,10 +271,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/images")
-                                    .param("albumId", "1")
-                                    .param("size", "1")
-                                    .param("direction", sort));
+                            get("/albums/1/images").param("size", "1").param("direction", sort));
 
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
@@ -323,10 +298,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "2")
-                                    .param("direction", "ASC"));
+                            get("/events/1/images").param("size", "2").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -351,10 +323,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "2")
-                                    .param("direction", "DESC"));
+                            get("/events/1/images").param("size", "2").param("direction", "DESC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -376,10 +345,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "1")
-                                    .param("direction", "ASC"));
+                            get("/events/1/images").param("size", "1").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -402,10 +368,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "1")
-                                    .param("direction", "ASC"));
+                            get("/events/1/images").param("size", "1").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -426,10 +389,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "1")
-                                    .param("direction", "ASC"));
+                            get("/events/1/images").param("size", "1").param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -447,10 +407,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "2")
-                                    .param("direction", "ASC"));
+                            get("/events/1/images").param("size", "2").param("direction", "ASC"));
 
             perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
@@ -468,10 +425,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "2")
-                                    .param("direction", "ASC"));
+                            get("/events/1/images").param("size", "2").param("direction", "ASC"));
 
             perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
@@ -486,8 +440,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
+                            get("/events/1/images")
                                     .param("size", pageSize)
                                     .param("direction", "ASC"));
 
@@ -504,10 +457,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/images")
-                                    .param("eventId", "1")
-                                    .param("size", "1")
-                                    .param("direction", sort));
+                            get("/events/1/images").param("size", "1").param("direction", sort));
 
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))


### PR DESCRIPTION
## 🌱 관련 이슈
- close #123 

---
## 📌 작업 내용 및 특이사항
### 이벤트 이미지 추가 & 제거 API의 엔드 포인트가 변경 되었습니다. 
- 이벤트 이미지 추가 (POST /event/{eventId}/add-images ->  /event/{eventId}/images )
- 이벤트 이미지 제거 (DELETE /event/{eventId}/remove-images ->  /event/{eventId}/images )

### 앨범 이미지 조회 API의 엔드 포인트가 변경되었습니다.
- 앨범 이미지 조회 (GET /albums/images -> /albums/{albumId}/images )

### 초대 코드 Redis 지속 시간 변경
- 30분에서 24시간으로 확장되었습니다.
