### PR TITLE
feat: 앨범 입장 시 인원 수 제한 기능 추가

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -20,6 +20,7 @@ public enum AlbumErrorCode implements BaseErrorCode {
     INVITATION_CODE_NOT_FOUND(404, "앨범의 초대 코드가 만료되었습니다."),
     INVITATION_CODE_MISMATCH(400, "초대 코드가 올바르지 않습니다."),
     ALREADY_PARTICIPATED(400, "이미 참가한 앨범입니다."),
+    ALBUM_PARTICIPANT_LIMIT_EXCEEDED(400, "앨범 인원 제한으로 더 이상 참가할 수 없습니다."),
 
     OTHER_PARTICIPANTS_EXIST(400, "다른 참가자가 남아 있어 앨범을 삭제할 수 없습니다."),
     SUBSCRIPTION_ACTIVE(400, "구독 중인 앨범은 삭제할 수 없습니다."),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
@@ -1,6 +1,15 @@
 package org.cherrypic.domain.album.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.cherrypic.album.entity.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {}
+public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from Album a where a.id = :albumId")
+    Optional<Album> findByIdWithPessimisticLock(@Param("albumId") Long albumId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -154,7 +154,7 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     public AlbumJoinResponse joinAlbum(Long albumId, String code) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Album album = getAlbumById(albumId);
+        final Album album = getAlbumByIdWithLock(albumId);
         final InvitationCode currentInvitationCode =
                 invitationCodeRepository
                         .findById(album.getId())
@@ -165,6 +165,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         validateAlbumRejoin(currentMember, album);
         validateInvitationCode(currentInvitationCode, code);
+        validateMaxParticipantLimit(album);
 
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
@@ -188,6 +189,12 @@ public class AlbumServiceImpl implements AlbumService {
     private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+
+    private Album getAlbumByIdWithLock(Long albumId) {
+        return albumRepository
+                .findByIdWithPessimisticLock(albumId)
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
     }
 
@@ -243,6 +250,13 @@ public class AlbumServiceImpl implements AlbumService {
         return paymentRepository
                 .findById(paymentId)
                 .orElseThrow(() -> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    private void validateMaxParticipantLimit(Album album) {
+        if (participantRepository.countByAlbumId(album.getId())
+                >= album.getPlan().getMaxParticipants()) {
+            throw new CustomException(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED);
+        }
     }
 
     private void validateInvitationCode(InvitationCode currentInvitationCode, String code) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -22,4 +22,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             "select p.member.id from Participant p where p.album.id = :albumId and p.member.id <> :memberId")
     List<Long> findOtherParticipantMemberIds(
             @Param("albumId") Long albumId, @Param("memberId") Long memberId);
+
+    int countByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -934,6 +934,24 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_MISMATCH"))
                     .andExpect(jsonPath("$.data.message").value("초대 코드가 올바르지 않습니다."));
         }
+
+        @Test
+        void 최대_참가자_수를_초과하면_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "testInvitationCode"))
+                    .willThrow(
+                            new CustomException(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_PARTICIPANT_LIMIT_EXCEEDED"))
+                    .andExpect(jsonPath("$.data.message").value("앨범 인원 제한으로 더 이상 참가할 수 없습니다."));
+        }
     }
 
     @Nested

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -16,7 +16,6 @@ import org.cherrypic.album.entity.InvitationCode;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
-import org.cherrypic.domain.album.dto.response.AlbumJoinResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.event.AlbumDeleteEvent;
@@ -805,7 +804,7 @@ class AlbumServiceTest extends IntegrationTest {
         @Test
         void 유효한_초대_코드면_앨범_참가자가_생성된다() {
             // when
-            AlbumJoinResponse response = albumService.joinAlbum(1L, "testInvitationCode1");
+            albumService.joinAlbum(1L, "testInvitationCode1");
 
             // then
             Participant participant =
@@ -846,6 +845,31 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.joinAlbum(3L, "testInvitationCode2"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALREADY_PARTICIPATED.getMessage());
+        }
+
+        @Test
+        void 최대_참가자_수를_초과하면_예외가_발생한다() {
+            // given
+            Album album = albumRepository.findById(1L).orElseThrow();
+            int maxParticipants = album.getPlan().getMaxParticipants();
+
+            for (int i = 0; i < maxParticipants; i++) {
+                Member member =
+                        Member.createMember(
+                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                                "testNickname",
+                                "testProfileImageUrl");
+                memberRepository.save(member);
+
+                Participant participant =
+                        Participant.createParticipant(member, album, ParticipantRole.STANDARD);
+                participantRepository.save(participant);
+            }
+
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(album.getId(), "testInvitationCode1"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED.getMessage());
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -83,7 +83,7 @@ public class PaymentServiceTest extends IntegrationTest {
                     () -> assertThat(payment.getMember().getId()).isEqualTo(1L),
                     () -> assertThat(payment.getMerchantUid()).startsWith("album_"),
                     () -> assertThat(payment.getMerchantUid()).contains("pro"),
-                    () -> assertThat(payment.getAmount()).isEqualTo(3900),
+                    () -> assertThat(payment.getAmount()).isEqualTo(5900),
                     () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY));
         }
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
@@ -8,12 +8,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AlbumPlan {
-    BASIC(0),
-    PRO(5900),
-    PREMIUM(12900),
+    BASIC(0, 10),
+    PRO(5900, 50),
+    PREMIUM(12900, Integer.MAX_VALUE),
     ;
 
     private final int price;
+    private final int maxParticipants;
 
     @JsonCreator
     public static AlbumPlan from(String plan) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AlbumPlan {
     BASIC(0),
-    PRO(3900),
-    PREMIUM(7900),
+    PRO(5900),
+    PREMIUM(12900),
     ;
 
     private final int price;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #130 

---
## 📌 작업 내용 및 특이사항
* 앨범 입장 시 인원 수 제한 기능을 추가했습니다.
* 비관적 락(PESSIMISTIC_WRITE)을 적용하여, 동시에 입장 요청이 들어오더라도 최대 인원 수를 초과하지 않도록 처리했습니다.
* 최대 인원을 초과한 경우 ALBUM_PARTICIPANT_LIMIT_EXCEEDED 예외를 반환하도록 했습니다.

---
## 📚 참고사항
* DB 수준에서 동시성 제약을 보장하고 있어, 스레드 풀을 이용한 병렬 테스트는 진행하지 않았습니다.