### PR TITLE
feat:  업로드 실패한 동영상 & 이미지 제거 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -49,7 +49,7 @@ public class ImageController {
     @DeleteMapping("/images")
     @Operation(
             summary = "업로드 실패한 동영상 & 이미지 삭제",
-            description = "업로드를 실패한 Presigned URL을 바탕으로 동영상 & 이미지를 삭제합니다.")
+            description = "업로드를 실패한 Presigned URL을 기반으로 동영상 & 이미지를 삭제합니다.")
     public ResponseEntity<Void> uploadFailedImagedDelete(
             @Valid @RequestBody UploadFailedImageDeleteRequest request) {
         imageService.deleteUploadFailedImages(request);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.UploadFailedImageDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
@@ -15,6 +16,7 @@ import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.global.annotation.PageSize;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,6 +44,16 @@ public class ImageController {
     public PresignedUrlsResponse albumImageUploadUrlsCreate(
             @PathVariable Long albumId, @Valid @RequestBody AlbumImageUploadRequest request) {
         return imageService.createAlbumImageUploadUrls(albumId, request);
+    }
+
+    @DeleteMapping("/images")
+    @Operation(
+            summary = "업로드 실패한 동영상 & 이미지 삭제",
+            description = "업로드를 실패한 Presigned URL을 바탕으로 동영상 & 이미지를 삭제합니다.")
+    public ResponseEntity<Void> uploadFailedImagedDelete(
+            @Valid @RequestBody UploadFailedImageDeleteRequest request) {
+        imageService.deleteUploadFailedImages(request);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/albums/{albumId}/images")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/UploadFailedImageDeleteRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/UploadFailedImageDeleteRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record UploadFailedImageDeleteRequest(
+        @NotEmpty(message = "Presigned URL은 비워둘 수 없습니다.")
+                @Schema(description = "업로드 실패한 Presigned URL들")
+                List<String> presignedUrls) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -10,7 +10,8 @@ public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
     IMAGES_IN_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
     IMAGE_DELETED(409, "이미지 관련 작업 중 이미지가 삭제되었습니다."),
-    IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류");
+    IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류"),
+    PRESIGNED_IMAGES_NOT_MINE(403, "본인이 업로드하지 않은 Presigned Image는 삭제할 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -10,4 +10,6 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
     long countByIdIn(List<Long> ids);
 
     long countByIdInAndAlbumId(List<Long> imageIds, Long albumId);
+
+    void deleteAllByUrlIn(List<String> urls);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -11,5 +11,5 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
 
     long countByIdInAndAlbumId(List<Long> imageIds, Long albumId);
 
-    void deleteAllByUrlIn(List<String> urls);
+    List<Image> findByUrlIn(List<String> urls);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -2,6 +2,7 @@ package org.cherrypic.domain.image.service;
 
 import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.UploadFailedImageDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
@@ -19,4 +20,6 @@ public interface ImageService {
 
     SliceResponse<EventImageListResponse> getEventImages(
             Long eventId, Long lastImageId, int size, SortDirection direction);
+
+    void deleteUploadFailedImages(UploadFailedImageDeleteRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -25,6 +25,7 @@ import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
+import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.event.entity.Event;
@@ -33,6 +34,7 @@ import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.helper.SpringEnvironmentHelper;
+import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
@@ -123,7 +125,12 @@ public class ImageServiceImpl implements ImageService {
 
     @Override
     public void deleteUploadFailedImages(UploadFailedImageDeleteRequest request) {
-        imageRepository.deleteAllByUrlIn(request.presignedUrls());
+        final Member currentMember = memberUtil.getCurrentMember();
+        final List<Image> images = imageRepository.findByUrlIn(request.presignedUrls());
+
+        validatePresignedImageOwnership(currentMember, images);
+
+        imageRepository.deleteAllInBatch(images);
     }
 
     private String createPresignedUrl(
@@ -206,6 +213,17 @@ public class ImageServiceImpl implements ImageService {
 
         if (participant.getRole().equals(ParticipantRole.LIMITED)) {
             throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
+        }
+    }
+
+    private void validatePresignedImageOwnership(Member member, List<Image> images) {
+        Long memberId = member.getId();
+
+        boolean hasInvalidImage =
+                images.stream().anyMatch(image -> !image.getMemberId().equals(memberId));
+
+        if (hasInvalidImage) {
+            throw new CustomException(ImageErrorCode.PRESIGNED_IMAGES_NOT_MINE);
         }
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -18,6 +18,7 @@ import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.UploadFailedImageDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
@@ -118,6 +119,11 @@ public class ImageServiceImpl implements ImageService {
         Slice<EventImageListResponse> result =
                 imageRepository.findAllByEventId(eventId, lastImageId, size, direction);
         return SliceResponse.from(result);
+    }
+
+    @Override
+    public void deleteUploadFailedImages(UploadFailedImageDeleteRequest request) {
+        imageRepository.deleteAllByUrlIn(request.presignedUrls());
     }
 
     private String createPresignedUrl(

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -1,7 +1,6 @@
 package org.cherrypic.image.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -20,6 +19,7 @@ import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
@@ -653,6 +653,31 @@ class ImageControllerTest {
             perform.andExpect(status().isNoContent())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 내가_업로드하지_않은_이미지를_삭제할_경우_예외가_발생한다() throws Exception {
+            // given
+            UploadFailedImageDeleteRequest request =
+                    new UploadFailedImageDeleteRequest(List.of("testPresignedUrl"));
+            willThrow(new CustomException(ImageErrorCode.PRESIGNED_IMAGES_NOT_MINE))
+                    .given(imageService)
+                    .deleteUploadFailedImages(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("PRESIGNED_IMAGES_NOT_MINE"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("본인이 업로드하지 않은 Presigned Image는 삭제할 수 없습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -1,8 +1,8 @@
 package org.cherrypic.image.controller;
 
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,6 +14,7 @@ import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.image.controller.ImageController;
 import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.UploadFailedImageDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
@@ -628,6 +629,49 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
                     .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 업로드_실패한_이미지_삭제_요청_시 {
+
+        @Test
+        void 유효한_요청이면_이미지를_삭제하고_NO_CONTENT를_반환한다() throws Exception {
+            // given
+            UploadFailedImageDeleteRequest request =
+                    new UploadFailedImageDeleteRequest(List.of("testPresignedUrl"));
+
+            willDoNothing().given(imageService).deleteUploadFailedImages(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void Presigned_URL이_없는_경우_예외가_발생한다() throws Exception {
+            // given
+            UploadFailedImageDeleteRequest request = new UploadFailedImageDeleteRequest(List.of());
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("Presigned URL은 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -15,6 +15,7 @@ import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.AlbumImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.UploadFailedImageDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
@@ -407,6 +408,40 @@ class ImageServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> imageService.getEventImages(999L, null, 2, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 업로드_실패한_이미지_삭제할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+
+            Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
+            albumRepository.save(album);
+
+            Image image1 = Image.createImage(album, 1L, "testUrl1", LocalDateTime.now());
+            Image image2 = Image.createImage(album, 1L, "testUrl2", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2));
+        }
+
+        @Test
+        void 유효한_요청이면_업로드_실패한_이미지를_삭제한다() {
+            // given
+            UploadFailedImageDeleteRequest request =
+                    new UploadFailedImageDeleteRequest(List.of("testUrl1", "testUrl2"));
+
+            // when
+            imageService.deleteUploadFailedImages(request);
+
+            // then
+            assertThat(imageRepository.findAllById(List.of(1L, 2L))).isEmpty();
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -21,6 +21,7 @@ import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.ImageFileExtension;
+import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.image.service.ImageService;
@@ -416,19 +417,26 @@ class ImageServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            Member member =
+            Member member1 =
                     Member.createMember(
                             OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                            "testNickname",
-                            "testProfileImageUrl");
-            memberRepository.save(member);
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
 
             Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
             albumRepository.save(album);
 
             Image image1 = Image.createImage(album, 1L, "testUrl1", LocalDateTime.now());
             Image image2 = Image.createImage(album, 1L, "testUrl2", LocalDateTime.now());
-            imageRepository.saveAll(List.of(image1, image2));
+            Image image3 = Image.createImage(album, 2L, "testUrl3", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3));
         }
 
         @Test
@@ -442,6 +450,18 @@ class ImageServiceTest extends IntegrationTest {
 
             // then
             assertThat(imageRepository.findAllById(List.of(1L, 2L))).isEmpty();
+        }
+
+        @Test
+        void 내가_업로드하지_않은_이미지를_삭제할_경우_예외가_발생한다() {
+            // given
+            UploadFailedImageDeleteRequest request =
+                    new UploadFailedImageDeleteRequest(List.of("testUrl3"));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.deleteUploadFailedImages(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ImageErrorCode.PRESIGNED_IMAGES_NOT_MINE.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -99,7 +99,6 @@ class MemberControllerTest {
 
         @ParameterizedTest
         @NullSource
-        @EmptySource
         @ValueSource(strings = {" "})
         void 닉네임이_null_또는_공백이면_예외가_발생한다(String nickname) throws Exception {
             // given


### PR DESCRIPTION
## 🌱 관련 이슈
- close #147 

---
## 📌 작업 내용 및 특이사항
-  업로드 실패한 이미지 엔티티를 제거하는 API를 구현했습니다.
- 기본적인 요청값 검증은 두었고, 서비스 로직에서 별다른 검증은 추가하지 않았습니다.

---
## 📚 참고사항
- 완전히 프론트 만을 위한 기능이라 서비스 검증을 추가 하지 않았는데, 이미지를 업로드한 유저와 현재 유저가 동일한지 정도는 확인할 필요가 있을까요? -> 추가됨.
- 이미지 삭제를 Batch 처리함으로써 동시성 문제 해결.