### PR TITLE
feat: 앨범 참가자 목록 조회 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
@@ -8,7 +8,6 @@ import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.global.annotation.PageSize;
 import org.cherrypic.global.pagination.SliceResponse;
-import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -44,10 +43,7 @@ public class ParticipantController {
             @Parameter(description = "이전 페이지의 마지막 참가자 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastParticipantId,
-            @Parameter(description = "페이지당 조회할 참가자 수") @RequestParam @PageSize Integer size,
-            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
-                    @RequestParam(defaultValue = "DESC")
-                    SortDirection direction) {
-        return participantService.getParticipants(albumId, lastParticipantId, size, direction);
+            @Parameter(description = "페이지당 조회할 참가자 수") @RequestParam @PageSize Integer size) {
+        return participantService.getParticipants(albumId, lastParticipantId, size);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
@@ -40,10 +40,13 @@ public class ParticipantController {
     @Operation(summary = "참가자 목록 조회", description = "특정 앨범의 참가자 목록을 커서 기반 페이징 방식으로 조회합니다.")
     public SliceResponse<ParticipantListResponse> participantsGet(
             @PathVariable Long albumId,
+            @Parameter(description = "이전 페이지의 마지막 참가자 닉네임 (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    String lastNickname,
             @Parameter(description = "이전 페이지의 마지막 참가자 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastParticipantId,
             @Parameter(description = "페이지당 조회할 참가자 수") @RequestParam @PageSize Integer size) {
-        return participantService.getParticipants(albumId, lastParticipantId, size);
+        return participantService.getParticipants(albumId, lastNickname, lastParticipantId, size);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
@@ -1,18 +1,22 @@
 package org.cherrypic.domain.participant.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.service.ParticipantService;
+import org.cherrypic.global.annotation.PageSize;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/albums/{albumId}/participants")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "6. 참가자 API", description = "앨범의 참가자 관련 API입니다.")
 public class ParticipantController {
 
@@ -31,5 +35,19 @@ public class ParticipantController {
             @PathVariable Long albumId, @PathVariable Long participantId) {
         participantService.kickParticipant(albumId, participantId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    @Operation(summary = "참가자 목록 조회", description = "특정 앨범의 참가자 목록을 커서 기반 페이징 방식으로 조회합니다.")
+    public SliceResponse<ParticipantListResponse> participantsGet(
+            @PathVariable Long albumId,
+            @Parameter(description = "이전 페이지의 마지막 참가자 ID (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    Long lastParticipantId,
+            @Parameter(description = "페이지당 조회할 참가자 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
+                    @RequestParam(defaultValue = "DESC")
+                    SortDirection direction) {
+        return participantService.getParticipants(albumId, lastParticipantId, size, direction);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/dto/response/ParticipantListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/dto/response/ParticipantListResponse.java
@@ -1,0 +1,14 @@
+package org.cherrypic.domain.participant.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.participant.enums.ParticipantRole;
+
+public record ParticipantListResponse(
+        @Schema(description = "참가자 ID", example = "1") Long participantId,
+        @Schema(description = "회원 닉네임", example = "최현태") String nickname,
+        @Schema(
+                        description = "회원 프로필 사진",
+                        example =
+                                "http://k.kakaocdn.net/dn/ceTrU6/btsL0V0mhKO/DGqAZKAK/img_110x110.jpg")
+                String profileImageUrl,
+        @Schema(description = "참가자 역할", example = "STANDARD") ParticipantRole role) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/dto/response/ParticipantListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/dto/response/ParticipantListResponse.java
@@ -1,6 +1,7 @@
 package org.cherrypic.domain.participant.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 
 public record ParticipantListResponse(
@@ -11,4 +12,12 @@ public record ParticipantListResponse(
                         example =
                                 "http://k.kakaocdn.net/dn/ceTrU6/btsL0V0mhKO/DGqAZKAK/img_110x110.jpg")
                 String profileImageUrl,
-        @Schema(description = "참가자 역할", example = "STANDARD") ParticipantRole role) {}
+        @Schema(description = "참가자 역할", example = "STANDARD") ParticipantRole role) {
+    public static ParticipantListResponse from(Participant participant) {
+        return new ParticipantListResponse(
+                participant.getId(),
+                participant.getMember().getNickname(),
+                participant.getMember().getProfileImageUrl(),
+                participant.getRole());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
@@ -7,7 +7,9 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum ParticipantErrorCode implements BaseErrorCode {
-    PARTICIPANT_NOT_FOUND(404, "참가자를 찾을 수 없습니다.");
+    PARTICIPANT_NOT_FOUND(404, "참가자를 찾을 수 없습니다."),
+
+    MISSING_CURSOR_PAIR(400, "lastNickname과 lastParticipantId는 요청에 함께 포함되어야 합니다. 하나만 포함할 수는 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+public interface ParticipantRepository
+        extends JpaRepository<Participant, Long>, ParticipantRepositoryCustom {
     Optional<Participant> findByMemberIdAndAlbumId(Long memberId, Long albumId);
 
     @Modifying(clearAutomatically = true)

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -25,4 +25,6 @@ public interface ParticipantRepository
             @Param("albumId") Long albumId, @Param("memberId") Long memberId);
 
     int countByAlbumId(Long albumId);
+
+    long countByAlbumIdAndMemberIdNot(Long albumId, Long excludeMemberId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.participant.repository;
+
+import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
+import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.data.domain.Slice;
+
+public interface ParticipantRepositoryCustom {
+    Slice<ParticipantListResponse> findAllByAlbumId(
+            Long albumId, Long lastParticipantId, int size, SortDirection direction);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryCustom.java
@@ -4,5 +4,10 @@ import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.springframework.data.domain.Slice;
 
 public interface ParticipantRepositoryCustom {
-    Slice<ParticipantListResponse> findAllByAlbumId(Long albumId, Long lastParticipantId, int size);
+    Slice<ParticipantListResponse> findParticipantsByAlbumIdExcludingMemberId(
+            Long albumId,
+            Long excludeMemberId,
+            String lastNickname,
+            Long lastParticipantId,
+            int size);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryCustom.java
@@ -1,10 +1,8 @@
 package org.cherrypic.domain.participant.repository;
 
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
-import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.Slice;
 
 public interface ParticipantRepositoryCustom {
-    Slice<ParticipantListResponse> findAllByAlbumId(
-            Long albumId, Long lastParticipantId, int size, SortDirection direction);
+    Slice<ParticipantListResponse> findAllByAlbumId(Long albumId, Long lastParticipantId, int size);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.cherrypic.domain.participant.repository;
 import static org.cherrypic.member.entity.QMember.member;
 import static org.cherrypic.participant.entity.QParticipant.participant;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -20,8 +21,12 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<ParticipantListResponse> findAllByAlbumId(
-            Long albumId, Long lastParticipantId, int size) {
+    public Slice<ParticipantListResponse> findParticipantsByAlbumIdExcludingMemberId(
+            Long albumId,
+            Long excludeMemberId,
+            String lastNickname,
+            Long lastParticipantId,
+            int size) {
         List<ParticipantListResponse> results =
                 queryFactory
                         .select(
@@ -33,11 +38,30 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
                                         participant.role))
                         .from(participant)
                         .join(participant.member, member)
-                        .where(participant.album.id.eq(albumId))
+                        .where(
+                                participant.album.id.eq(albumId),
+                                participant.member.id.ne(excludeMemberId),
+                                cursorCondition(lastNickname, lastParticipantId))
+                        .orderBy(participant.member.nickname.asc(), participant.id.asc())
                         .limit(size + 1)
                         .fetch();
 
         return checkLastPage(size, results);
+    }
+
+    private BooleanBuilder cursorCondition(String lastNickname, Long lastParticipantId) {
+        return new BooleanBuilder()
+                .and(
+                        participant
+                                .member
+                                .nickname
+                                .gt(lastNickname)
+                                .or(
+                                        participant
+                                                .member
+                                                .nickname
+                                                .eq(lastNickname)
+                                                .and(participant.id.gt(lastParticipantId))));
     }
 
     private Slice<ParticipantListResponse> checkLastPage(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
@@ -50,6 +50,10 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
     }
 
     private BooleanBuilder cursorCondition(String lastNickname, Long lastParticipantId) {
+        if (lastNickname == null && lastParticipantId == null) {
+            return null;
+        }
+
         return new BooleanBuilder()
                 .and(
                         participant

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
@@ -1,0 +1,73 @@
+package org.cherrypic.domain.participant.repository;
+
+import static org.cherrypic.member.entity.QMember.member;
+import static org.cherrypic.participant.entity.QParticipant.participant;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
+import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<ParticipantListResponse> findAllByAlbumId(
+            Long albumId, Long lastParticipantId, int size, SortDirection direction) {
+        List<ParticipantListResponse> results =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        ParticipantListResponse.class,
+                                        participant.id,
+                                        member.nickname,
+                                        member.profileImageUrl,
+                                        participant.role))
+                        .from(participant)
+                        .join(participant.member, member)
+                        .where(
+                                participant.album.id.eq(albumId),
+                                lastParticipantIdCondition(lastParticipantId, direction))
+                        .orderBy(
+                                direction == SortDirection.DESC
+                                        ? participant.id.desc()
+                                        : participant.id.asc())
+                        .limit(size + 1)
+                        .fetch();
+
+        return checkLastPage(size, results);
+    }
+
+    private BooleanExpression lastParticipantIdCondition(
+            Long participantId, SortDirection direction) {
+        if (participantId == null) {
+            return null;
+        }
+
+        return direction == SortDirection.DESC
+                ? participant.id.lt(participantId)
+                : participant.id.gt(participantId);
+    }
+
+    private Slice<ParticipantListResponse> checkLastPage(
+            int pageSize, List<ParticipantListResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepositoryImpl.java
@@ -4,12 +4,10 @@ import static org.cherrypic.member.entity.QMember.member;
 import static org.cherrypic.participant.entity.QParticipant.participant;
 
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
-import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -23,7 +21,7 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
 
     @Override
     public Slice<ParticipantListResponse> findAllByAlbumId(
-            Long albumId, Long lastParticipantId, int size, SortDirection direction) {
+            Long albumId, Long lastParticipantId, int size) {
         List<ParticipantListResponse> results =
                 queryFactory
                         .select(
@@ -35,28 +33,11 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
                                         participant.role))
                         .from(participant)
                         .join(participant.member, member)
-                        .where(
-                                participant.album.id.eq(albumId),
-                                lastParticipantIdCondition(lastParticipantId, direction))
-                        .orderBy(
-                                direction == SortDirection.DESC
-                                        ? participant.id.desc()
-                                        : participant.id.asc())
+                        .where(participant.album.id.eq(albumId))
                         .limit(size + 1)
                         .fetch();
 
         return checkLastPage(size, results);
-    }
-
-    private BooleanExpression lastParticipantIdCondition(
-            Long participantId, SortDirection direction) {
-        if (participantId == null) {
-            return null;
-        }
-
-        return direction == SortDirection.DESC
-                ? participant.id.lt(participantId)
-                : participant.id.gt(participantId);
     }
 
     private Slice<ParticipantListResponse> checkLastPage(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
@@ -2,7 +2,6 @@ package org.cherrypic.domain.participant.service;
 
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.global.pagination.SliceResponse;
-import org.cherrypic.global.pagination.SortDirection;
 
 public interface ParticipantService {
     void leaveAlbum(Long albumId);
@@ -10,5 +9,5 @@ public interface ParticipantService {
     void kickParticipant(Long albumId, Long participantId);
 
     SliceResponse<ParticipantListResponse> getParticipants(
-            Long albumId, Long lastParticipantId, int size, SortDirection direction);
+            Long albumId, Long lastParticipantId, int size);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
@@ -1,7 +1,14 @@
 package org.cherrypic.domain.participant.service;
 
+import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
+
 public interface ParticipantService {
     void leaveAlbum(Long albumId);
 
     void kickParticipant(Long albumId, Long participantId);
+
+    SliceResponse<ParticipantListResponse> getParticipants(
+            Long albumId, Long lastParticipantId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
@@ -9,5 +9,5 @@ public interface ParticipantService {
     void kickParticipant(Long albumId, Long participantId);
 
     SliceResponse<ParticipantListResponse> getParticipants(
-            Long albumId, Long lastParticipantId, int size);
+            Long albumId, String lastNickname, Long lastParticipantId, int size);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -10,7 +10,6 @@ import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
-import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
@@ -71,14 +70,14 @@ public class ParticipantServiceImpl implements ParticipantService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<ParticipantListResponse> getParticipants(
-            Long albumId, Long lastParticipantId, int size, SortDirection direction) {
+            Long albumId, Long lastParticipantId, int size) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumById(albumId);
 
         getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
 
         Slice<ParticipantListResponse> results =
-                participantRepository.findAllByAlbumId(albumId, lastParticipantId, size, direction);
+                participantRepository.findAllByAlbumId(albumId, lastParticipantId, size);
 
         return SliceResponse.from(results);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -5,13 +5,17 @@ import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.notification.repository.NotificationRepository;
+import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.springframework.data.domain.Slice;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +66,20 @@ public class ParticipantServiceImpl implements ParticipantService {
                     target.getMember().getId(), album.getId());
         } catch (ObjectOptimisticLockingFailureException ignored) {
         }
+    }
+
+    @Override
+    public SliceResponse<ParticipantListResponse> getParticipants(
+            Long albumId, Long lastParticipantId, int size, SortDirection direction) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
+
+        Slice<ParticipantListResponse> results =
+                participantRepository.findAllByAlbumId(albumId, lastParticipantId, size, direction);
+
+        return SliceResponse.from(results);
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -69,6 +69,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public SliceResponse<ParticipantListResponse> getParticipants(
             Long albumId, Long lastParticipantId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -1,5 +1,7 @@
 package org.cherrypic.domain.participant.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -70,16 +72,43 @@ public class ParticipantServiceImpl implements ParticipantService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<ParticipantListResponse> getParticipants(
-            Long albumId, Long lastParticipantId, int size) {
+            Long albumId, String lastNickname, Long lastParticipantId, int size) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumById(albumId);
+        final Participant currentParticipant =
+                getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
 
-        getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
+        if ((lastNickname == null) != (lastParticipantId == null)) {
+            throw new CustomException(ParticipantErrorCode.MISSING_CURSOR_PAIR);
+        }
 
-        Slice<ParticipantListResponse> results =
-                participantRepository.findAllByAlbumId(albumId, lastParticipantId, size);
+        List<ParticipantListResponse> results = new ArrayList<>();
+        int adjustedSize = size;
 
-        return SliceResponse.from(results);
+        if (lastNickname == null) {
+            results.add(ParticipantListResponse.from(currentParticipant));
+            adjustedSize = size - 1;
+
+            if (adjustedSize == 0) {
+                boolean hasNext =
+                        participantRepository.countByAlbumIdAndMemberIdNot(
+                                        albumId, currentMember.getId())
+                                > 0;
+                return new SliceResponse<>(results, !hasNext);
+            }
+        }
+
+        Slice<ParticipantListResponse> paged =
+                participantRepository.findParticipantsByAlbumIdExcludingMemberId(
+                        albumId,
+                        currentMember.getId(),
+                        lastNickname,
+                        lastParticipantId,
+                        adjustedSize);
+
+        results.addAll(paged.getContent());
+
+        return new SliceResponse<>(results, paged.isLast());
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -15,7 +15,6 @@ import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
-import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -229,74 +228,6 @@ class ParticipantControllerTest {
     class 참가자_목록_조회_요청_시 {
 
         @Test
-        void 정렬_조건이_ASC이면_participantId를_오름차순으로_응답한다() throws Exception {
-            // given
-            List<ParticipantListResponse> participants =
-                    List.of(
-                            new ParticipantListResponse(
-                                    1L,
-                                    "testNickname1",
-                                    "testProfileImageUrl2",
-                                    ParticipantRole.HOST),
-                            new ParticipantListResponse(
-                                    2L,
-                                    "testNickname2",
-                                    "testProfileImageUrl1",
-                                    ParticipantRole.STANDARD));
-
-            given(participantService.getParticipants(1L, null, 2, SortDirection.ASC))
-                    .willReturn(new SliceResponse<>(participants, true));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", "2")
-                                    .param("direction", "ASC"));
-
-            perform.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                    .andExpect(jsonPath("$.data.content[0].participantId").value(1))
-                    .andExpect(jsonPath("$.data.content[1].participantId").value(2))
-                    .andExpect(jsonPath("$.data.isLast").value(true));
-        }
-
-        @Test
-        void 정렬_조건이_DESC이면_participantId를_내림차순으로_응답한다() throws Exception {
-            // given
-            List<ParticipantListResponse> participants =
-                    List.of(
-                            new ParticipantListResponse(
-                                    2L,
-                                    "testNickname2",
-                                    "testProfileImageUrl1",
-                                    ParticipantRole.STANDARD),
-                            new ParticipantListResponse(
-                                    1L,
-                                    "testNickname1",
-                                    "testProfileImageUrl2",
-                                    ParticipantRole.HOST));
-
-            given(participantService.getParticipants(1L, null, 2, SortDirection.DESC))
-                    .willReturn(new SliceResponse<>(participants, true));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", "2")
-                                    .param("direction", "DESC"));
-
-            perform.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                    .andExpect(jsonPath("$.data.content[0].participantId").value(2))
-                    .andExpect(jsonPath("$.data.content[1].participantId").value(1))
-                    .andExpect(jsonPath("$.data.isLast").value(true));
-        }
-
-        @Test
         void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
             // given
             List<ParticipantListResponse> participants =
@@ -312,15 +243,12 @@ class ParticipantControllerTest {
                                     "testProfileImageUrl2",
                                     ParticipantRole.HOST));
 
-            given(participantService.getParticipants(1L, null, 2, SortDirection.DESC))
+            given(participantService.getParticipants(1L, null, 2))
                     .willReturn(new SliceResponse<>(participants, true));
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", "2")
-                                    .param("direction", "DESC"));
+                    mockMvc.perform(get("/albums/1/participants").param("size", "2"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -345,15 +273,12 @@ class ParticipantControllerTest {
                                     "testProfileImageUrl2",
                                     ParticipantRole.HOST));
 
-            given(participantService.getParticipants(1L, null, 1, SortDirection.DESC))
+            given(participantService.getParticipants(1L, null, 1))
                     .willReturn(new SliceResponse<>(participants, false));
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", "1")
-                                    .param("direction", "DESC"));
+                    mockMvc.perform(get("/albums/1/participants").param("size", "1"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -367,14 +292,11 @@ class ParticipantControllerTest {
             // given
             willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
                     .given(participantService)
-                    .getParticipants(1L, null, 2, SortDirection.DESC);
+                    .getParticipants(1L, null, 2);
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", "2")
-                                    .param("direction", "DESC"));
+                    mockMvc.perform(get("/albums/1/participants").param("size", "2"));
 
             perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
@@ -388,14 +310,11 @@ class ParticipantControllerTest {
             // given
             willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
                     .given(participantService)
-                    .getParticipants(1L, null, 2, SortDirection.DESC);
+                    .getParticipants(1L, null, 2);
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", "2")
-                                    .param("direction", "DESC"));
+                    mockMvc.perform(get("/albums/1/participants").param("size", "2"));
 
             perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
@@ -409,33 +328,13 @@ class ParticipantControllerTest {
         void 페이지_크기가_0_이하이면_예외가_발생한다(String pageSize) throws Exception {
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", pageSize)
-                                    .param("direction", "DESC"));
+                    mockMvc.perform(get("/albums/1/participants").param("size", pageSize));
 
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("ConstraintViolationException"))
                     .andExpect(jsonPath("$.data.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
-        void 존재하지_않는_정렬_기준을_입력하면_예외가_발생한다(String sort) throws Exception {
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums/1/participants")
-                                    .param("size", "2")
-                                    .param("direction", sort));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
-                    .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -243,7 +243,7 @@ class ParticipantControllerTest {
                                     "testProfileImageUrl2",
                                     ParticipantRole.HOST));
 
-            given(participantService.getParticipants(1L, null, 2))
+            given(participantService.getParticipants(1L, null, null, 2))
                     .willReturn(new SliceResponse<>(participants, true));
 
             // when & then
@@ -273,7 +273,7 @@ class ParticipantControllerTest {
                                     "testProfileImageUrl2",
                                     ParticipantRole.HOST));
 
-            given(participantService.getParticipants(1L, null, 1))
+            given(participantService.getParticipants(1L, null, null, 1))
                     .willReturn(new SliceResponse<>(participants, false));
 
             // when & then
@@ -290,9 +290,8 @@ class ParticipantControllerTest {
         @Test
         void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
             // given
-            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
-                    .given(participantService)
-                    .getParticipants(1L, null, 2);
+            given(participantService.getParticipants(1L, null, null, 2))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
             // when & then
             ResultActions perform =
@@ -308,9 +307,8 @@ class ParticipantControllerTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
-                    .given(participantService)
-                    .getParticipants(1L, null, 2);
+            given(participantService.getParticipants(1L, null, null, 2))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
             ResultActions perform =
@@ -321,6 +319,52 @@ class ParticipantControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                     .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
                     .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void lastNickname만_포함된_요청의_경우_예외가_발생한다() throws Exception {
+            // given
+            given(participantService.getParticipants(1L, "가가가", null, 2))
+                    .willThrow(new CustomException(ParticipantErrorCode.MISSING_CURSOR_PAIR));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("lastNickname", "가가가"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MISSING_CURSOR_PAIR"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(
+                                            "lastNickname과 lastParticipantId는 요청에 함께 포함되어야 합니다. 하나만 포함할 수는 없습니다."));
+        }
+
+        @Test
+        void lastParticipantId만_포함된_요청의_경우_예외가_발생한다() throws Exception {
+            // given
+            given(participantService.getParticipants(1L, null, 1L, 2))
+                    .willThrow(new CustomException(ParticipantErrorCode.MISSING_CURSOR_PAIR));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("lastParticipantId", "1"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MISSING_CURSOR_PAIR"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(
+                                            "lastNickname과 lastParticipantId는 요청에 함께 포함되어야 합니다. 하나만 포함할 수는 없습니다."));
         }
 
         @ParameterizedTest

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -6,14 +6,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.participant.controller.ParticipantController;
+import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.participant.enums.ParticipantRole;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -215,6 +222,220 @@ class ParticipantControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("PARTICIPANT_NOT_IN_ALBUM"))
                     .andExpect(jsonPath("$.data.message").value("해당 참가자는 이 앨범에 속해 있지 않습니다."));
+        }
+    }
+
+    @Nested
+    class 참가자_목록_조회_요청_시 {
+
+        @Test
+        void 정렬_조건이_ASC이면_participantId를_오름차순으로_응답한다() throws Exception {
+            // given
+            List<ParticipantListResponse> participants =
+                    List.of(
+                            new ParticipantListResponse(
+                                    1L,
+                                    "testNickname1",
+                                    "testProfileImageUrl2",
+                                    ParticipantRole.HOST),
+                            new ParticipantListResponse(
+                                    2L,
+                                    "testNickname2",
+                                    "testProfileImageUrl1",
+                                    ParticipantRole.STANDARD));
+
+            given(participantService.getParticipants(1L, null, 2, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(participants, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].participantId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].participantId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_participantId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<ParticipantListResponse> participants =
+                    List.of(
+                            new ParticipantListResponse(
+                                    2L,
+                                    "testNickname2",
+                                    "testProfileImageUrl1",
+                                    ParticipantRole.STANDARD),
+                            new ParticipantListResponse(
+                                    1L,
+                                    "testNickname1",
+                                    "testProfileImageUrl2",
+                                    ParticipantRole.HOST));
+
+            given(participantService.getParticipants(1L, null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(participants, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].participantId").value(2))
+                    .andExpect(jsonPath("$.data.content[1].participantId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
+            // given
+            List<ParticipantListResponse> participants =
+                    List.of(
+                            new ParticipantListResponse(
+                                    2L,
+                                    "testNickname2",
+                                    "testProfileImageUrl1",
+                                    ParticipantRole.STANDARD),
+                            new ParticipantListResponse(
+                                    1L,
+                                    "testNickname1",
+                                    "testProfileImageUrl2",
+                                    ParticipantRole.HOST));
+
+            given(participantService.getParticipants(1L, null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(participants, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].participantId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_응답한다() throws Exception {
+            // given
+            List<ParticipantListResponse> participants =
+                    List.of(
+                            new ParticipantListResponse(
+                                    2L,
+                                    "testNickname2",
+                                    "testProfileImageUrl1",
+                                    ParticipantRole.STANDARD),
+                            new ParticipantListResponse(
+                                    1L,
+                                    "testNickname1",
+                                    "testProfileImageUrl2",
+                                    ParticipantRole.HOST));
+
+            given(participantService.getParticipants(1L, null, 1, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(participants, false));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "1")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].participantId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(false));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(participantService)
+                    .getParticipants(1L, null, 2, SortDirection.DESC);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(participantService)
+                    .getParticipants(1L, null, 2, SortDirection.DESC);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "-999", "0"})
+        void 페이지_크기가_0_이하이면_예외가_발생한다(String pageSize) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", pageSize)
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ConstraintViolationException"))
+                    .andExpect(jsonPath("$.data.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
+        void 존재하지_않는_정렬_기준을_입력하면_예외가_발생한다(String sort) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/participants")
+                                    .param("size", "2")
+                                    .param("direction", sort));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -18,7 +18,6 @@ import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
-import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
@@ -315,40 +314,10 @@ class ParticipantServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 정렬_조건이_ASC이면_participantId를_오름차순으로_조회한다() {
-            // when
-            SliceResponse<ParticipantListResponse> response =
-                    participantService.getParticipants(1L, null, 2, SortDirection.ASC);
-
-            // then
-            Assertions.assertAll(
-                    () ->
-                            assertThat(response.content())
-                                    .extracting("participantId")
-                                    .containsExactly(1L, 2L),
-                    () -> assertThat(response.isLast()).isTrue());
-        }
-
-        @Test
-        void 정렬_조건이_DESC이면_participantId를_내림차순으로_조회한다() {
-            // when
-            SliceResponse<ParticipantListResponse> response =
-                    participantService.getParticipants(1L, null, 2, SortDirection.DESC);
-
-            // then
-            Assertions.assertAll(
-                    () ->
-                            assertThat(response.content())
-                                    .extracting("participantId")
-                                    .containsExactly(2L, 1L),
-                    () -> assertThat(response.isLast()).isTrue());
-        }
-
-        @Test
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
             SliceResponse<ParticipantListResponse> response =
-                    participantService.getParticipants(1L, null, 2, SortDirection.DESC);
+                    participantService.getParticipants(1L, null, 2);
 
             // then
             Assertions.assertAll(
@@ -360,7 +329,7 @@ class ParticipantServiceTest extends IntegrationTest {
         void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
             // when
             SliceResponse<ParticipantListResponse> response =
-                    participantService.getParticipants(1L, null, 1, SortDirection.DESC);
+                    participantService.getParticipants(1L, null, 1);
 
             // then
             Assertions.assertAll(
@@ -371,10 +340,7 @@ class ParticipantServiceTest extends IntegrationTest {
         @Test
         void 앨범이_존재하지_않는_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(
-                            () ->
-                                    participantService.getParticipants(
-                                            999L, null, 2, SortDirection.DESC))
+            assertThatThrownBy(() -> participantService.getParticipants(999L, null, 2))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -382,10 +348,7 @@ class ParticipantServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(
-                            () ->
-                                    participantService.getParticipants(
-                                            2L, null, 2, SortDirection.DESC))
+            assertThatThrownBy(() -> participantService.getParticipants(2L, null, 2))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -12,10 +12,13 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.notification.repository.NotificationRepository;
+import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
@@ -279,6 +282,112 @@ class ParticipantServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> participantService.kickParticipant(1L, 3L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM.getMessage());
+        }
+    }
+
+    @Nested
+    class 참가자_목록을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.STANDARD);
+            participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @Test
+        void 정렬_조건이_ASC이면_participantId를_오름차순으로_조회한다() {
+            // when
+            SliceResponse<ParticipantListResponse> response =
+                    participantService.getParticipants(1L, null, 2, SortDirection.ASC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content())
+                                    .extracting("participantId")
+                                    .containsExactly(1L, 2L),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_participantId를_내림차순으로_조회한다() {
+            // when
+            SliceResponse<ParticipantListResponse> response =
+                    participantService.getParticipants(1L, null, 2, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content())
+                                    .extracting("participantId")
+                                    .containsExactly(2L, 1L),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_반환한다() {
+            // when
+            SliceResponse<ParticipantListResponse> response =
+                    participantService.getParticipants(1L, null, 2, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(2),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
+            // when
+            SliceResponse<ParticipantListResponse> response =
+                    participantService.getParticipants(1L, null, 1, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(1),
+                    () -> assertThat(response.isLast()).isFalse());
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    participantService.getParticipants(
+                                            999L, null, 2, SortDirection.DESC))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    participantService.getParticipants(
+                                            2L, null, 2, SortDirection.DESC))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -292,14 +292,24 @@ class ParticipantServiceTest extends IntegrationTest {
             Member member1 =
                     Member.createMember(
                             OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
-                            "testNickname1",
+                            "가가가",
                             "testProfileImageUrl1");
             Member member2 =
                     Member.createMember(
                             OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
-                            "testNickname2",
+                            "다다다",
                             "testProfileImageUrl2");
-            memberRepository.saveAll(List.of(member1, member2));
+            Member member3 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId3", "testOauthProvider3"),
+                            "나나나",
+                            "testProfileImageUrl3");
+            Member member4 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId4", "testOauthProvider4"),
+                            "다다다",
+                            "testProfileImageUrl4");
+            memberRepository.saveAll(List.of(member1, member2, member3, member4));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
@@ -310,18 +320,51 @@ class ParticipantServiceTest extends IntegrationTest {
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
             Participant participant2 =
                     Participant.createParticipant(member2, album1, ParticipantRole.STANDARD);
-            participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant3 =
+                    Participant.createParticipant(member3, album1, ParticipantRole.STANDARD);
+            Participant participant4 =
+                    Participant.createParticipant(member4, album1, ParticipantRole.STANDARD);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4));
+        }
+
+        @Test
+        void 본인_조회_후_닉네임_오름차순으로_이후_참가자를_조회한다() {
+            // when
+            SliceResponse<ParticipantListResponse> firstPage =
+                    participantService.getParticipants(1L, null, null, 1);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(firstPage.content().size()).isEqualTo(1),
+                    () -> assertThat(firstPage.content().getFirst().participantId()).isEqualTo(1),
+                    () -> assertThat(firstPage.content().getFirst().nickname()).isEqualTo("가가가"),
+                    () -> assertThat(firstPage.isLast()).isFalse());
+
+            // when
+            SliceResponse<ParticipantListResponse> secondPage =
+                    participantService.getParticipants(1L, "가가가", 1L, 3);
+
+            Assertions.assertAll(
+                    () -> assertThat(secondPage.content().size()).isEqualTo(3),
+                    () -> assertThat(secondPage.content().getFirst().participantId()).isEqualTo(3),
+                    () -> assertThat(secondPage.content().getFirst().nickname()).isEqualTo("나나나"),
+                    () -> assertThat(secondPage.content().get(1).participantId()).isEqualTo(2),
+                    () -> assertThat(secondPage.content().get(1).nickname()).isEqualTo("다다다"),
+                    () -> assertThat(secondPage.content().get(2).participantId()).isEqualTo(4),
+                    () -> assertThat(secondPage.content().get(2).nickname()).isEqualTo("다다다"),
+                    () -> assertThat(secondPage.isLast()).isTrue());
         }
 
         @Test
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
             SliceResponse<ParticipantListResponse> response =
-                    participantService.getParticipants(1L, null, 2);
+                    participantService.getParticipants(1L, null, null, 4);
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(response.content().size()).isEqualTo(2),
+                    () -> assertThat(response.content().size()).isEqualTo(4),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -329,18 +372,18 @@ class ParticipantServiceTest extends IntegrationTest {
         void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
             // when
             SliceResponse<ParticipantListResponse> response =
-                    participantService.getParticipants(1L, null, 1);
+                    participantService.getParticipants(1L, null, null, 2);
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(response.content().size()).isEqualTo(1),
+                    () -> assertThat(response.content().size()).isEqualTo(2),
                     () -> assertThat(response.isLast()).isFalse());
         }
 
         @Test
         void 앨범이_존재하지_않는_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> participantService.getParticipants(999L, null, 2))
+            assertThatThrownBy(() -> participantService.getParticipants(999L, null, null, 2))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -348,9 +391,23 @@ class ParticipantServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> participantService.getParticipants(2L, null, 2))
+            assertThatThrownBy(() -> participantService.getParticipants(2L, null, null, 2))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void lastNickname만_포함된_요청의_경우_예외가_발생한다() {
+            assertThatThrownBy(() -> participantService.getParticipants(1L, "가가가", null, 2))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ParticipantErrorCode.MISSING_CURSOR_PAIR.getMessage());
+        }
+
+        @Test
+        void lastParticipantId만_포함된_요청의_경우_예외가_발생한다() {
+            assertThatThrownBy(() -> participantService.getParticipants(1L, null, 1L, 2))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ParticipantErrorCode.MISSING_CURSOR_PAIR.getMessage());
         }
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
@@ -32,8 +32,6 @@ public class Participant extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ParticipantRole role;
 
-    private String password;
-
     @Builder(access = AccessLevel.PRIVATE)
     private Participant(Member member, Album album, ParticipantRole role) {
         this.member = member;

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -103,7 +103,6 @@ CREATE TABLE participant (
                              member_id BIGINT NOT NULL,
                              album_id BIGINT NOT NULL,
                              role VARCHAR(255) NOT NULL CHECK (role IN ('HOST','STANDARD','LIMITED')),
-                             password VARCHAR(255),
                              created_at DATETIME(6) NOT NULL,
                              updated_at DATETIME(6) NOT NULL,
                              CONSTRAINT fk_participant_member FOREIGN KEY (member_id) REFERENCES member (id),

--- a/cherrypic-domain/src/main/resources/db/migration/V2__create_member_nickname_index.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V2__create_member_nickname_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_member_nickname ON member(nickname);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #112 

---
## 📌 작업 내용 및 특이사항
* 앨범의 참가자 목록을 닉네임 기준 오름차순으로 조회하는 커서 기반 페이징 기능을 구현했습니다.
  * 첫 페이지 요청의 경우, 클라이언트에서 lastNickname, lastParticipantId를 포함하지 않기 때문에 현재 사용자의 정보를 가장 먼저 응답에 포함시킵니다.
  * 이후, 요청된 size 값에서 본인을 포함한 수를 뺀 남은 개수만큼 다른 참가자들을 닉네임 기준으로 정렬하여 추가 조회합니다.
  * 이후 페이지 요청부터는 lastNickname, lastParticipantId가 커서로 함께 전달되며, 이를 기준으로 닉네임 오름차순 → 동일 닉네임이면 participantId 오름차순 방식으로 참가자 목록을 순차적으로 조회합니다.
  * 이때 동일 닉네임이 여러 명일 경우 participantId 오름차순, 즉 앨범에 먼저 입장한 순서대로 정렬되어 응답됩니다.
  * 응답 항목에는 참가자의 ID, 닉네임, 프로필 이미지 URL, 권한 정보가 포함됩니다.
* 또한, 더 이상 사용되지 않는 Participant 테이블의 앨범 비밀번호(albumPassword) 필드를 제거하였습니다.
