### PR TITLE
feat: 회원 닉네임 변경 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
+import org.cherrypic.domain.member.dto.request.NicknameUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.member.dto.response.NicknameUpdateResponse;
 import org.cherrypic.domain.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +24,13 @@ public class MemberController {
     @Operation(summary = "회원 정보 조회", description = "로그인한 회원 정보를 조회합니다.")
     public MemberInfoResponse memberInfo() {
         return memberService.getMemberInfo();
+    }
+
+    @PatchMapping("/me")
+    @Operation(summary = "회원 닉네임 변경", description = "회원의 닉네임을 변경합니다.")
+    public NicknameUpdateResponse memberNicknameUpdate(
+            @Valid @RequestBody NicknameUpdateRequest request) {
+        return memberService.updateNickname(request);
     }
 
     @PostMapping("/fcm-tokens")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/request/NicknameUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,11 @@
+package org.cherrypic.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NicknameUpdateRequest(
+        @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
+                @Size(max = 10, message = "닉네임은 최대 10자까지 입력 가능합니다.")
+                @Schema(description = "닉네임", example = "최현태")
+                String nickname) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/request/NicknameUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/request/NicknameUpdateRequest.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.Size;
 
 public record NicknameUpdateRequest(
         @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
-                @Size(max = 10, message = "닉네임은 최대 10자까지 입력 가능합니다.")
+                @Size(max = 15, message = "닉네임은 최대 15자까지 입력 가능합니다.")
                 @Schema(description = "닉네임", example = "최현태")
                 String nickname) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/NicknameUpdateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/NicknameUpdateResponse.java
@@ -1,0 +1,11 @@
+package org.cherrypic.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.member.entity.Member;
+
+public record NicknameUpdateResponse(
+        @Schema(description = "닉네임", example = "최현태") String nickname) {
+    public static NicknameUpdateResponse from(Member member) {
+        return new NicknameUpdateResponse(member.getNickname());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
@@ -1,10 +1,14 @@
 package org.cherrypic.domain.member.service;
 
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
+import org.cherrypic.domain.member.dto.request.NicknameUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.member.dto.response.NicknameUpdateResponse;
 
 public interface MemberService {
     MemberInfoResponse getMemberInfo();
+
+    NicknameUpdateResponse updateNickname(NicknameUpdateRequest request);
 
     void saveFcmToken(FcmTokenSaveRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -2,7 +2,9 @@ package org.cherrypic.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
+import org.cherrypic.domain.member.dto.request.NicknameUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.member.dto.response.NicknameUpdateResponse;
 import org.cherrypic.domain.notification.service.FcmTokenService;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
@@ -22,6 +24,15 @@ public class MemberServiceImpl implements MemberService {
     public MemberInfoResponse getMemberInfo() {
         final Member currentMember = memberUtil.getCurrentMember();
         return MemberInfoResponse.from(currentMember);
+    }
+
+    @Override
+    public NicknameUpdateResponse updateNickname(NicknameUpdateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        currentMember.updateNickname(request.nickname());
+
+        return NicknameUpdateResponse.from(currentMember);
     }
 
     @Override

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -30,7 +30,7 @@ public class MemberServiceImpl implements MemberService {
     public NicknameUpdateResponse updateNickname(NicknameUpdateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        currentMember.updateNickname(request.nickname());
+        currentMember.updateNickname(removeSpecialCharacters(request.nickname()));
 
         return NicknameUpdateResponse.from(currentMember);
     }
@@ -40,5 +40,9 @@ public class MemberServiceImpl implements MemberService {
     public void saveFcmToken(FcmTokenSaveRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         fcmTokenService.saveFcmToken(currentMember.getId(), request.fcmToken());
+    }
+
+    private String removeSpecialCharacters(String nickname) {
+        return nickname.replaceAll("[^0-9a-zA-Z가-힣 ]", "");
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -8,7 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.member.controller.MemberController;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
+import org.cherrypic.domain.member.dto.request.NicknameUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
+import org.cherrypic.domain.member.dto.response.NicknameUpdateResponse;
 import org.cherrypic.domain.member.service.MemberService;
 import org.cherrypic.member.enums.MemberRole;
 import org.cherrypic.member.enums.MemberStatus;
@@ -65,6 +67,72 @@ class MemberControllerTest {
                     .andExpect(jsonPath("$.data.profileImageUrl").value("testProfileImageUrl"))
                     .andExpect(jsonPath("$.data.status").value("NORMAL"))
                     .andExpect(jsonPath("$.data.role").value("USER"));
+        }
+    }
+
+    @Nested
+    class 회원_닉네임_변경_요청_시 {
+
+        @Test
+        void 유효한_요청이면_변경된_회원_닉네임을_반환한다() throws Exception {
+            // given
+            NicknameUpdateRequest request = new NicknameUpdateRequest("updateNickname");
+            NicknameUpdateResponse response = new NicknameUpdateResponse("updateNickname");
+
+            given(memberService.updateNickname(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/members/me")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.nickname").value("updateNickname"));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 닉네임이_null_또는_공백이면_예외가_발생한다(String nickname) throws Exception {
+            // given
+            NicknameUpdateRequest request = new NicknameUpdateRequest(nickname);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/members/me")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("닉네임은 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 닉네임이_15자를_초과하면_예외가_발생한다() throws Exception {
+            // given
+            NicknameUpdateRequest request = new NicknameUpdateRequest("t".repeat(16));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/members/me")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("닉네임은 최대 15자까지 입력 가능합니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -6,10 +6,12 @@ import static org.mockito.BDDMockito.given;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
+import org.cherrypic.domain.member.dto.request.NicknameUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.member.service.MemberService;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.member.enums.MemberRole;
@@ -21,9 +23,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
 
 class MemberServiceTest extends IntegrationTest {
 
+    @Autowired private TransactionUtil transactionUtil;
     @Autowired private RedisCleaner redisCleaner;
     @Autowired private StringRedisTemplate redisTemplate;
 
@@ -68,6 +72,38 @@ class MemberServiceTest extends IntegrationTest {
                             "testProfileImageUrl",
                             MemberRole.USER,
                             MemberStatus.NORMAL);
+        }
+    }
+
+    @Nested
+    class 회원_닉네임을_변경할_때 {
+
+        @Transactional
+        @Test
+        void 유효한_요청이면_회원_닉네임을_변경한다() {
+            // given
+            NicknameUpdateRequest request = new NicknameUpdateRequest("updateNickname");
+
+            // when
+            memberService.updateNickname(request);
+
+            // then
+            Member member = memberRepository.findById(1L).orElseThrow();
+            assertThat(member.getNickname()).isEqualTo("updateNickname");
+        }
+
+        @Transactional
+        @Test
+        void 특수문자가_포함된_요청이면_특수문자를_제거하고_닉네임을_변경한다() {
+            // given
+            NicknameUpdateRequest request = new NicknameUpdateRequest("닉!네@임#수^정");
+
+            // when
+            memberService.updateNickname(request);
+
+            // then
+            Member member = memberRepository.findById(1L).orElseThrow();
+            assertThat(member.getNickname()).isEqualTo("닉네임수정");
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -1,7 +1,6 @@
 package org.cherrypic.member.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
 
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
@@ -10,7 +9,6 @@ import org.cherrypic.domain.member.dto.request.NicknameUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.member.service.MemberService;
-import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
@@ -22,8 +20,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 
 class MemberServiceTest extends IntegrationTest {
 
@@ -34,8 +34,6 @@ class MemberServiceTest extends IntegrationTest {
     @Autowired private MemberService memberService;
     @Autowired private MemberRepository memberRepository;
 
-    @MockitoBean private MemberUtil memberUtil;
-
     @BeforeEach
     void setUp() {
         Member member =
@@ -45,7 +43,15 @@ class MemberServiceTest extends IntegrationTest {
                         "testProfileImageUrl");
         memberRepository.save(member);
 
-        given(memberUtil.getCurrentMember()).willReturn(member);
+        UserDetails userDetails =
+                User.withUsername(member.getId().toString())
+                        .password("")
+                        .authorities(member.getRole().name())
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
     }
 
     @Nested
@@ -78,7 +84,6 @@ class MemberServiceTest extends IntegrationTest {
     @Nested
     class 회원_닉네임을_변경할_때 {
 
-        @Transactional
         @Test
         void 유효한_요청이면_회원_닉네임을_변경한다() {
             // given
@@ -92,7 +97,6 @@ class MemberServiceTest extends IntegrationTest {
             assertThat(member.getNickname()).isEqualTo("updateNickname");
         }
 
-        @Transactional
         @Test
         void 특수문자가_포함된_요청이면_특수문자를_제거하고_닉네임을_변경한다() {
             // given

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -74,4 +74,8 @@ public class Member extends BaseTimeEntity {
                 .status(MemberStatus.NORMAL)
                 .build();
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -1,6 +1,6 @@
 CREATE TABLE member (
                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                        nickname VARCHAR(50) NOT NULL,
+                        nickname VARCHAR(15) NOT NULL,
                         oauth_id VARCHAR(255) NOT NULL,
                         oauth_provider VARCHAR(255) NOT NULL,
                         profile_image_url VARCHAR(255),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #131 

---
## 📌 작업 내용 및 특이사항
* 회원 닉네임 변경 API를 구현했습니다.
* 닉네임 변경 시 특수문자는 공백으로 치환되도록 처리했습니다 ([^0-9a-zA-Z가-힣 ] → " ").
* 닉네임 길이는 최대 15자로 제한했습니다.

---
## 📚 참고사항
* 앨범, 이벤트 수정 테스트에서는 트랜잭션 내부에서 findById()를 직접 사용하기 때문에 ```@Transactional``` 없이도 상태 변경이 반영됩니다.
* 반면, 회원 닉네임 변경은 memberUtil.getCurrentMember()를 통해 findById()를 내부에서 호출하는 구조이므로, 테스트 환경에서는 SecurityContext에 인증 정보를 수동 주입해야 변경 사항이 정상 반영됩니다.
* 이에 따라 테스트 코드에서 `@Transactional` 대신 `SecurityContextHolder`에 사용자 정보를 설정하는 방식으로 수정하여, MemberUtil의 내부 동작도 자연스럽게 테스트되도록 개선했습니다.