### PR TITLE
feat: 앨범 목록 조회 API에 앨범 플랜 필터링 기능 추가

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
@@ -65,8 +66,14 @@ public class AlbumController {
     }
 
     @GetMapping
-    @Operation(summary = "앨범 목록 조회", description = "회원이 참여 중인 앨범 목록을 커서 기반 페이징 방식으로 조회합니다.")
+    @Operation(
+            summary = "앨범 목록 조회",
+            description =
+                    "회원이 참여 중인 앨범 목록을 커서 기반 페이징 방식으로 조회합니다. 앨범 플랜을 지정하면 해당 플랜에 해당하는 앨범만 필터링하여 조회합니다.")
     public SliceResponse<AlbumListResponse> albumsGet(
+            @Parameter(description = "앨범 플랜 (BASIC, PRO, PREMIUM). 생략 시 전체 조회")
+                    @RequestParam(required = false)
+                    AlbumPlan plan,
             @Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastAlbumId,
@@ -74,7 +81,7 @@ public class AlbumController {
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
-        return albumService.getParticipatingAlbums(lastAlbumId, size, direction);
+        return albumService.getParticipatingAlbumsByPlan(plan, lastAlbumId, size, direction);
     }
 
     @DeleteMapping("/{albumId}")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -1,10 +1,11 @@
 package org.cherrypic.domain.album.repository;
 
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.Slice;
 
 public interface AlbumRepositoryCustom {
-    Slice<AlbumListResponse> findAllByMemberId(
-            Long memberId, Long lastAlbumId, int size, SortDirection direction);
+    Slice<AlbumListResponse> findAllByMemberIdAndPlan(
+            Long memberId, AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.PageRequest;
@@ -22,8 +23,8 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<AlbumListResponse> findAllByMemberId(
-            Long memberId, Long lastAlbumId, int size, SortDirection direction) {
+    public Slice<AlbumListResponse> findAllByMemberIdAndPlan(
+            Long memberId, AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction) {
         List<AlbumListResponse> results =
                 queryFactory
                         .select(
@@ -38,6 +39,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                         .join(participant.album, album)
                         .where(
                                 participant.member.id.eq(memberId),
+                                plan != null ? album.plan.eq(plan) : null,
                                 lastAlbumIdCondition(lastAlbumId, direction))
                         .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())
                         .limit(size + 1)

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.album.service;
 
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
@@ -15,8 +16,8 @@ public interface AlbumService {
 
     InvitationLinkCreateResponse createInvitationLink(Long albumId);
 
-    SliceResponse<AlbumListResponse> getParticipatingAlbums(
-            Long lastAlbumId, int size, SortDirection direction);
+    SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
+            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction);
 
     AlbumJoinResponse joinAlbum(Long albumId, String code);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -142,13 +142,13 @@ public class AlbumServiceImpl implements AlbumService {
 
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<AlbumListResponse> getParticipatingAlbums(
-            Long lastAlbumId, int size, SortDirection direction) {
+    public SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
+            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
 
         Slice<AlbumListResponse> results =
-                albumRepository.findAllByMemberId(
-                        currentMember.getId(), lastAlbumId, size, direction);
+                albumRepository.findAllByMemberIdAndPlan(
+                        currentMember.getId(), plan, lastAlbumId, size, direction);
 
         return SliceResponse.from(results);
     }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -708,14 +708,43 @@ class AlbumControllerTest {
     class 앨범_목록_조회_요청_시 {
 
         @Test
+        void PRO_플랜으로_필터링하면_PRO_앨범만_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(
+                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                            new AlbumListResponse(
+                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.PRO, false));
+
+            given(
+                            albumService.getParticipatingAlbumsByPlan(
+                                    AlbumPlan.PRO, null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("plan", "PRO").param("size", "2"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].plan").value("PRO"))
+                    .andExpect(jsonPath("$.data.content[1].plan").value("PRO"))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
         void 정렬_조건이_ASC이면_albumId를_오름차순으로_응답한다() throws Exception {
             // given
             List<AlbumListResponse> albums =
                     List.of(
-                            new AlbumListResponse(1L, "first", "coverUrl1", AlbumPlan.BASIC, false),
-                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO, true));
+                            new AlbumListResponse(
+                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false),
+                            new AlbumListResponse(
+                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true));
 
-            given(albumService.getParticipatingAlbums(null, 2, SortDirection.ASC))
+            given(albumService.getParticipatingAlbumsByPlan(null, null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -735,11 +764,12 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums =
                     List.of(
-                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO, true),
                             new AlbumListResponse(
-                                    1L, "first", "coverUrl1", AlbumPlan.BASIC, false));
+                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                            new AlbumListResponse(
+                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
 
-            given(albumService.getParticipatingAlbums(null, 2, SortDirection.DESC))
+            given(albumService.getParticipatingAlbumsByPlan(null, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -760,9 +790,9 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    1L, "first", "coverUrl1", AlbumPlan.BASIC, false));
+                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
 
-            given(albumService.getParticipatingAlbums(null, 1, SortDirection.DESC))
+            given(albumService.getParticipatingAlbumsByPlan(null, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -781,11 +811,12 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums =
                     List.of(
-                            new AlbumListResponse(2L, "second", "coverUrl2", AlbumPlan.PRO, true),
                             new AlbumListResponse(
-                                    1L, "first", "coverUrl1", AlbumPlan.BASIC, false));
+                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                            new AlbumListResponse(
+                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
 
-            given(albumService.getParticipatingAlbums(null, 1, SortDirection.DESC))
+            given(albumService.getParticipatingAlbumsByPlan(null, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, false));
 
             // when & then
@@ -804,7 +835,7 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums = List.of();
 
-            given(albumService.getParticipatingAlbums(null, 10, SortDirection.DESC))
+            given(albumService.getParticipatingAlbumsByPlan(null, null, 10, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -671,31 +671,49 @@ class AlbumServiceTest extends IntegrationTest {
 
             Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
             Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2));
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
             Participant participant2 =
                     Participant.createParticipant(member, album2, ParticipantRole.HOST);
-            participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant3 =
+                    Participant.createParticipant(member, album3, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
 
             Favorites favorites1 = Favorites.createFavorites(participant1);
             Favorites favorites2 = Favorites.createFavorites(participant2);
-            favoritesRepository.saveAll(List.of(favorites1, favorites2));
+            Favorites favorites3 = Favorites.createFavorites(participant3);
+            favoritesRepository.saveAll(List.of(favorites1, favorites2, favorites3));
+        }
+
+        @Test
+        void PRO_플랜으로_필터링하면_PRO_앨범만_조회한다() {
+            // given
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbumsByPlan(
+                            AlbumPlan.PRO, null, 1, SortDirection.DESC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().get(0).albumId()).isEqualTo(3),
+                    () -> assertThat(response.content().get(0).plan()).isEqualTo(AlbumPlan.PRO),
+                    () -> assertThat(response.isLast()).isTrue());
         }
 
         @Test
         void 정렬_조건이_ASC이면_albumId를_오름차순으로_조회한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbums(null, 2, SortDirection.ASC);
+                    albumService.getParticipatingAlbumsByPlan(null, null, 3, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
                     () ->
                             assertThat(response.content())
                                     .extracting("albumId")
-                                    .containsExactly(1L, 2L),
+                                    .containsExactly(1L, 2L, 3L),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -703,14 +721,14 @@ class AlbumServiceTest extends IntegrationTest {
         void 정렬_조건이_DESC이면_albumId를_내림차순으로_조회한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbums(null, 2, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByPlan(null, null, 3, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
                     () ->
                             assertThat(response.content())
                                     .extracting("albumId")
-                                    .containsExactly(2L, 1L),
+                                    .containsExactly(3L, 2L, 1L),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -718,11 +736,11 @@ class AlbumServiceTest extends IntegrationTest {
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbums(null, 2, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByPlan(null, null, 3, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(response.content().size()).isEqualTo(2),
+                    () -> assertThat(response.content().size()).isEqualTo(3),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -730,7 +748,7 @@ class AlbumServiceTest extends IntegrationTest {
         void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbums(null, 1, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByPlan(null, null, 1, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
@@ -745,7 +763,7 @@ class AlbumServiceTest extends IntegrationTest {
 
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbums(null, 10, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByPlan(null, null, 10, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #149 

---
## 📌 작업 내용 및 특이사항
* 앨범 목록 조회 API에 앨범 플랜 필터링 기능을 추가했습니다.
  * plan 파라미터를 추가하여 BASIC, PRO, PREMIUM 플랜에 따라 앨범을 필터링할 수 있습니다.
  * plan이 null인 경우 기존과 동일하게 전체 앨범을 조회합니다.