### PR TITLE
feat: 앨범 이미지 업로드 Presigned Url 발급 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -28,7 +28,9 @@ public enum AlbumErrorCode implements BaseErrorCode {
     HOST_LEAVE_NOT_ALLOWED(403, "방장은 앨범을 나갈 수 없습니다."),
     HOST_SELF_KICK_NOT_ALLOWED(400, "방장은 자기 자신을 강퇴할 수 없습니다."),
 
-    PARTICIPANT_NOT_IN_ALBUM(400, "해당 참가자는 이 앨범에 속해 있지 않습니다.");
+    PARTICIPANT_NOT_IN_ALBUM(400, "해당 참가자는 이 앨범에 속해 있지 않습니다."),
+
+    ALBUM_CAPACITY_EXCEEDED(400, "앨범의 용량을 초과했습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -35,10 +35,10 @@ public class ImageController {
         return imageService.createMemberProfileImageUploadUrl(request);
     }
 
-    @PostMapping("/albums/{albumId}/images")
+    @PostMapping("/albums/{albumId}/images-upload-url")
     @Operation(
-            summary = "앨범 이미지를 업로드 Presigned URL 생성",
-            description = "앨범 이미지 업로드를 위한 Presigned URL을 생성합니다.")
+            summary = "앨범 이미지들의 업로드 Presigned URL 생성",
+            description = "앨범 이미지들의 업로드를 위한 Presigned URL을 생성합니다.")
     public PresignedUrlsResponse albumImageUploadUrlsCreate(
             @Valid @RequestBody AlbumImageUploadRequest request) {
         return imageService.createAlbumImageUploadUrls(request);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -5,10 +5,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.global.annotation.PageSize;
 import org.cherrypic.global.pagination.SliceResponse;
@@ -31,6 +33,15 @@ public class ImageController {
     public PresignedUrlResponse memberProfileImageUploadUrlCreate(
             @Valid @RequestBody MemberProfileImageUploadRequest request) {
         return imageService.createMemberProfileImageUploadUrl(request);
+    }
+
+    @PostMapping("/albums/{albumId}/images")
+    @Operation(
+            summary = "앨범 이미지를 업로드 Presigned URL 생성",
+            description = "앨범 이미지 업로드를 위한 Presigned URL을 생성합니다.")
+    public PresignedUrlsResponse albumImageUploadUrlsCreate(
+            @Valid @RequestBody AlbumImageUploadRequest request) {
+        return imageService.createAlbumImageUploadUrls(request);
     }
 
     @GetMapping("/albums/{albumId}/images")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -37,8 +37,8 @@ public class ImageController {
 
     @PostMapping("/albums/{albumId}/images-upload-url")
     @Operation(
-            summary = "앨범 이미지들의 업로드 Presigned URL 생성",
-            description = "앨범 이미지들의 업로드를 위한 Presigned URL을 생성합니다.")
+            summary = "앨범 이미지 업로드 Presigned URL 생성",
+            description = "앨범 이미지 업로드를 위한 Presigned URL들을 생성합니다.")
     public PresignedUrlsResponse albumImageUploadUrlsCreate(
             @Valid @RequestBody AlbumImageUploadRequest request) {
         return imageService.createAlbumImageUploadUrls(request);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -41,7 +41,7 @@ public class ImageController {
             description = "앨범 이미지 업로드를 위한 Presigned URL들을 생성합니다.")
     public PresignedUrlsResponse albumImageUploadUrlsCreate(
             @PathVariable Long albumId, @Valid @RequestBody AlbumImageUploadRequest request) {
-        return imageService.createAlbumImageUploadUrls(request, albumId);
+        return imageService.createAlbumImageUploadUrls(albumId, request);
     }
 
     @GetMapping("/albums/{albumId}/images")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -35,13 +35,13 @@ public class ImageController {
         return imageService.createMemberProfileImageUploadUrl(request);
     }
 
-    @PostMapping("/albums/{albumId}/images-upload-url")
+    @PostMapping("/albums/{albumId}/image-upload-urls")
     @Operation(
-            summary = "앨범 이미지 업로드 Presigned URL 생성",
+            summary = "앨범 이미지 업로드 Presigned URL들 생성",
             description = "앨범 이미지 업로드를 위한 Presigned URL들을 생성합니다.")
     public PresignedUrlsResponse albumImageUploadUrlsCreate(
-            @Valid @RequestBody AlbumImageUploadRequest request) {
-        return imageService.createAlbumImageUploadUrls(request);
+            @PathVariable Long albumId, @Valid @RequestBody AlbumImageUploadRequest request) {
+        return imageService.createAlbumImageUploadUrls(request, albumId);
     }
 
     @GetMapping("/albums/{albumId}/images")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
@@ -1,6 +1,7 @@
 package org.cherrypic.domain.image.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
@@ -8,9 +9,14 @@ import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.global.annotation.Enum;
 
 public record AlbumImageUploadRequest(
-        @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
-                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
-                List<ImageFileExtension> imageFileExtensions,
+        @NotEmpty(message = "이미지 파일들의 확장자는 비워둘 수 없습니다.")
+                @Schema(description = "이미지 파일들의 확장자", defaultValue = "JPEG")
+                List<
+                                @Enum(
+                                        message =
+                                                "이미지 파일의 확장자는 PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다.")
+                                ImageFileExtension>
+                        imageFileExtensions,
         @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23") BigDecimal capacity,
         @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
                 @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
@@ -1,0 +1,20 @@
+package org.cherrypic.domain.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.List;
+import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.global.annotation.Enum;
+
+public record AlbumImageUploadRequest(
+        @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
+                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
+                List<ImageFileExtension> imageFileExtensions,
+        @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23") BigDecimal capacity,
+        @NotNull(message = "적어도 하나의 이미지를 업로드 해야합니다.")
+                @Schema(description = "업로드 하는 이미지의 개수", defaultValue = "1")
+                Integer numOfImages,
+        @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
+                @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")
+                Long albumId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
@@ -12,9 +12,6 @@ public record AlbumImageUploadRequest(
                 @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 List<ImageFileExtension> imageFileExtensions,
         @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23") BigDecimal capacity,
-        @NotNull(message = "적어도 하나의 이미지를 업로드 해야합니다.")
-                @Schema(description = "업로드 하는 이미지의 개수", defaultValue = "1")
-                Integer numOfImages,
         @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
                 @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")
                 Long albumId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
@@ -6,18 +6,11 @@ import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
-import org.cherrypic.global.annotation.Enum;
 
 public record AlbumImageUploadRequest(
         @NotEmpty(message = "이미지 파일들의 확장자는 비워둘 수 없습니다.")
-                @Schema(description = "이미지 파일들의 확장자", defaultValue = "JPEG")
-                List<
-                                @Enum(
-                                        message =
-                                                "이미지 파일의 확장자는 PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다.")
-                                ImageFileExtension>
-                        imageFileExtensions,
-        @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23") BigDecimal capacity,
-        @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")
-                Long albumId) {}
+                @Schema(description = "이미지 파일들의 확장자", defaultValue = "[JPEG,JPG]")
+                List<ImageFileExtension> imageFileExtensions,
+        @NotNull(message = "이미지 파일들의 용량은 비워둘 수 없습니다.")
+                @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23")
+                BigDecimal capacity) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/MemberProfileImageUploadRequest.java
@@ -5,6 +5,6 @@ import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.global.annotation.Enum;
 
 public record MemberProfileImageUploadRequest(
-        @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
+        @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다.")
                 @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlResponse.java
@@ -2,4 +2,8 @@ package org.cherrypic.domain.image.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record PresignedUrlResponse(@Schema(description = "Presigned URL") String presignedUrl) {}
+public record PresignedUrlResponse(@Schema(description = "Presigned URL") String presignedUrl) {
+    public static PresignedUrlResponse of(String presignedUrl) {
+        return new PresignedUrlResponse(presignedUrl);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlsResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlsResponse.java
@@ -4,4 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record PresignedUrlsResponse(
-        @Schema(description = "Presigned URLs") List<String> presignedUrls) {}
+        @Schema(description = "Presigned URLs") List<String> presignedUrls) {
+    public static PresignedUrlsResponse of(List<String> presignedUrls) {
+        return new PresignedUrlsResponse(presignedUrls);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlsResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/PresignedUrlsResponse.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record PresignedUrlsResponse(
+        @Schema(description = "Presigned URLs") List<String> presignedUrls) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
@@ -1,7 +1,6 @@
 package org.cherrypic.domain.image.enums;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import java.util.List;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +11,9 @@ public enum ImageFileExtension {
     PNG("png"),
     JPG("jpg"),
     JPEG("jpeg"),
-    ;
+    WEBP("webp"),
+    HEIC("heic"),
+    HEIF("heif");
 
     private final String extension;
 
@@ -22,17 +23,5 @@ public enum ImageFileExtension {
                 .filter(e -> e.name().equalsIgnoreCase(extension))
                 .findFirst()
                 .orElse(null);
-    }
-
-    public static List<ImageFileExtension> getPremiumAlbumImageFileExtension() {
-        return null;
-    }
-
-    public static List<ImageFileExtension> getProAlbumImageFileExtension() {
-        return null;
-    }
-
-    public static List<ImageFileExtension> getBasicAlbumImageFileExtension() {
-        return null;
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageFileExtension.java
@@ -1,6 +1,7 @@
 package org.cherrypic.domain.image.enums;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,5 +22,17 @@ public enum ImageFileExtension {
                 .filter(e -> e.name().equalsIgnoreCase(extension))
                 .findFirst()
                 .orElse(null);
+    }
+
+    public static List<ImageFileExtension> getPremiumAlbumImageFileExtension() {
+        return null;
+    }
+
+    public static List<ImageFileExtension> getProAlbumImageFileExtension() {
+        return null;
+    }
+
+    public static List<ImageFileExtension> getBasicAlbumImageFileExtension() {
+        return null;
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -10,10 +10,7 @@ public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
     IMAGES_IN_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
     IMAGE_DELETED(409, "이미지 관련 작업 중 이미지가 삭제되었습니다."),
-    IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류"),
-
-    IMAGE_EXTENSION_AUTHORITY(403, "%s 앨범은 %s 확장자만 가능합니다."),
-    IMAGE_CAPACITY_EXCEEDED(400, "앨범의 이미지 용량 허용치를 초과했습니다.");
+    IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -10,7 +10,10 @@ public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
     IMAGES_IN_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
     IMAGE_DELETED(409, "이미지 관련 작업 중 이미지가 삭제되었습니다."),
-    IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류");
+    IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류"),
+
+    IMAGE_EXTENSION_AUTHORITY(403, "%s 앨범은 %s 확장자만 가능합니다."),
+    IMAGE_CAPACITY_EXCEEDED(400, "앨범의 이미지 용량 허용치를 초과했습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -12,7 +12,7 @@ import org.cherrypic.global.pagination.SortDirection;
 public interface ImageService {
     PresignedUrlResponse createMemberProfileImageUploadUrl(MemberProfileImageUploadRequest request);
 
-    PresignedUrlsResponse createAlbumImageUploadUrls(AlbumImageUploadRequest request, Long albumId);
+    PresignedUrlsResponse createAlbumImageUploadUrls(Long albumId, AlbumImageUploadRequest request);
 
     SliceResponse<AlbumImageListResponse> getAlbumImages(
             Long albumId, Long lastImageId, int size, SortDirection direction);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -12,7 +12,7 @@ import org.cherrypic.global.pagination.SortDirection;
 public interface ImageService {
     PresignedUrlResponse createMemberProfileImageUploadUrl(MemberProfileImageUploadRequest request);
 
-    PresignedUrlsResponse createAlbumImageUploadUrls(AlbumImageUploadRequest request);
+    PresignedUrlsResponse createAlbumImageUploadUrls(AlbumImageUploadRequest request, Long albumId);
 
     SliceResponse<AlbumImageListResponse> getAlbumImages(
             Long albumId, Long lastImageId, int size, SortDirection direction);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -1,14 +1,18 @@
 package org.cherrypic.domain.image.service;
 
+import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 
 public interface ImageService {
     PresignedUrlResponse createMemberProfileImageUploadUrl(MemberProfileImageUploadRequest request);
+
+    PresignedUrlsResponse createAlbumImageUploadUrls(AlbumImageUploadRequest request);
 
     SliceResponse<AlbumImageListResponse> getAlbumImages(
             Long albumId, Long lastImageId, int size, SortDirection direction);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -5,7 +5,11 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -14,22 +18,26 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
+import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.annotation.Enum;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.helper.SpringEnvironmentHelper;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.s3.S3Properties;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -57,6 +65,35 @@ public class ImageServiceImpl implements ImageService {
 
         return createPresignedUrl(
                 ImageType.MEMBER_PROFILE, currentMember.getId(), request.imageFileExtension());
+    }
+
+    @Override
+    public PresignedUrlsResponse createAlbumImageUploadUrls(AlbumImageUploadRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(request.albumId());
+
+        validateParticipantAuthority(currentMember.getId(), album.getId());
+
+        //plan에 따라서 확장자 + 확장자 자체도 업데이트 해야함
+        //이미지들의 용량합을 검사 -> 이것도 플랜에 따라서 이거 ALBUM PLAN Enum에서 관리하자.
+        //이미지 업로드 횟수
+        //앨범 존재 여부와 권한 검사 했음.
+        public record AlbumImageUploadRequest(
+                @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
+                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
+                List<ImageFileExtension> imageFileExtensions,
+                @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23")
+                BigDecimal capacity,
+                @NotNull(message = "적어도 하나의 이미지를 업로드 해야합니다.")
+                @Schema(description = "업로드 하는 이미지의 개수", defaultValue = "1")
+                Integer numOfImages,
+                @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
+                @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")
+                Long albumId) {
+        }
+
+
+        return null;
     }
 
     @Override
@@ -155,5 +192,13 @@ public class ImageServiceImpl implements ImageService {
         return participantRepository
                 .findByMemberIdAndAlbumId(memberId, albumId)
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
+    private void validateParticipantAuthority(Long memberId, Long albumId) {
+        Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
+
+        if (participant.getRole().equals(ParticipantRole.LIMITED)) {
+            throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
+        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -6,10 +6,12 @@ import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -22,6 +24,7 @@ import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
+import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
@@ -68,24 +71,6 @@ public class ImageServiceImpl implements ImageService {
         final Album album = getAlbumById(request.albumId());
 
         validateParticipantAuthority(currentMember.getId(), album.getId());
-
-        // plan에 따라서 확장자 + 확장자 자체도 업데이트 해야함
-        // 이미지들의 용량합을 검사 -> 이것도 플랜에 따라서 이거 ALBUM PLAN Enum에서 관리하자.
-        // 이미지 업로드 횟수
-        // 앨범 존재 여부와 권한 검사 했음.
-        //        public record AlbumImageUploadRequest(
-        //                @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
-        //                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
-        //                List<ImageFileExtension> imageFileExtensions,
-        //                @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23")
-        //                BigDecimal capacity,
-        //                @NotNull(message = "적어도 하나의 이미지를 업로드 해야합니다.")
-        //                @Schema(description = "업로드 하는 이미지의 개수", defaultValue = "1")
-        //                Integer numOfImages,
-        //                @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
-        //                @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")
-        //                Long albumId) {
-        //        }
 
         return null;
     }
@@ -193,6 +178,31 @@ public class ImageServiceImpl implements ImageService {
 
         if (participant.getRole().equals(ParticipantRole.LIMITED)) {
             throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
+        }
+    }
+
+    // Extension 만지자 + Enum
+    private void validateProAlbumUploadRequest(Album album, AlbumImageUploadRequest request) {
+        if (!new HashSet<>(ImageFileExtension.getProAlbumImageFileExtension())
+                .containsAll(request.imageFileExtensions())) {
+            throw new CustomException(ImageErrorCode.IMAGE_EXTENSION_AUTHORITY);
+        }
+
+        if (album.getCapacityGb().add(request.capacity()).compareTo(AlbumPlan.PRO.getCapacityGb())
+                > 0) {
+            throw new CustomException(ImageErrorCode.IMAGE_CAPACITY_EXCEEDED);
+        }
+    }
+
+    private void validateProAlbumUploadRequest(Album album, AlbumImageUploadRequest request) {
+        if (!new HashSet<>(ImageFileExtension.getProAlbumImageFileExtension())
+                .containsAll(request.imageFileExtensions())) {
+            throw new CustomException(ImageErrorCode.IMAGE_EXTENSION_AUTHORITY);
+        }
+
+        if (album.getCapacityGb().add(request.capacity()).compareTo(AlbumPlan.PRO.getCapacityGb())
+                > 0) {
+            throw new CustomException(ImageErrorCode.IMAGE_CAPACITY_EXCEEDED);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -78,6 +78,8 @@ public class ImageServiceImpl implements ImageService {
         validateParticipantAuthority(currentMember.getId(), album.getId());
         validateAlbumCapacity(album, request.capacity());
 
+        album.increaseCapacity(request.capacity());
+
         List<String> presignedUrls =
                 request.imageFileExtensions().stream()
                         .map(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -73,7 +73,7 @@ public class ImageServiceImpl implements ImageService {
     public PresignedUrlsResponse createAlbumImageUploadUrls(
             AlbumImageUploadRequest request, Long albumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Album album = getAlbumById(albumId);
+        final Album album = getAlbumByIdWithLock(albumId);
 
         validateParticipantAuthority(currentMember.getId(), album.getId());
         validateAlbumCapacity(album, request.capacity());
@@ -173,6 +173,12 @@ public class ImageServiceImpl implements ImageService {
     private Album getAlbumById(Long albumId) {
         return albumRepository
                 .findById(albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+
+    private Album getAlbumByIdWithLock(Long albumId) {
+        return albumRepository
+                .findByIdWithPessimisticLock(albumId)
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -6,12 +6,10 @@ import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -24,7 +22,6 @@ import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
-import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
@@ -178,31 +175,6 @@ public class ImageServiceImpl implements ImageService {
 
         if (participant.getRole().equals(ParticipantRole.LIMITED)) {
             throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
-        }
-    }
-
-    // Extension 만지자 + Enum
-    private void validateProAlbumUploadRequest(Album album, AlbumImageUploadRequest request) {
-        if (!new HashSet<>(ImageFileExtension.getProAlbumImageFileExtension())
-                .containsAll(request.imageFileExtensions())) {
-            throw new CustomException(ImageErrorCode.IMAGE_EXTENSION_AUTHORITY);
-        }
-
-        if (album.getCapacityGb().add(request.capacity()).compareTo(AlbumPlan.PRO.getCapacityGb())
-                > 0) {
-            throw new CustomException(ImageErrorCode.IMAGE_CAPACITY_EXCEEDED);
-        }
-    }
-
-    private void validateProAlbumUploadRequest(Album album, AlbumImageUploadRequest request) {
-        if (!new HashSet<>(ImageFileExtension.getProAlbumImageFileExtension())
-                .containsAll(request.imageFileExtensions())) {
-            throw new CustomException(ImageErrorCode.IMAGE_EXTENSION_AUTHORITY);
-        }
-
-        if (album.getCapacityGb().add(request.capacity()).compareTo(AlbumPlan.PRO.getCapacityGb())
-                > 0) {
-            throw new CustomException(ImageErrorCode.IMAGE_CAPACITY_EXCEEDED);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -70,9 +70,10 @@ public class ImageServiceImpl implements ImageService {
     }
 
     @Override
-    public PresignedUrlsResponse createAlbumImageUploadUrls(AlbumImageUploadRequest request) {
+    public PresignedUrlsResponse createAlbumImageUploadUrls(
+            AlbumImageUploadRequest request, Long albumId) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Album album = getAlbumById(request.albumId());
+        final Album album = getAlbumById(albumId);
 
         validateParticipantAuthority(currentMember.getId(), album.getId());
         validateAlbumCapacity(album, request.capacity());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -5,7 +5,9 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import java.math.BigDecimal;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -58,8 +60,13 @@ public class ImageServiceImpl implements ImageService {
             MemberProfileImageUploadRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        return createPresignedUrl(
-                ImageType.MEMBER_PROFILE, currentMember.getId(), request.imageFileExtension());
+        String presignedUrl =
+                createPresignedUrl(
+                        ImageType.MEMBER_PROFILE,
+                        currentMember.getId(),
+                        request.imageFileExtension());
+
+        return PresignedUrlResponse.of(presignedUrl);
     }
 
     @Override
@@ -68,8 +75,20 @@ public class ImageServiceImpl implements ImageService {
         final Album album = getAlbumById(request.albumId());
 
         validateParticipantAuthority(currentMember.getId(), album.getId());
+        validateAlbumCapacity(album, request.capacity());
 
-        return null;
+        List<String> presignedUrls =
+                request.imageFileExtensions().stream()
+                        .map(
+                                extension -> {
+                                    return createPresignedUrl(
+                                            ImageType.ALBUM_IMAGE,
+                                            currentMember.getId(),
+                                            extension);
+                                })
+                        .toList();
+
+        return PresignedUrlsResponse.of(presignedUrls);
     }
 
     @Override
@@ -99,7 +118,7 @@ public class ImageServiceImpl implements ImageService {
         return SliceResponse.from(result);
     }
 
-    private PresignedUrlResponse createPresignedUrl(
+    private String createPresignedUrl(
             ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
         String imageKey = UUID.randomUUID().toString();
         String fileName = createFileName(imageType, targetId, imageKey, imageFileExtension);
@@ -108,9 +127,7 @@ public class ImageServiceImpl implements ImageService {
                 generatePresignedUrlRequest(
                         s3Properties.bucket(), fileName, imageFileExtension.getExtension());
 
-        String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
-
-        return new PresignedUrlResponse(presignedUrl);
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
     }
 
     private String createFileName(
@@ -175,6 +192,16 @@ public class ImageServiceImpl implements ImageService {
 
         if (participant.getRole().equals(ParticipantRole.LIMITED)) {
             throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
+        }
+    }
+
+    private void validateAlbumCapacity(Album album, BigDecimal additionalUpload) {
+        BigDecimal maxCapacity = album.getPlan().getCapacityGb();
+        BigDecimal current = album.getCapacityGb();
+        BigDecimal afterUpload = current.add(additionalUpload);
+
+        if (afterUpload.compareTo(maxCapacity) > 0) {
+            throw new CustomException(AlbumErrorCode.ALBUM_CAPACITY_EXCEEDED);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -71,7 +71,7 @@ public class ImageServiceImpl implements ImageService {
 
     @Override
     public PresignedUrlsResponse createAlbumImageUploadUrls(
-            AlbumImageUploadRequest request, Long albumId) {
+            Long albumId, AlbumImageUploadRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumByIdWithLock(albumId);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -5,11 +5,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
-import java.math.BigDecimal;
 import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +26,6 @@ import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
-import org.cherrypic.global.annotation.Enum;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
@@ -74,24 +69,23 @@ public class ImageServiceImpl implements ImageService {
 
         validateParticipantAuthority(currentMember.getId(), album.getId());
 
-        //plan에 따라서 확장자 + 확장자 자체도 업데이트 해야함
-        //이미지들의 용량합을 검사 -> 이것도 플랜에 따라서 이거 ALBUM PLAN Enum에서 관리하자.
-        //이미지 업로드 횟수
-        //앨범 존재 여부와 권한 검사 했음.
-        public record AlbumImageUploadRequest(
-                @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
-                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
-                List<ImageFileExtension> imageFileExtensions,
-                @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23")
-                BigDecimal capacity,
-                @NotNull(message = "적어도 하나의 이미지를 업로드 해야합니다.")
-                @Schema(description = "업로드 하는 이미지의 개수", defaultValue = "1")
-                Integer numOfImages,
-                @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
-                @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")
-                Long albumId) {
-        }
-
+        // plan에 따라서 확장자 + 확장자 자체도 업데이트 해야함
+        // 이미지들의 용량합을 검사 -> 이것도 플랜에 따라서 이거 ALBUM PLAN Enum에서 관리하자.
+        // 이미지 업로드 횟수
+        // 앨범 존재 여부와 권한 검사 했음.
+        //        public record AlbumImageUploadRequest(
+        //                @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다.")
+        //                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
+        //                List<ImageFileExtension> imageFileExtensions,
+        //                @Schema(description = "업로드 하는 이미지들의 용량합(GB)", example = "1.23")
+        //                BigDecimal capacity,
+        //                @NotNull(message = "적어도 하나의 이미지를 업로드 해야합니다.")
+        //                @Schema(description = "업로드 하는 이미지의 개수", defaultValue = "1")
+        //                Integer numOfImages,
+        //                @NotNull(message = "앨범 ID는 비워둘 수 없습니다.")
+        //                @Schema(description = "이미지를 업로드 하고자 하는 앨범 ID", example = "1")
+        //                Long albumId) {
+        //        }
 
         return null;
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -83,12 +83,11 @@ public class ImageServiceImpl implements ImageService {
         List<String> presignedUrls =
                 request.imageFileExtensions().stream()
                         .map(
-                                extension -> {
-                                    return createPresignedUrl(
-                                            ImageType.ALBUM_IMAGE,
-                                            currentMember.getId(),
-                                            extension);
-                                })
+                                extension ->
+                                        createPresignedUrl(
+                                                ImageType.ALBUM_IMAGE,
+                                                currentMember.getId(),
+                                                extension))
                         .toList();
 
         return PresignedUrlsResponse.of(presignedUrls);

--- a/cherrypic-api/src/main/java/org/cherrypic/global/annotation/Enum.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/annotation/Enum.java
@@ -10,7 +10,7 @@ import org.cherrypic.global.validator.EnumValidator;
 
 /** RequestBody 의 Enum 검증을 위한 어노테이션 입니다 */
 @Constraint(validatedBy = {EnumValidator.class})
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Enum {
     String message() default "적절하지 않은 Enum값 입니다.";

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -112,7 +112,7 @@ class ImageControllerTest {
             PresignedUrlsResponse response =
                     new PresignedUrlsResponse(List.of("testPresignedUrl1", "testPresignedUrl2"));
 
-            given(imageService.createAlbumImageUploadUrls(request, 1L)).willReturn(response);
+            given(imageService.createAlbumImageUploadUrls(1L, request)).willReturn(response);
 
             // when & then
             ResultActions perform =
@@ -133,7 +133,7 @@ class ImageControllerTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
 
-            given(imageService.createAlbumImageUploadUrls(request, 1L))
+            given(imageService.createAlbumImageUploadUrls(1L, request))
                     .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
             // when & then
@@ -156,7 +156,7 @@ class ImageControllerTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
 
-            given(imageService.createAlbumImageUploadUrls(request, 1L))
+            given(imageService.createAlbumImageUploadUrls(1L, request))
                     .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
@@ -179,7 +179,7 @@ class ImageControllerTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
 
-            given(imageService.createAlbumImageUploadUrls(request, 1L))
+            given(imageService.createAlbumImageUploadUrls(1L, request))
                     .willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY));
 
             // when & then
@@ -202,7 +202,7 @@ class ImageControllerTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
 
-            given(imageService.createAlbumImageUploadUrls(request, 1L))
+            given(imageService.createAlbumImageUploadUrls(1L, request))
                     .willThrow(new CustomException(AlbumErrorCode.ALBUM_CAPACITY_EXCEEDED));
 
             // when & then

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -7,14 +7,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.util.List;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.image.controller.ImageController;
+import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.exception.CustomException;
@@ -45,7 +48,7 @@ class ImageControllerTest {
     @MockitoBean private ImageService imageService;
 
     @Nested
-    class Presigned_URL을_생성할_때 {
+    class Presigned_URL을_생성_요청_시 {
 
         @Test
         void 유효한_요청이면_회원_프로필_이미지용_Presigned_URL을_반환한다() throws Exception {
@@ -94,6 +97,166 @@ class ImageControllerTest {
                             jsonPath("$.data.message")
                                     .value(
                                             "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다."));
+        }
+    }
+
+    @Nested
+    class 앨범_이미지_업로드_Presigned_URL을_생성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_이미지_업로드_Presigned_URL들을_반환한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
+
+            PresignedUrlsResponse response =
+                    new PresignedUrlsResponse(List.of("testPresignedUrl1", "testPresignedUrl2"));
+
+            given(imageService.createAlbumImageUploadUrls(request, 1L)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/image-upload-urls")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.presignedUrls").isNotEmpty());
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
+
+            given(imageService.createAlbumImageUploadUrls(request, 1L))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/image-upload-urls")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_앨범_이미지_업로드_URL을_요청하면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
+
+            given(imageService.createAlbumImageUploadUrls(request, 1L))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/image-upload-urls")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_앨범_이미지_업로드_URL을_요청하면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
+
+            given(imageService.createAlbumImageUploadUrls(request, 1L))
+                    .willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/image-upload-urls")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Test
+        void 앨범의_남은_용량을_초과해서_요청하면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(List.of(ImageFileExtension.JPEG), BigDecimal.ONE);
+
+            given(imageService.createAlbumImageUploadUrls(request, 1L))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_CAPACITY_EXCEEDED));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/image-upload-urls")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_CAPACITY_EXCEEDED"))
+                    .andExpect(jsonPath("$.data.message").value("앨범의 용량을 초과했습니다."));
+        }
+
+        @Test
+        void 이미지들의_확장자를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(List.of(), BigDecimal.ONE);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/image-upload-urls")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이미지 파일들의 확장자는 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 이미지_용량_총합을_비워두면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(List.of(ImageFileExtension.JPG), null);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/image-upload-urls")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("이미지 파일들의 용량은 비워둘 수 없습니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -92,7 +92,8 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(
                             jsonPath("$.data.message")
-                                    .value("이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG만 지원됩니다."));
+                                    .value(
+                                            "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -3,6 +3,7 @@ package org.cherrypic.image.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
@@ -12,10 +13,12 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
+import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
+import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
@@ -80,6 +83,122 @@ class ImageServiceTest extends IntegrationTest {
                     .containsPattern(
                             String.format(
                                     "/%s/%s/%d/[\\w\\-]+\\.jpeg", "local", "member-profile", 1));
+        }
+    }
+
+    @Nested
+    class 앨범_이미지_업로드_Presigned_URL을_생성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            album1.increaseCapacity(new BigDecimal("1"));
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @Test
+        void 유효한_요청이면_앨범_업로드_이미지_URL들을_반환한다() {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(
+                            List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
+                            new BigDecimal("1"),
+                            1L);
+
+            // when & then
+            PresignedUrlsResponse response = imageService.createAlbumImageUploadUrls(request);
+
+            assertThat(response.presignedUrls())
+                    .hasSize(2)
+                    .satisfiesExactly(
+                            url1 ->
+                                    assertThat(url1)
+                                            .containsPattern(
+                                                    String.format(
+                                                            "/%s/%s/%d/[\\w\\-]+\\.jpg",
+                                                            "local", "album-image", 1)),
+                            url2 ->
+                                    assertThat(url2)
+                                            .containsPattern(
+                                                    String.format(
+                                                            "/%s/%s/%d/[\\w\\-]+\\.jpeg",
+                                                            "local", "album-image", 1)));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(
+                            List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
+                            new BigDecimal("1"),
+                            999L);
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_앨범_이미지_업로드_URL을_요청하면_예외가_발생한다() {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(
+                            List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
+                            new BigDecimal("1"),
+                            3L);
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_앨범_이미지_업로드_URL을_요청하면_예외가_발생한다() {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(
+                            List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
+                            new BigDecimal("1"),
+                            2L);
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 앨범의_남은_용량을_초과해서_요청하면_예외가_발생한다() {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(
+                            List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
+                            new BigDecimal("3"),
+                            1L);
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_CAPACITY_EXCEEDED.getMessage());
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -87,7 +87,7 @@ class ImageServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 앨범_이미지_업로드_Presigned_URL을_생성할_때 {
+    class 앨범_이미지_업로드_Presigned_URL들을_생성할_때 {
 
         @BeforeEach
         void setUp() {
@@ -100,7 +100,7 @@ class ImageServiceTest extends IntegrationTest {
             given(memberUtil.getCurrentMember()).willReturn(member);
 
             Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            album1.increaseCapacity(new BigDecimal("1"));
+            album1.increaseCapacity(BigDecimal.ONE);
             Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
             Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
@@ -118,11 +118,10 @@ class ImageServiceTest extends IntegrationTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(
                             List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
-                            new BigDecimal("1"),
-                            1L);
+                            BigDecimal.ONE);
 
             // when & then
-            PresignedUrlsResponse response = imageService.createAlbumImageUploadUrls(request);
+            PresignedUrlsResponse response = imageService.createAlbumImageUploadUrls(request, 1L);
 
             assertThat(response.presignedUrls())
                     .hasSize(2)
@@ -147,11 +146,10 @@ class ImageServiceTest extends IntegrationTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(
                             List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
-                            new BigDecimal("1"),
-                            999L);
+                            BigDecimal.ONE);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 999L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -162,11 +160,10 @@ class ImageServiceTest extends IntegrationTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(
                             List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
-                            new BigDecimal("1"),
-                            3L);
+                            BigDecimal.ONE);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 3L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -177,11 +174,10 @@ class ImageServiceTest extends IntegrationTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(
                             List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
-                            new BigDecimal("1"),
-                            2L);
+                            BigDecimal.ONE);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 2L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
@@ -192,11 +188,10 @@ class ImageServiceTest extends IntegrationTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(
                             List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
-                            new BigDecimal("3"),
-                            1L);
+                            BigDecimal.ONE);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 1L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_CAPACITY_EXCEEDED.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -121,7 +121,7 @@ class ImageServiceTest extends IntegrationTest {
                             BigDecimal.ONE);
 
             // when & then
-            PresignedUrlsResponse response = imageService.createAlbumImageUploadUrls(request, 1L);
+            PresignedUrlsResponse response = imageService.createAlbumImageUploadUrls(1L, request);
 
             assertThat(response.presignedUrls())
                     .hasSize(2)
@@ -149,7 +149,7 @@ class ImageServiceTest extends IntegrationTest {
                             BigDecimal.ONE);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 999L))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(999L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -163,7 +163,7 @@ class ImageServiceTest extends IntegrationTest {
                             BigDecimal.ONE);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 3L))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(3L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -177,7 +177,7 @@ class ImageServiceTest extends IntegrationTest {
                             BigDecimal.ONE);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 2L))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(2L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
@@ -191,7 +191,7 @@ class ImageServiceTest extends IntegrationTest {
                             BigDecimal.TEN);
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 1L))
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(1L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_CAPACITY_EXCEEDED.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -188,7 +188,7 @@ class ImageServiceTest extends IntegrationTest {
             AlbumImageUploadRequest request =
                     new AlbumImageUploadRequest(
                             List.of(ImageFileExtension.JPG, ImageFileExtension.JPEG),
-                            BigDecimal.ONE);
+                            BigDecimal.TEN);
 
             // when & then
             assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(request, 1L))

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -2,6 +2,7 @@ package org.cherrypic.album.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -9,8 +10,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.common.exception.DomainErrorCode;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.exception.CustomException;
 import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.notification.entity.Notification;
@@ -36,6 +39,8 @@ public class Album extends BaseTimeEntity {
 
     @NotNull private Boolean permissionControl;
 
+    @NotNull private BigDecimal capacityGb;
+
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
 
@@ -58,11 +63,17 @@ public class Album extends BaseTimeEntity {
     private List<Image> images = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Album(String title, String coverUrl, AlbumPlan plan, boolean permissionControl) {
+    private Album(
+            String title,
+            String coverUrl,
+            AlbumPlan plan,
+            boolean permissionControl,
+            BigDecimal capacityGb) {
         this.title = title;
         this.coverUrl = coverUrl;
         this.plan = plan;
         this.permissionControl = permissionControl;
+        this.capacityGb = capacityGb;
     }
 
     public static Album createAlbum(
@@ -72,6 +83,7 @@ public class Album extends BaseTimeEntity {
                 .coverUrl(coverUrl)
                 .plan(plan)
                 .permissionControl(permissionControl)
+                .capacityGb(BigDecimal.ZERO)
                 .build();
     }
 
@@ -86,5 +98,19 @@ public class Album extends BaseTimeEntity {
 
     public void togglePermissionControl() {
         this.permissionControl = !this.permissionControl;
+    }
+
+    public void increaseCapacity(BigDecimal decimal) {
+        if (this.capacityGb.add(decimal).compareTo(BigDecimal.valueOf(9999.99)) > 0) {
+            throw new CustomException(DomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT);
+        }
+        this.capacityGb = capacityGb.add(decimal);
+    }
+
+    public void decreaseCapacity(BigDecimal decimal) {
+        if (this.capacityGb.subtract(decimal).compareTo(BigDecimal.ZERO) < 0) {
+            throw new CustomException(DomainErrorCode.ALBUM_CAPACITY_DECREASE_UNDER_ZERO);
+        }
+        this.capacityGb = capacityGb.subtract(decimal);
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
@@ -1,6 +1,7 @@
 package org.cherrypic.album.enums;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.math.BigDecimal;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,13 +9,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AlbumPlan {
-    BASIC(0, 10),
-    PRO(5900, 50),
-    PREMIUM(12900, Integer.MAX_VALUE),
-    ;
+    BASIC(0, new BigDecimal("3")),
+    PRO(5900, new BigDecimal("200")),
+    PREMIUM(12900, new BigDecimal("2048"));
 
     private final int price;
-    private final int maxParticipants;
+    private final BigDecimal capacityGb;
 
     @JsonCreator
     public static AlbumPlan from(String plan) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumPlan.java
@@ -9,12 +9,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AlbumPlan {
-    BASIC(0, new BigDecimal("3")),
-    PRO(5900, new BigDecimal("200")),
-    PREMIUM(12900, new BigDecimal("2048"));
+    BASIC(0, new BigDecimal("3"), 10),
+    PRO(5900, new BigDecimal("200"), 50),
+    PREMIUM(12900, new BigDecimal("2048"), Integer.MAX_VALUE);
 
     private final int price;
     private final BigDecimal capacityGb;
+    private final int maxParticipants;
 
     @JsonCreator
     public static AlbumPlan from(String plan) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/common/exception/DomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/common/exception/DomainErrorCode.java
@@ -1,0 +1,15 @@
+package org.cherrypic.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum DomainErrorCode implements BaseErrorCode {
+    ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "앨범 용량은 9999GB 초과로 늘릴 수 없습니다"),
+    ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "앨범 용량은 0GB 미만으로 줄일 수 없습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -18,6 +18,7 @@ CREATE TABLE album (
                        cover_url VARCHAR(255),
                        plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
                        permission_control BOOLEAN NOT NULL,
+                       capacityGb DECIMAL(6,2) NOT NULL,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
 );

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -18,7 +18,7 @@ CREATE TABLE album (
                        cover_url VARCHAR(255),
                        plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
                        permission_control BOOLEAN NOT NULL,
-                       capacityGb DECIMAL(6,2) NOT NULL,
+                       capacity_gb DECIMAL(6,2) NOT NULL,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
 );

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/AlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/AlbumTest.java
@@ -1,0 +1,35 @@
+package org.cherrypic.album.entity;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.common.exception.DomainErrorCode;
+import org.cherrypic.exception.CustomException;
+import org.junit.jupiter.api.Test;
+
+class AlbumTest {
+
+    @Test
+    void 용량을_4자리_GB_이상으로_늘릴_경우_예외가_발생한다() {
+        // given
+        Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
+
+        // when & then
+        assertThatThrownBy(() -> album.increaseCapacity(BigDecimal.valueOf(10000)))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(DomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT.getMessage());
+    }
+
+    @Test
+    void 용량을_0GB_미만으로_줄일_경우_예외가_발생한다() {
+        // given
+        Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
+
+        // when & then
+        assertThatThrownBy(() -> album.decreaseCapacity(BigDecimal.valueOf(1)))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(DomainErrorCode.ALBUM_CAPACITY_DECREASE_UNDER_ZERO.getMessage());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #122 

---
## 📌 작업 내용 및 특이사항
- 앨범 이미지 업로드 Presigned Url 발급 API 구현했습니다.
- List 형태의 요청을 받아서 List로 반환하는 구조입니다.
- 앨범에 용량 필드를 추가했습니다.
- 용량 필드를 업데이트 하는 메서드를 만들고 Domain 레벨에서 방어 로직과 테스트 코드를 작성했습니다.


---
## 📚 참고사항
- 앨범 이미지 업로드 Url에서 용량을 업데이트 합니다. 