### PR TITLE
feat: 구독 플랜별 앨범 목록 조회 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
@@ -75,6 +76,22 @@ public class AlbumController {
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
         return albumService.getParticipatingAlbums(lastAlbumId, size, direction);
+    }
+
+    @GetMapping("/subscribed")
+    @Operation(
+            summary = "구독 플랜별 앨범 목록 조회",
+            description = "회원이 참여 중인 앨범 중, 특정 구독 플랜에 해당하는 앨범을 커서 기반 페이징 방식으로 조회합니다.")
+    public SliceResponse<SubscribedAlbumListResponse> subscribedAlbumsGet(
+            @Parameter(description = "구독 플랜") @RequestParam AlbumPlan plan,
+            @Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    Long lastAlbumId,
+            @Parameter(description = "페이지당 조회할 앨범 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
+                    @RequestParam(defaultValue = "DESC")
+                    SortDirection direction) {
+        return albumService.getSubscribedAlbumsByPlan(plan, lastAlbumId, size, direction);
     }
 
     @DeleteMapping("/{albumId}")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/SubscribedAlbumListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/SubscribedAlbumListResponse.java
@@ -1,0 +1,55 @@
+package org.cherrypic.domain.album.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import org.cherrypic.album.enums.AlbumPlan;
+
+public record SubscribedAlbumListResponse(
+        @Schema(description = "앨범 ID", example = "1") Long albumId,
+        @Schema(description = "앨범 이름", example = "연인 앨범") String title,
+        @Schema(description = "앨범 플랜", example = "PRO") AlbumPlan plan,
+        @Schema(description = "앨범 플랜 가격", example = "3900") Integer price,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "앨범 생성일", example = "2024-08-21")
+                LocalDateTime albumCreatedAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "구독 시작일", example = "2024-08-21")
+                LocalDateTime subscriptionStartAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "구독 종료일", example = "2024-09-20")
+                LocalDateTime subscriptionEndAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "다음 결제일", example = "2024-09-21")
+                LocalDateTime subscriptionNextBillingAt) {
+    public static SubscribedAlbumListResponse of(
+            Long albumId,
+            String title,
+            AlbumPlan plan,
+            LocalDateTime albumCreatedAt,
+            LocalDateTime subscriptionStartAt,
+            LocalDateTime subscriptionEndAt,
+            LocalDateTime subscriptionNextBillingAt) {
+        return new SubscribedAlbumListResponse(
+                albumId,
+                title,
+                plan,
+                plan.getPrice(),
+                albumCreatedAt,
+                subscriptionStartAt,
+                subscriptionEndAt,
+                subscriptionNextBillingAt);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -1,10 +1,15 @@
 package org.cherrypic.domain.album.repository;
 
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.domain.album.dto.response.SubscribedAlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.Slice;
 
 public interface AlbumRepositoryCustom {
     Slice<AlbumListResponse> findAllByMemberId(
             Long memberId, Long lastAlbumId, int size, SortDirection direction);
+
+    Slice<SubscribedAlbumListResponse> findAllByMemberIdAndPlan(
+            Long memberId, AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -2,13 +2,17 @@ package org.cherrypic.domain.album.repository;
 
 import static org.cherrypic.album.entity.QAlbum.album;
 import static org.cherrypic.participant.entity.QParticipant.participant;
+import static org.cherrypic.subscription.entity.QSubscription.subscription;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
+import org.cherrypic.domain.album.dto.response.SubscribedAlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -45,6 +49,47 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
         return checkLastPage(size, results);
     }
 
+    @Override
+    public Slice<SubscribedAlbumListResponse> findAllByMemberIdAndPlan(
+            Long memberId, AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction) {
+        List<Tuple> tuples =
+                queryFactory
+                        .select(
+                                album.id,
+                                album.title,
+                                album.plan,
+                                album.createdAt,
+                                subscription.startAt,
+                                subscription.endAt,
+                                subscription.nextBillingAt)
+                        .from(participant)
+                        .join(participant.album, album)
+                        .leftJoin(album.subscription, subscription)
+                        .where(
+                                participant.member.id.eq(memberId),
+                                album.plan.eq(plan),
+                                lastAlbumIdCondition(lastAlbumId, direction))
+                        .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())
+                        .limit(size + 1)
+                        .fetch();
+
+        List<SubscribedAlbumListResponse> results =
+                tuples.stream()
+                        .map(
+                                tuple ->
+                                        SubscribedAlbumListResponse.of(
+                                                tuple.get(album.id),
+                                                tuple.get(album.title),
+                                                tuple.get(album.plan),
+                                                tuple.get(album.createdAt),
+                                                tuple.get(subscription.startAt),
+                                                tuple.get(subscription.endAt),
+                                                tuple.get(subscription.nextBillingAt)))
+                        .toList();
+
+        return checkLastPage(size, results);
+    }
+
     private BooleanExpression lastAlbumIdCondition(Long albumId, SortDirection direction) {
         if (albumId == null) {
             return null;
@@ -53,7 +98,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
         return direction == SortDirection.DESC ? album.id.lt(albumId) : album.id.gt(albumId);
     }
 
-    private Slice<AlbumListResponse> checkLastPage(int pageSize, List<AlbumListResponse> results) {
+    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
         boolean hasNext = false;
 
         if (results.size() > pageSize) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.album.service;
 
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
@@ -17,6 +18,9 @@ public interface AlbumService {
 
     SliceResponse<AlbumListResponse> getParticipatingAlbums(
             Long lastAlbumId, int size, SortDirection direction);
+
+    SliceResponse<SubscribedAlbumListResponse> getSubscribedAlbumsByPlan(
+            AlbumPlan plan, Long lastAlbumId, Integer size, SortDirection direction);
 
     AlbumJoinResponse joinAlbum(Long albumId, String code);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -152,6 +152,19 @@ public class AlbumServiceImpl implements AlbumService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public SliceResponse<SubscribedAlbumListResponse> getSubscribedAlbumsByPlan(
+            AlbumPlan plan, Long lastAlbumId, Integer size, SortDirection direction) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        Slice<SubscribedAlbumListResponse> results =
+                albumRepository.findAllByMemberIdAndPlan(
+                        currentMember.getId(), plan, lastAlbumId, size, direction);
+
+        return SliceResponse.from(results);
+    }
+
+    @Override
     public AlbumJoinResponse joinAlbum(Long albumId, String code) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumByIdWithLock(albumId);

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -898,7 +898,7 @@ class AlbumControllerTest {
                                     "testTitle1",
                                     AlbumPlan.PRO,
                                     AlbumPlan.PRO.getPrice(),
-                                    LocalDateTime.of(2025, 8, 21, 0, 0, 0),
+                                    LocalDateTime.of(2025, 8, 21, 0, 0),
                                     LocalDateTime.of(2025, 8, 21, 0, 0),
                                     LocalDateTime.of(2025, 9, 21, 0, 0),
                                     LocalDateTime.of(2025, 9, 22, 0, 0)));

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.controller.AlbumController;
@@ -712,8 +713,8 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums =
                     List.of(
-                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC),
-                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO));
+                            new AlbumListResponse(1L, "testTitle1", "coverUrl1", AlbumPlan.BASIC),
+                            new AlbumListResponse(2L, "testTitle2", "coverUrl2", AlbumPlan.PRO));
 
             given(albumService.getParticipatingAlbums(null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(albums, true));
@@ -835,6 +836,149 @@ class AlbumControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(get("/albums").param("size", "2").param("direction", sort));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 구독_플랜별_앨범_목록_조회_요청_시 {
+
+        @Test
+        void BASIC_플랜이면_구독_정보는_null로_응답한다() throws Exception {
+            // given
+            List<SubscribedAlbumListResponse> albums =
+                    List.of(
+                            new SubscribedAlbumListResponse(
+                                    1L,
+                                    "testTitle1",
+                                    AlbumPlan.BASIC,
+                                    0,
+                                    LocalDateTime.of(2025, 8, 21, 0, 0),
+                                    null,
+                                    null,
+                                    null));
+
+            given(
+                            albumService.getSubscribedAlbumsByPlan(
+                                    AlbumPlan.BASIC, null, 1, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/subscribed").param("plan", "BASIC").param("size", "1"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(1))
+                    .andExpect(jsonPath("$.data.content[0].title").value("testTitle1"))
+                    .andExpect(jsonPath("$.data.content[0].plan").value("BASIC"))
+                    .andExpect(jsonPath("$.data.content[0].price").value(0))
+                    .andExpect(jsonPath("$.data.content[0].albumCreatedAt").value("2025-08-21"))
+                    .andExpect(jsonPath("$.data.content[0].subscriptionStartAt").doesNotExist())
+                    .andExpect(jsonPath("$.data.content[0].subscriptionEndAt").doesNotExist())
+                    .andExpect(
+                            jsonPath("$.data.content[0].subscriptionNextBillingAt").doesNotExist())
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void PRO_플랜이면_구독_정보를_포함하여_응답한다() throws Exception {
+            // given
+            List<SubscribedAlbumListResponse> albums =
+                    List.of(
+                            new SubscribedAlbumListResponse(
+                                    1L,
+                                    "testTitle1",
+                                    AlbumPlan.PRO,
+                                    AlbumPlan.PRO.getPrice(),
+                                    LocalDateTime.of(2025, 8, 21, 0, 0, 0),
+                                    LocalDateTime.of(2025, 8, 21, 0, 0),
+                                    LocalDateTime.of(2025, 9, 21, 0, 0),
+                                    LocalDateTime.of(2025, 9, 22, 0, 0)));
+
+            given(
+                            albumService.getSubscribedAlbumsByPlan(
+                                    AlbumPlan.PRO, null, 1, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/subscribed").param("plan", "PRO").param("size", "1"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(1))
+                    .andExpect(jsonPath("$.data.content[0].title").value("testTitle1"))
+                    .andExpect(jsonPath("$.data.content[0].plan").value("PRO"))
+                    .andExpect(jsonPath("$.data.content[0].price").value(5900))
+                    .andExpect(jsonPath("$.data.content[0].albumCreatedAt").value("2025-08-21"))
+                    .andExpect(
+                            jsonPath("$.data.content[0].subscriptionStartAt").value("2025-08-21"))
+                    .andExpect(jsonPath("$.data.content[0].subscriptionEndAt").value("2025-09-21"))
+                    .andExpect(
+                            jsonPath("$.data.content[0].subscriptionNextBillingAt")
+                                    .value("2025-09-22"))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void PRO_앨범이_없는_경우_빈_리스트를_응답한다() throws Exception {
+            // given
+            List<SubscribedAlbumListResponse> albums = List.of();
+
+            given(
+                            albumService.getSubscribedAlbumsByPlan(
+                                    AlbumPlan.PRO, null, 10, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/subscribed").param("plan", "PRO").param("size", "10"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content").isEmpty())
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "-999", "0"})
+        void 페이지_크기가_0_이하이면_예외가_발생한다(String pageSize) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/subscribed")
+                                    .param("plan", "BASIC")
+                                    .param("size", pageSize));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ConstraintViolationException"))
+                    .andExpect(jsonPath("$.data.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
+        void 존재하지_않는_정렬_기준을_입력하면_예외가_발생한다(String sort) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/subscribed")
+                                    .param("plan", "BASIC")
+                                    .param("size", "2")
+                                    .param("direction", sort));
 
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -20,6 +20,7 @@ import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumInfoResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
+import org.cherrypic.domain.album.dto.response.SubscribedAlbumListResponse;
 import org.cherrypic.domain.album.event.AlbumDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
@@ -758,6 +759,117 @@ class AlbumServiceTest extends IntegrationTest {
             Participant participant2 =
                     Participant.createParticipant(member, album2, ParticipantRole.HOST);
             participantRepository.saveAll(List.of(participant1, participant2));
+        }
+    }
+
+    @Nested
+    class 구독_플랜별_앨범_목록을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2));
+
+            subscriptionRepository.save(
+                    Subscription.createSubscription(
+                            member, album2, LocalDateTime.of(2025, 8, 21, 0, 0)));
+        }
+
+        @Test
+        void BASIC_플랜이면_구독_정보는_null로_반환한다() {
+            // when
+            SliceResponse<SubscribedAlbumListResponse> response =
+                    albumService.getSubscribedAlbumsByPlan(
+                            AlbumPlan.BASIC, null, 1, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content().get(0))
+                                    .extracting(
+                                            "albumId",
+                                            "title",
+                                            "plan",
+                                            "price",
+                                            "subscriptionStartAt",
+                                            "subscriptionEndAt",
+                                            "subscriptionNextBillingAt")
+                                    .containsExactly(
+                                            1L, "testTitle1", AlbumPlan.BASIC, 0, null, null, null),
+                    () ->
+                            assertThat(
+                                            response.content()
+                                                    .get(0)
+                                                    .albumCreatedAt()
+                                                    .truncatedTo(ChronoUnit.MINUTES))
+                                    .isEqualTo(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void PRO_플랜이면_구독_정보를_포함하여_반환한다() {
+            // when
+            SliceResponse<SubscribedAlbumListResponse> response =
+                    albumService.getSubscribedAlbumsByPlan(
+                            AlbumPlan.PRO, null, 1, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content().get(0))
+                                    .extracting(
+                                            "albumId",
+                                            "title",
+                                            "plan",
+                                            "price",
+                                            "subscriptionStartAt",
+                                            "subscriptionEndAt",
+                                            "subscriptionNextBillingAt")
+                                    .containsExactly(
+                                            2L,
+                                            "testTitle2",
+                                            AlbumPlan.PRO,
+                                            5900,
+                                            LocalDateTime.of(2025, 8, 21, 0, 0),
+                                            LocalDateTime.of(2025, 9, 21, 0, 0),
+                                            LocalDateTime.of(2025, 9, 22, 0, 0)),
+                    () ->
+                            assertThat(
+                                            response.content()
+                                                    .get(0)
+                                                    .albumCreatedAt()
+                                                    .truncatedTo(ChronoUnit.MINUTES))
+                                    .isEqualTo(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void PREMIUM_앨범이_없는_경우_빈_리스트를_응답한다() {
+            // when
+            SliceResponse<SubscribedAlbumListResponse> response =
+                    albumService.getSubscribedAlbumsByPlan(
+                            AlbumPlan.PREMIUM, null, 10, SortDirection.DESC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isZero(),
+                    () -> assertThat(response.isLast()).isTrue());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #142 

---
## 📌 작업 내용 및 특이사항
* 구독 플랜별 앨범 목록을 조회하는 기능을 구현했습니다.
  * BASIC 플랜의 경우 구독 정보(startAt, endAt, nextBillingAt)는 null로 응답되도록 했습니다.
  * PRO / PREMIUM 플랜의 경우에는 구독 정보를 포함하여 응답되도록 했습니다.
* @QueryProjection 대신 Tuple과 정적 팩토리 메서드(of)를 사용했습니다.
  * AlbumPlan enum 내부의 price 값을 QueryDSL에서 직접 매핑할 수 없어 Tuple로 받아 처리하는 방식으로 구현했습니다.

---
## 📚 참고사항
* 커서 기반 페이징 쿼리는 기존의 “참여 중인 앨범 목록 조회”와 동일한 방식이므로, 별도의 쿼리 테스트는 작성하지 않았습니다.
* 대신 응답 구조에 대한 검증 위주의 테스트만 작성했습니다.