### PR TITLE
fix: 이벤트 이미지 누락된 테스트 추가

### DIFF
--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -628,6 +628,28 @@ public class EventControllerTest {
         }
 
         @Test
+        void 앨범에_속하지_않은_사용자가_이벤트에_이미지를_추가하면_예외가_발생한다() throws Exception {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(eventService)
+                    .addImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
         void LIMITED_권한의_사용자가_이벤트에_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
@@ -801,6 +823,27 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.data.code").value("EVENT_IMAGES_NOT_IN_EVENT"))
                     .andExpect(
                             jsonPath("$.data.message").value("이벤트에 속해 있지 않은 이벤트 이미지가 포함되어 있습니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        void 제거할_이미지를_입력하지_않은_경우_예외가_발생한다(List<Long> input) throws Exception {
+            // given
+            EventImageRemoveRequest request = new EventImageRemoveRequest(input);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/events/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("제거할 이벤트 이미지 ID는 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -435,7 +435,8 @@ public class EventServiceTest extends IntegrationTest {
 
             Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
             Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2));
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
@@ -445,13 +446,15 @@ public class EventServiceTest extends IntegrationTest {
 
             Event event1 = Event.createEvent(album1, "testTitle1", "testCoverUrl1");
             Event event2 = Event.createEvent(album2, "testTitle2", "testCoverUrl2");
-            eventRepository.saveAll(List.of(event1, event2));
+            Event event3 = Event.createEvent(album3, "testTitle3", "testCoverUrl3");
+            eventRepository.saveAll(List.of(event1, event2, event3));
 
             Image image1 = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());
             Image image2 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
             Image image3 = Image.createImage(album2, 1L, "testUrl3", LocalDateTime.now());
             Image image4 = Image.createImage(album1, 1L, "testUrl4", LocalDateTime.now());
-            imageRepository.saveAll(List.of(image1, image2, image3, image4));
+            Image image5 = Image.createImage(album3, 1L, "testUrl5", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3, image4, image5));
 
             EventImage eventImage = EventImage.createEventImage(event1, image2);
             eventImageRepository.save(eventImage);
@@ -492,6 +495,17 @@ public class EventServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ImageErrorCode.IMAGES_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_이벤트에_이미지를_추가하면_예외가_발생한다() {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(5L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.addImages(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
 
         @Test

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/InvitationCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/InvitationCode.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
 @Getter
-@RedisHash(value = "InvitationCode")
+@RedisHash(value = "invitationCode")
 public class InvitationCode {
 
     @Id private Long albumId;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #126 

---
## 📌 작업 내용 및 특이사항
- 이벤트 이미지에서 누락된 테스트 케이스를 추가했습니다.
- 이벤트 이미지를 추가하는 경우 : 앨범 참가자 확인 테스트
- 이벤트 이미지를 삭제하는 경우 : (요청값 테스트) 삭제하고자 하는 이미지 ID를 비워둔 경우
- 기능적으로는 문제가 없었으나 테스트 케이스가 누락된 것을 추가했습니다.

---
## 📚 참고사항
- 초대 코드의 Redis Key를 카멜 케이스로 수정했습니다.