### PR TITLE
feat: 앨범 즐겨찾기 토글 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ sonarqube {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/**, **/*Application*.java, **/*Config*.java,' +
                 '**/*Dto*.java, **/*Request*.java, **/*Response*.java, **/*Exception*.java, **/*ErrorCode*.java, **/*Validator*.java,' +
-                '**/*FcmService*.java, **/EventImage.java, **/Notification.java'
+                '**/*FcmService*.java, **/EventImage.java, **/Notification.java, **/Favorites.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
@@ -7,4 +7,5 @@ public record AlbumListResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan) {}
+        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan,
+        @Schema(description = "즐겨찾기 상태", example = "true") Boolean marked) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -32,7 +32,8 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                                         album.id,
                                         album.title,
                                         album.coverUrl,
-                                        album.plan))
+                                        album.plan,
+                                        participant.favorites.marked))
                         .from(participant)
                         .join(participant.album, album)
                         .where(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -65,6 +65,8 @@ public class AlbumServiceImpl implements AlbumService {
 
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.HOST);
+        participant.assignFavorites();
+
         album.addParticipant(participant);
 
         if (request.plan() != AlbumPlan.BASIC) {
@@ -169,6 +171,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
+        participant.assignFavorites();
         participantRepository.save(participant);
 
         return AlbumJoinResponse.from(participant);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/controller/FavoritesController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/controller/FavoritesController.java
@@ -1,0 +1,23 @@
+package org.cherrypic.domain.favorites.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.favorites.dto.response.FavoritesMarkToggleResponse;
+import org.cherrypic.domain.favorites.service.FavoritesService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/albums/{albumId}/favorites")
+@RequiredArgsConstructor
+@Tag(name = "7. 즐겨찾기 API", description = "즐겨찾기 관련 API입니다.")
+public class FavoritesController {
+
+    private final FavoritesService favoritesService;
+
+    @PatchMapping
+    @Operation(summary = "앨범 즐겨찾기 토글", description = "앨범의 즐겨찾기 상태를 토글합니다.")
+    public FavoritesMarkToggleResponse markToggle(@PathVariable Long albumId) {
+        return favoritesService.toggleMark(albumId);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/dto/response/FavoritesMarkToggleResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/dto/response/FavoritesMarkToggleResponse.java
@@ -1,0 +1,11 @@
+package org.cherrypic.domain.favorites.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.favorites.entity.Favorites;
+
+public record FavoritesMarkToggleResponse(
+        @Schema(description = "즐겨찾기 상태", example = "true") Boolean marked) {
+    public static FavoritesMarkToggleResponse from(Favorites favorites) {
+        return new FavoritesMarkToggleResponse(favorites.getMarked());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
@@ -1,4 +1,4 @@
-package org.cherrypic.domain.favorites;
+package org.cherrypic.domain.favorites.repository;
 
 import org.cherrypic.favorites.entity.Favorites;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/service/FavoritesService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/service/FavoritesService.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.favorites.service;
+
+import org.cherrypic.domain.favorites.dto.response.FavoritesMarkToggleResponse;
+
+public interface FavoritesService {
+    FavoritesMarkToggleResponse toggleMark(Long albumId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/service/FavoritesServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/service/FavoritesServiceImpl.java
@@ -1,0 +1,51 @@
+package org.cherrypic.domain.favorites.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.favorites.dto.response.FavoritesMarkToggleResponse;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.favorites.entity.Favorites;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.entity.Participant;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FavoritesServiceImpl implements FavoritesService {
+
+    private final MemberUtil memberUtil;
+
+    private final AlbumRepository albumRepository;
+    private final ParticipantRepository participantRepository;
+
+    @Override
+    public FavoritesMarkToggleResponse toggleMark(Long albumId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+        final Participant participant =
+                getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
+
+        Favorites favorites = participant.getFavorites();
+        favorites.toggleMarked();
+
+        return FavoritesMarkToggleResponse.from(favorites);
+    }
+
+    private Album getAlbumById(Long albumId) {
+        return albumRepository
+                .findById(albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+
+    private Participant getParticipantByMemberIdAndAlbumId(Long memberId, Long albumId) {
+        return participantRepository
+                .findByMemberIdAndAlbumId(memberId, albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -712,8 +712,8 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums =
                     List.of(
-                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC),
-                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO));
+                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC, false),
+                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO, true));
 
             given(albumService.getParticipatingAlbums(null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(albums, true));
@@ -735,8 +735,9 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums =
                     List.of(
-                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO),
-                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC));
+                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO, true),
+                            new AlbumListResponse(
+                                    1L, "first", "coverUrl1", AlbumPlan.BASIC, false));
 
             given(albumService.getParticipatingAlbums(null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
@@ -757,7 +758,9 @@ class AlbumControllerTest {
         void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
             // given
             List<AlbumListResponse> albums =
-                    List.of(new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC));
+                    List.of(
+                            new AlbumListResponse(
+                                    1L, "first", "coverUrl1", AlbumPlan.BASIC, false));
 
             given(albumService.getParticipatingAlbums(null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
@@ -778,8 +781,9 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums =
                     List.of(
-                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO),
-                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC));
+                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO, true),
+                            new AlbumListResponse(
+                                    1L, "first", "coverUrl1", AlbumPlan.BASIC, false));
 
             given(albumService.getParticipatingAlbums(null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, false));

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -26,6 +26,7 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.domain.event.repository.EventRepository;
+import org.cherrypic.domain.favorites.repository.FavoritesRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
@@ -33,6 +34,7 @@ import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
@@ -64,6 +66,7 @@ class AlbumServiceTest extends IntegrationTest {
     @Autowired private PaymentRepository paymentRepository;
     @Autowired private SubscriptionRepository subscriptionRepository;
     @Autowired private ParticipantRepository participantRepository;
+    @Autowired private FavoritesRepository favoritesRepository;
     @Autowired private InvitationCodeRepository invitationCodeRepository;
     @Autowired private EventRepository eventRepository;
 
@@ -664,15 +667,25 @@ class AlbumServiceTest extends IntegrationTest {
                             "testNickname",
                             "testProfileImageUrl");
             memberRepository.save(member);
-
             given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2));
+
+            Favorites favorites1 = Favorites.createFavorites(participant1);
+            Favorites favorites2 = Favorites.createFavorites(participant2);
+            favoritesRepository.saveAll(List.of(favorites1, favorites2));
         }
 
         @Test
         void 정렬_조건이_ASC이면_albumId를_오름차순으로_조회한다() {
-            // given
-            createTestAlbums();
-
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbums(null, 2, SortDirection.ASC);
@@ -688,9 +701,6 @@ class AlbumServiceTest extends IntegrationTest {
 
         @Test
         void 정렬_조건이_DESC이면_albumId를_내림차순으로_조회한다() {
-            // given
-            createTestAlbums();
-
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbums(null, 2, SortDirection.DESC);
@@ -706,9 +716,6 @@ class AlbumServiceTest extends IntegrationTest {
 
         @Test
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
-            // given
-            createTestAlbums();
-
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbums(null, 2, SortDirection.DESC);
@@ -721,9 +728,6 @@ class AlbumServiceTest extends IntegrationTest {
 
         @Test
         void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
-            // given
-            createTestAlbums();
-
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbums(null, 1, SortDirection.DESC);
@@ -736,6 +740,9 @@ class AlbumServiceTest extends IntegrationTest {
 
         @Test
         void 앨범이_없는_경우_빈_리스트를_조회한다() {
+            // given
+            albumRepository.deleteAll();
+
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbums(null, 10, SortDirection.DESC);
@@ -744,20 +751,6 @@ class AlbumServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(response.content().size()).isZero(),
                     () -> assertThat(response.isLast()).isTrue());
-        }
-
-        private void createTestAlbums() {
-            Member member = memberRepository.findById(1L).get();
-
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.PRO, false);
-            albumRepository.saveAll(List.of(album1, album2));
-
-            Participant participant1 =
-                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
-            Participant participant2 =
-                    Participant.createParticipant(member, album2, ParticipantRole.HOST);
-            participantRepository.saveAll(List.of(participant1, participant2));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/favorites/controller/FavoritesControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/favorites/controller/FavoritesControllerTest.java
@@ -1,0 +1,82 @@
+package org.cherrypic.favorites.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.favorites.controller.FavoritesController;
+import org.cherrypic.domain.favorites.dto.response.FavoritesMarkToggleResponse;
+import org.cherrypic.domain.favorites.service.FavoritesService;
+import org.cherrypic.exception.CustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(FavoritesController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class FavoritesControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private FavoritesService favoritesService;
+
+    @Nested
+    class 앨범_즐겨찾기_토글_상태_변경_요청_시 {
+
+        @Test
+        void 유효한_요청이면_앨범의_즐겨찾기_상태가_변경된다() throws Exception {
+            // given
+            FavoritesMarkToggleResponse response = new FavoritesMarkToggleResponse(true);
+
+            given(favoritesService.toggleMark(1L)).willReturn(response);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(patch("/albums/1/favorites"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.marked").value(true));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(favoritesService.toggleMark(1L))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(patch("/albums/1/favorites"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            given(favoritesService.toggleMark(1L))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(patch("/albums/1/favorites"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/favorites/service/FavoritesServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/favorites/service/FavoritesServiceTest.java
@@ -1,0 +1,88 @@
+package org.cherrypic.favorites.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.favorites.repository.FavoritesRepository;
+import org.cherrypic.domain.favorites.service.FavoritesService;
+import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.favorites.entity.Favorites;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class FavoritesServiceTest extends IntegrationTest {
+
+    @Autowired private FavoritesService favoritesService;
+    @Autowired private FavoritesRepository favoritesRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private AlbumRepository albumRepository;
+    @Autowired private ParticipantRepository participantRepository;
+
+    @MockitoBean private MemberUtil memberUtil;
+
+    @Nested
+    class 앨범_즐겨찾기_토글_상태를_변경_할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            participantRepository.save(participant1);
+
+            favoritesRepository.save(Favorites.createFavorites(participant1));
+        }
+
+        @Test
+        void 유효한_요청이면_앨범의_즐겨찾기_상태가_변경된다() {
+            // when
+            favoritesService.toggleMark(1L);
+
+            // then
+            Favorites favorites = favoritesRepository.findById(1L).get();
+            Assertions.assertAll(() -> assertThat(favorites.getMarked()).isTrue());
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> favoritesService.toggleMark(999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> favoritesService.toggleMark(2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+    }
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -14,7 +14,6 @@ import org.cherrypic.common.exception.DomainErrorCode;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
-import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -57,9 +57,6 @@ public class Album extends BaseTimeEntity {
     private List<Participant> participants = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Favorites> favorites = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
@@ -5,9 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.cherrypic.album.entity.Album;
 import org.cherrypic.favorites.enums.FavoriteStatus;
-import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.entity.Participant;
 
 @Getter
 @Entity
@@ -18,13 +17,9 @@ public class Favorites {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "album_id")
-    private Album album;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id")
+    private Participant participant;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
@@ -3,6 +3,7 @@ package org.cherrypic.favorites.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.favorites.enums.FavoriteStatus;
@@ -24,4 +25,14 @@ public class Favorites {
     @NotNull
     @Enumerated(EnumType.STRING)
     private FavoriteStatus status;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Favorites(Participant participant, FavoriteStatus status) {
+        this.participant = participant;
+        this.status = status;
+    }
+
+    public static Favorites createFavorites(Participant participant) {
+        return Favorites.builder().participant(participant).status(FavoriteStatus.EXCLUDED).build();
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
@@ -32,4 +32,8 @@ public class Favorites {
     public static Favorites createFavorites(Participant participant) {
         return Favorites.builder().participant(participant).marked(false).build();
     }
+
+    public void toggleMarked() {
+        this.marked = !this.marked;
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/favorites/entity/Favorites.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.cherrypic.favorites.enums.FavoriteStatus;
 import org.cherrypic.participant.entity.Participant;
 
 @Getter
@@ -22,17 +21,15 @@ public class Favorites {
     @JoinColumn(name = "participant_id")
     private Participant participant;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private FavoriteStatus status;
+    @NotNull private Boolean marked;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Favorites(Participant participant, FavoriteStatus status) {
+    private Favorites(Participant participant, Boolean marked) {
         this.participant = participant;
-        this.status = status;
+        this.marked = marked;
     }
 
     public static Favorites createFavorites(Participant participant) {
-        return Favorites.builder().participant(participant).status(FavoriteStatus.EXCLUDED).build();
+        return Favorites.builder().participant(participant).marked(false).build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/favorites/enums/FavoriteStatus.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/favorites/enums/FavoriteStatus.java
@@ -1,6 +1,0 @@
-package org.cherrypic.favorites.enums;
-
-public enum FavoriteStatus {
-    INCLUDED,
-    EXCLUDED
-}

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.*;
 import org.cherrypic.common.model.BaseTimeEntity;
-import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.member.enums.MemberRole;
 import org.cherrypic.member.enums.MemberStatus;
 import org.cherrypic.participant.entity.Participant;
@@ -46,9 +45,6 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Participant> participants = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Favorites> favorites = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Member(

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
@@ -46,4 +46,8 @@ public class Participant extends BaseTimeEntity {
     public static Participant createParticipant(Member member, Album album, ParticipantRole role) {
         return Participant.builder().member(member).album(album).role(role).build();
     }
+
+    public void assignFavorites() {
+        this.favorites = Favorites.createFavorites(this);
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
+import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.enums.ParticipantRole;
 
@@ -31,6 +32,9 @@ public class Participant extends BaseTimeEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     private ParticipantRole role;
+
+    @OneToOne(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Favorites favorites;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Participant(Member member, Album album, ParticipantRole role) {

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -55,6 +55,26 @@ CREATE TABLE subscription (
                               CONSTRAINT fk_subscription_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
 
+CREATE TABLE participant (
+                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                             member_id BIGINT NOT NULL,
+                             album_id BIGINT NOT NULL,
+                             role VARCHAR(255) NOT NULL CHECK (role IN ('HOST','STANDARD','LIMITED')),
+                             password VARCHAR(255),
+                             created_at DATETIME(6) NOT NULL,
+                             updated_at DATETIME(6) NOT NULL,
+                             CONSTRAINT fk_participant_member FOREIGN KEY (member_id) REFERENCES member (id),
+                             CONSTRAINT fk_participant_album FOREIGN KEY (album_id) REFERENCES album (id)
+);
+
+
+CREATE TABLE favorites (
+                           id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                           participant_id BIGINT NOT NULL,
+                           status VARCHAR(255) NOT NULL CHECK (status IN ('INCLUDED','EXCLUDED')),
+                           CONSTRAINT fk_favorites_participant FOREIGN KEY (participant_id) REFERENCES participant (id)
+);
+
 
 CREATE TABLE event (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -78,6 +98,7 @@ CREATE TABLE image (
                        CONSTRAINT fk_image_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
 
+
 CREATE TABLE event_image (
                              id BIGINT AUTO_INCREMENT PRIMARY KEY,
                              event_id BIGINT,
@@ -87,27 +108,6 @@ CREATE TABLE event_image (
                              CONSTRAINT fk_event_image_event FOREIGN KEY (event_id) REFERENCES event(id),
                              CONSTRAINT fk_event_image_image FOREIGN KEY (image_id) REFERENCES image(id),
                              CONSTRAINT uk_event_image_event_id_image_id UNIQUE (event_id, image_id)
-);
-
-CREATE TABLE favorites (
-                           id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                           member_id BIGINT NOT NULL,
-                           album_id BIGINT NOT NULL,
-                           status VARCHAR(255) NOT NULL CHECK (status IN ('INCLUDED','EXCLUDED')),
-                           CONSTRAINT fk_favorites_member FOREIGN KEY (member_id) REFERENCES member (id),
-                           CONSTRAINT fk_favorites_album FOREIGN KEY (album_id) REFERENCES album (id)
-);
-
-
-CREATE TABLE participant (
-                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                             member_id BIGINT NOT NULL,
-                             album_id BIGINT NOT NULL,
-                             role VARCHAR(255) NOT NULL CHECK (role IN ('HOST','STANDARD','LIMITED')),
-                             created_at DATETIME(6) NOT NULL,
-                             updated_at DATETIME(6) NOT NULL,
-                             CONSTRAINT fk_participant_member FOREIGN KEY (member_id) REFERENCES member (id),
-                             CONSTRAINT fk_participant_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
 
 

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -71,7 +71,7 @@ CREATE TABLE participant (
 CREATE TABLE favorites (
                            id BIGINT AUTO_INCREMENT PRIMARY KEY,
                            participant_id BIGINT NOT NULL,
-                           status VARCHAR(255) NOT NULL CHECK (status IN ('INCLUDED','EXCLUDED')),
+                           marked BOOLEAN NOT NULL,
                            CONSTRAINT fk_favorites_participant FOREIGN KEY (participant_id) REFERENCES participant (id)
 );
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #101 

---
## 📌 작업 내용 및 특이사항
* 앨범 즐겨찾기 토글 기능을 구현했습니다.  
* 앨범 생성 또는 초대 코드를 통한 입장 시, 해당 Participant에 대한 Favorites 엔티티가 자동 생성되도록 처리했습니다.
  * 초기에 즐겨찾기 여부(marked)는 기본값 false로 설정되며, assignFavorites() 메서드를 통해 생성 시점에 연결됩니다. 
* 기존에는 즐겨찾기 기능을 Member와 Album 간의 관계로 구현했지만, 실제 사용자는 앨범에 참여한 경우에만 즐겨찾기를 설정할 수 있으므로, 이를 반영해 Favorites 엔티티를 Participant와 1:1 관계로 재구성했습니다. 
  * 이를 통해 즐겨찾기 상태를 참가자 단위로 정확하게 관리할 수 있도록 개선했습니다.
* 즐겨찾기 상태는 `marked`라는 boolean 값으로 단순화했습니다.  
* 앨범 목록 조회 시 현재 사용자의 즐겨찾기 상태를 함께 조회할 수 있도록 쿼리를 수정했습니다.

---
## 📚 참고사항
- Redis 동기화 방식은 사용하지 않고, RDB에 직접 업데이트하는 방식으로 구현했습니다.