### PR TITLE
feat: 앨범 검색 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -65,6 +65,12 @@ public class AlbumController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @GetMapping("/{albumId}")
+    @Operation(summary = "개별 앨범 조회", description = "개별 앨범을 조회합니다.")
+    public AlbumInfoResponse albumGet(@PathVariable Long albumId) {
+        return albumService.getAlbum(albumId);
+    }
+
     @GetMapping
     @Operation(
             summary = "앨범 목록 조회",
@@ -89,11 +95,5 @@ public class AlbumController {
     public ResponseEntity<Void> albumDelete(@PathVariable Long albumId) {
         albumService.deleteAlbum(albumId);
         return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/{albumId}")
-    @Operation(summary = "개별 앨범 조회", description = "개별 앨범을 조회합니다.")
-    public AlbumInfoResponse albumGet(@PathVariable Long albumId) {
-        return albumService.getAlbum(albumId);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -80,6 +80,9 @@ public class AlbumController {
             @Parameter(description = "앨범 플랜 (BASIC, PRO, PREMIUM). 생략 시 전체 조회")
                     @RequestParam(required = false)
                     AlbumPlan plan,
+            @Parameter(description = "검색 키워드 (앨범 제목에 포함된 단어). 생략 시 전체 조회")
+                    @RequestParam(required = false)
+                    String keyword,
             @Parameter(description = "이전 페이지의 마지막 앨범 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastAlbumId,
@@ -87,7 +90,8 @@ public class AlbumController {
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
-        return albumService.getParticipatingAlbumsByPlan(plan, lastAlbumId, size, direction);
+        return albumService.getParticipatingAlbumsByCondition(
+                plan, keyword, lastAlbumId, size, direction);
     }
 
     @DeleteMapping("/{albumId}")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -6,6 +6,11 @@ import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.Slice;
 
 public interface AlbumRepositoryCustom {
-    Slice<AlbumListResponse> findAllByMemberIdAndPlan(
-            Long memberId, AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction);
+    Slice<AlbumListResponse> findAllByMemberIdAndPlanAndKeyword(
+            Long memberId,
+            AlbumPlan plan,
+            String keyword,
+            Long lastAlbumId,
+            int size,
+            SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -23,8 +23,13 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<AlbumListResponse> findAllByMemberIdAndPlan(
-            Long memberId, AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction) {
+    public Slice<AlbumListResponse> findAllByMemberIdAndPlanAndKeyword(
+            Long memberId,
+            AlbumPlan plan,
+            String keyword,
+            Long lastAlbumId,
+            int size,
+            SortDirection direction) {
         List<AlbumListResponse> results =
                 queryFactory
                         .select(
@@ -40,6 +45,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                         .where(
                                 participant.member.id.eq(memberId),
                                 plan != null ? album.plan.eq(plan) : null,
+                                keyword != null ? album.title.containsIgnoreCase(keyword) : null,
                                 lastAlbumIdCondition(lastAlbumId, direction))
                         .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())
                         .limit(size + 1)

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -16,12 +16,12 @@ public interface AlbumService {
 
     InvitationLinkCreateResponse createInvitationLink(Long albumId);
 
-    SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
-            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction);
-
     AlbumJoinResponse joinAlbum(Long albumId, String code);
 
     AlbumInfoResponse getAlbum(Long albumId);
+
+    SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
+            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction);
 
     void deleteAlbum(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -20,8 +20,8 @@ public interface AlbumService {
 
     AlbumInfoResponse getAlbum(Long albumId);
 
-    SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
-            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction);
+    SliceResponse<AlbumListResponse> getParticipatingAlbumsByCondition(
+            AlbumPlan plan, String keyword, Long lastAlbumId, int size, SortDirection direction);
 
     void deleteAlbum(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -186,13 +186,13 @@ public class AlbumServiceImpl implements AlbumService {
 
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
-            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction) {
+    public SliceResponse<AlbumListResponse> getParticipatingAlbumsByCondition(
+            AlbumPlan plan, String keyword, Long lastAlbumId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
 
         Slice<AlbumListResponse> results =
-                albumRepository.findAllByMemberIdAndPlan(
-                        currentMember.getId(), plan, lastAlbumId, size, direction);
+                albumRepository.findAllByMemberIdAndPlanAndKeyword(
+                        currentMember.getId(), plan, keyword, lastAlbumId, size, direction);
 
         return SliceResponse.from(results);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -141,19 +141,6 @@ public class AlbumServiceImpl implements AlbumService {
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
-            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction) {
-        final Member currentMember = memberUtil.getCurrentMember();
-
-        Slice<AlbumListResponse> results =
-                albumRepository.findAllByMemberIdAndPlan(
-                        currentMember.getId(), plan, lastAlbumId, size, direction);
-
-        return SliceResponse.from(results);
-    }
-
-    @Override
     public AlbumJoinResponse joinAlbum(Long albumId, String code) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumByIdWithLock(albumId);
@@ -195,6 +182,19 @@ public class AlbumServiceImpl implements AlbumService {
                 album.getPlan().getCapacityGb(),
                 hostName,
                 numOfParticipants);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SliceResponse<AlbumListResponse> getParticipatingAlbumsByPlan(
+            AlbumPlan plan, Long lastAlbumId, int size, SortDirection direction) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        Slice<AlbumListResponse> results =
+                albumRepository.findAllByMemberIdAndPlan(
+                        currentMember.getId(), plan, lastAlbumId, size, direction);
+
+        return SliceResponse.from(results);
     }
 
     @Override

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -705,6 +705,201 @@ class AlbumControllerTest {
     }
 
     @Nested
+    class 앨범_입장_요청_시 {
+
+        @Test
+        void 유효한_요청이면_참가자_정보를_반환한다() throws Exception {
+            // given
+            AlbumJoinResponse response =
+                    new AlbumJoinResponse(1L, 1L, 1L, ParticipantRole.STANDARD);
+
+            given(albumService.joinAlbum(1L, "testInvitationCode")).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
+
+            perform.andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
+                    .andExpect(jsonPath("$.data.participantId").value(1))
+                    .andExpect(jsonPath("$.data.albumId").value(1))
+                    .andExpect(jsonPath("$.data.memberId").value(1))
+                    .andExpect(jsonPath("$.data.role").value("STANDARD"));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(999L, "testInvitationCode"))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/999/join").param("code", "testInvitationCode"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_초대_코드가_redis에_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "noneExistingCode"))
+                    .willThrow(new CustomException(AlbumErrorCode.INVITATION_CODE_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "noneExistingCode"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범의 초대 코드가 만료되었습니다."));
+        }
+
+        @Test
+        void 앨범_초대_코드가_redis에_저장된_코드와_일치하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "testInvitationCode"))
+                    .willThrow(new CustomException(AlbumErrorCode.ALREADY_PARTICIPATED));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_PARTICIPATED"))
+                    .andExpect(jsonPath("$.data.message").value("이미 참가한 앨범입니다."));
+        }
+
+        @Test
+        void 이미_입장한_앨범에_재입장_하려는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "expiredInvitationCode"))
+                    .willThrow(new CustomException(AlbumErrorCode.INVITATION_CODE_MISMATCH));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "expiredInvitationCode"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("초대 코드가 올바르지 않습니다."));
+        }
+
+        @Test
+        void 최대_참가자_수를_초과하면_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "testInvitationCode"))
+                    .willThrow(
+                            new CustomException(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_PARTICIPANT_LIMIT_EXCEEDED"))
+                    .andExpect(jsonPath("$.data.message").value("앨범 인원 제한으로 더 이상 참가할 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 개별_앨범을_조회_요청_시 {
+
+        @Test
+        void 유효한_요청인_경우_앨범_정보를_반환한다() throws Exception {
+            // given
+            AlbumInfoResponse response =
+                    new AlbumInfoResponse(
+                            "testAlbum",
+                            "testUrl",
+                            AlbumPlan.BASIC,
+                            new BigDecimal("0.00"),
+                            new BigDecimal("3"),
+                            "testNickname",
+                            1);
+            given(albumService.getAlbum(1L)).willReturn(response);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.title").value("testAlbum"))
+                    .andExpect(jsonPath("$.data.coverUrl").value("testUrl"))
+                    .andExpect(jsonPath("$.data.albumPlan").value("BASIC"))
+                    .andExpect(jsonPath("$.data.capacityUsed").value("0.00"))
+                    .andExpect(jsonPath("$.data.totalCapacity").value("3"))
+                    .andExpect(jsonPath("$.data.hostName").value("testNickname"))
+                    .andExpect(jsonPath("$.data.numOfParticipants").value(1));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(albumService)
+                    .getAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참여자가_아닌_경우_에외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(albumService)
+                    .getAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범에_방장이_없는_경우_에외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_HOST_NOT_FOUND))
+                    .given(albumService)
+                    .getAlbum(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_HOST_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 존재하지 않는 앨범입니다"));
+        }
+    }
+
+    @Nested
     class 앨범_목록_조회_요청_시 {
 
         @Test
@@ -880,117 +1075,6 @@ class AlbumControllerTest {
     }
 
     @Nested
-    class 앨범_입장_요청_시 {
-
-        @Test
-        void 유효한_요청이면_참가자_정보를_반환한다() throws Exception {
-            // given
-            AlbumJoinResponse response =
-                    new AlbumJoinResponse(1L, 1L, 1L, ParticipantRole.STANDARD);
-
-            given(albumService.joinAlbum(1L, "testInvitationCode")).willReturn(response);
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
-
-            perform.andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
-                    .andExpect(jsonPath("$.data.participantId").value(1))
-                    .andExpect(jsonPath("$.data.albumId").value(1))
-                    .andExpect(jsonPath("$.data.memberId").value(1))
-                    .andExpect(jsonPath("$.data.role").value("STANDARD"));
-        }
-
-        @Test
-        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
-            // given
-            given(albumService.joinAlbum(999L, "testInvitationCode"))
-                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(post("/albums/999/join").param("code", "testInvitationCode"));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
-        }
-
-        @Test
-        void 앨범_초대_코드가_redis에_존재하지_않는_경우_예외가_발생한다() throws Exception {
-            // given
-            given(albumService.joinAlbum(1L, "noneExistingCode"))
-                    .willThrow(new CustomException(AlbumErrorCode.INVITATION_CODE_NOT_FOUND));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(post("/albums/1/join").param("code", "noneExistingCode"));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("앨범의 초대 코드가 만료되었습니다."));
-        }
-
-        @Test
-        void 앨범_초대_코드가_redis에_저장된_코드와_일치하지_않는_경우_예외가_발생한다() throws Exception {
-            // given
-            given(albumService.joinAlbum(1L, "testInvitationCode"))
-                    .willThrow(new CustomException(AlbumErrorCode.ALREADY_PARTICIPATED));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALREADY_PARTICIPATED"))
-                    .andExpect(jsonPath("$.data.message").value("이미 참가한 앨범입니다."));
-        }
-
-        @Test
-        void 이미_입장한_앨범에_재입장_하려는_경우_예외가_발생한다() throws Exception {
-            // given
-            given(albumService.joinAlbum(1L, "expiredInvitationCode"))
-                    .willThrow(new CustomException(AlbumErrorCode.INVITATION_CODE_MISMATCH));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(post("/albums/1/join").param("code", "expiredInvitationCode"));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("INVITATION_CODE_MISMATCH"))
-                    .andExpect(jsonPath("$.data.message").value("초대 코드가 올바르지 않습니다."));
-        }
-
-        @Test
-        void 최대_참가자_수를_초과하면_예외가_발생한다() throws Exception {
-            // given
-            given(albumService.joinAlbum(1L, "testInvitationCode"))
-                    .willThrow(
-                            new CustomException(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(post("/albums/1/join").param("code", "testInvitationCode"));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALBUM_PARTICIPANT_LIMIT_EXCEEDED"))
-                    .andExpect(jsonPath("$.data.message").value("앨범 인원 제한으로 더 이상 참가할 수 없습니다."));
-        }
-    }
-
-    @Nested
     class 앨범_삭제_요청_시 {
 
         @Test
@@ -1089,90 +1173,6 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_ACTIVE"))
                     .andExpect(jsonPath("$.data.message").value("구독 중인 앨범은 삭제할 수 없습니다."));
-        }
-    }
-
-    @Nested
-    class 개별_앨범을_조회할_때 {
-
-        @Test
-        void 유효한_요청인_경우_앨범_정보를_반환한다() throws Exception {
-            // given
-            AlbumInfoResponse response =
-                    new AlbumInfoResponse(
-                            "testAlbum",
-                            "testUrl",
-                            AlbumPlan.BASIC,
-                            new BigDecimal("0.00"),
-                            new BigDecimal("3"),
-                            "testNickname",
-                            1);
-            given(albumService.getAlbum(1L)).willReturn(response);
-
-            // when & then
-            ResultActions perform = mockMvc.perform(get("/albums/1"));
-
-            perform.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                    .andExpect(jsonPath("$.data.title").value("testAlbum"))
-                    .andExpect(jsonPath("$.data.coverUrl").value("testUrl"))
-                    .andExpect(jsonPath("$.data.albumPlan").value("BASIC"))
-                    .andExpect(jsonPath("$.data.capacityUsed").value("0.00"))
-                    .andExpect(jsonPath("$.data.totalCapacity").value("3"))
-                    .andExpect(jsonPath("$.data.hostName").value("testNickname"))
-                    .andExpect(jsonPath("$.data.numOfParticipants").value(1));
-        }
-
-        @Test
-        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
-            // given
-            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
-                    .given(albumService)
-                    .getAlbum(1L);
-
-            // when & then
-            ResultActions perform = mockMvc.perform(get("/albums/1"));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
-        }
-
-        @Test
-        void 앨범_참여자가_아닌_경우_에외가_발생한다() throws Exception {
-            // given
-            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
-                    .given(albumService)
-                    .getAlbum(1L);
-
-            // when & then
-            ResultActions perform = mockMvc.perform(get("/albums/1"));
-
-            perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
-        }
-
-        @Test
-        void 앨범에_방장이_없는_경우_에외가_발생한다() throws Exception {
-            // given
-            willThrow(new CustomException(AlbumErrorCode.ALBUM_HOST_NOT_FOUND))
-                    .given(albumService)
-                    .getAlbum(1L);
-
-            // when & then
-            ResultActions perform = mockMvc.perform(get("/albums/1"));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALBUM_HOST_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("방장이 존재하지 않는 앨범입니다"));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -913,8 +913,8 @@ class AlbumControllerTest {
                                     1L, "testTitle1", "testCoverUrl1", AlbumPlan.PRO, false));
 
             given(
-                            albumService.getParticipatingAlbumsByPlan(
-                                    AlbumPlan.PRO, null, 2, SortDirection.DESC))
+                            albumService.getParticipatingAlbumsByCondition(
+                                    AlbumPlan.PRO, null, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -930,6 +930,65 @@ class AlbumControllerTest {
         }
 
         @Test
+        void 앨범_이름으로_필터링하면_일치하는_앨범만_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(
+                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.BASIC, true),
+                            new AlbumListResponse(
+                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
+
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null, "testTitle", null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums").param("keyword", "testTitle").param("size", "2"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].title").value("testTitle2"))
+                    .andExpect(jsonPath("$.data.content[1].title").value("testTitle1"))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void PRO_플랜과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(
+                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                            new AlbumListResponse(
+                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.PRO, false));
+
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    AlbumPlan.PRO, "testTitle", null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums")
+                                    .param("plan", "PRO")
+                                    .param("keyword", "testTitle")
+                                    .param("size", "2"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].title").value("testTitle2"))
+                    .andExpect(jsonPath("$.data.content[1].title").value("testTitle1"))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
         void 정렬_조건이_ASC이면_albumId를_오름차순으로_응답한다() throws Exception {
             // given
             List<AlbumListResponse> albums =
@@ -939,7 +998,9 @@ class AlbumControllerTest {
                             new AlbumListResponse(
                                     2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true));
 
-            given(albumService.getParticipatingAlbumsByPlan(null, null, 2, SortDirection.ASC))
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null, null, null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -964,7 +1025,9 @@ class AlbumControllerTest {
                             new AlbumListResponse(
                                     1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
 
-            given(albumService.getParticipatingAlbumsByPlan(null, null, 2, SortDirection.DESC))
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null, null, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -987,7 +1050,9 @@ class AlbumControllerTest {
                             new AlbumListResponse(
                                     1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
 
-            given(albumService.getParticipatingAlbumsByPlan(null, null, 1, SortDirection.DESC))
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null, null, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -1011,7 +1076,9 @@ class AlbumControllerTest {
                             new AlbumListResponse(
                                     1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
 
-            given(albumService.getParticipatingAlbumsByPlan(null, null, 1, SortDirection.DESC))
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null, null, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, false));
 
             // when & then
@@ -1030,7 +1097,9 @@ class AlbumControllerTest {
             // given
             List<AlbumListResponse> albums = List.of();
 
-            given(albumService.getParticipatingAlbumsByPlan(null, null, 10, SortDirection.DESC))
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null, null, null, 10, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -657,6 +657,195 @@ class AlbumServiceTest extends IntegrationTest {
     }
 
     @Nested
+    class 앨범에_입장할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant =
+                    Participant.createParticipant(member, album3, ParticipantRole.HOST);
+            participantRepository.save(participant);
+
+            InvitationCode invitationCode1 =
+                    InvitationCode.builder()
+                            .albumId(1L)
+                            .code("testInvitationCode1")
+                            .ttl(Duration.ofMinutes(30).getSeconds())
+                            .build();
+            InvitationCode invitationCode2 =
+                    InvitationCode.builder()
+                            .albumId(3L)
+                            .code("testInvitationCode2")
+                            .ttl(Duration.ofMinutes(30).getSeconds())
+                            .build();
+            invitationCodeRepository.saveAll(List.of(invitationCode1, invitationCode2));
+        }
+
+        @AfterEach
+        void cleanUp() {
+            redisCleaner.flushAll();
+        }
+
+        @Test
+        void 유효한_초대_코드면_앨범_참가자가_생성된다() {
+            // when
+            albumService.joinAlbum(1L, "testInvitationCode1");
+
+            // then
+            Participant participant =
+                    participantRepository.findByMemberIdAndAlbumId(1L, 1L).orElseThrow();
+
+            Assertions.assertAll(
+                    () -> assertThat(participant).isNotNull(),
+                    () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.STANDARD));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(999L, "testInvitationCode1"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_초대_코드가_redis에_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(2L, "NoneExistingCode"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.INVITATION_CODE_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_초대_코드가_redis에_저장된_코드와_일치하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(1L, "expiredInvitationCode"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.INVITATION_CODE_MISMATCH.getMessage());
+        }
+
+        @Test
+        void 이미_입장한_앨범에_재입장_하려는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(3L, "testInvitationCode2"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALREADY_PARTICIPATED.getMessage());
+        }
+
+        @Test
+        void 최대_참가자_수를_초과하면_예외가_발생한다() {
+            // given
+            Album album = albumRepository.findById(1L).orElseThrow();
+            int maxParticipants = album.getPlan().getMaxParticipants();
+
+            for (int i = 0; i < maxParticipants; i++) {
+                Member member =
+                        Member.createMember(
+                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                                "testNickname",
+                                "testProfileImageUrl");
+                memberRepository.save(member);
+
+                Participant participant =
+                        Participant.createParticipant(member, album, ParticipantRole.STANDARD);
+                participantRepository.save(participant);
+            }
+
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(album.getId(), "testInvitationCode1"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED.getMessage());
+        }
+    }
+
+    @Nested
+    class 개별_앨범을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.STANDARD);
+            participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @Test
+        void 유효한_요청인_경우_앨범_정보를_반환한다() {
+            // when
+            AlbumInfoResponse response = albumService.getAlbum(1L);
+
+            // then
+            assertThat(response)
+                    .extracting(
+                            "title",
+                            "coverUrl",
+                            "albumPlan",
+                            "capacityUsed",
+                            "totalCapacity",
+                            "hostName",
+                            "numOfParticipants")
+                    .containsExactly(
+                            "testAlbum1",
+                            "testURL1",
+                            AlbumPlan.BASIC,
+                            new BigDecimal("0.00"),
+                            new BigDecimal("3"),
+                            "testNickname",
+                            1);
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.getAlbum(999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참여자가_아닌_경우_에외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.getAlbum(3L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 앨범에_방장이_없는_경우_에외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.getAlbum(2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_HOST_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
     class 앨범_목록을_조회할_때 {
 
         @BeforeEach
@@ -773,120 +962,6 @@ class AlbumServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 앨범에_입장할_때 {
-
-        @BeforeEach
-        void setUp() {
-            Member member =
-                    Member.createMember(
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                            "testNickname",
-                            "testProfileImageUrl");
-            memberRepository.save(member);
-            given(memberUtil.getCurrentMember()).willReturn(member);
-
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
-
-            Participant participant =
-                    Participant.createParticipant(member, album3, ParticipantRole.HOST);
-            participantRepository.save(participant);
-
-            InvitationCode invitationCode1 =
-                    InvitationCode.builder()
-                            .albumId(1L)
-                            .code("testInvitationCode1")
-                            .ttl(Duration.ofMinutes(30).getSeconds())
-                            .build();
-            InvitationCode invitationCode2 =
-                    InvitationCode.builder()
-                            .albumId(3L)
-                            .code("testInvitationCode2")
-                            .ttl(Duration.ofMinutes(30).getSeconds())
-                            .build();
-            invitationCodeRepository.saveAll(List.of(invitationCode1, invitationCode2));
-        }
-
-        @AfterEach
-        void cleanUp() {
-            redisCleaner.flushAll();
-        }
-
-        @Test
-        void 유효한_초대_코드면_앨범_참가자가_생성된다() {
-            // when
-            albumService.joinAlbum(1L, "testInvitationCode1");
-
-            // then
-            Participant participant =
-                    participantRepository.findByMemberIdAndAlbumId(1L, 1L).orElseThrow();
-
-            Assertions.assertAll(
-                    () -> assertThat(participant).isNotNull(),
-                    () -> assertThat(participant.getRole()).isEqualTo(ParticipantRole.STANDARD));
-        }
-
-        @Test
-        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> albumService.joinAlbum(999L, "testInvitationCode1"))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 앨범_초대_코드가_redis에_존재하지_않는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> albumService.joinAlbum(2L, "NoneExistingCode"))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.INVITATION_CODE_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 앨범_초대_코드가_redis에_저장된_코드와_일치하지_않는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> albumService.joinAlbum(1L, "expiredInvitationCode"))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.INVITATION_CODE_MISMATCH.getMessage());
-        }
-
-        @Test
-        void 이미_입장한_앨범에_재입장_하려는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> albumService.joinAlbum(3L, "testInvitationCode2"))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.ALREADY_PARTICIPATED.getMessage());
-        }
-
-        @Test
-        void 최대_참가자_수를_초과하면_예외가_발생한다() {
-            // given
-            Album album = albumRepository.findById(1L).orElseThrow();
-            int maxParticipants = album.getPlan().getMaxParticipants();
-
-            for (int i = 0; i < maxParticipants; i++) {
-                Member member =
-                        Member.createMember(
-                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                                "testNickname",
-                                "testProfileImageUrl");
-                memberRepository.save(member);
-
-                Participant participant =
-                        Participant.createParticipant(member, album, ParticipantRole.STANDARD);
-                participantRepository.save(participant);
-            }
-
-            // when & then
-            assertThatThrownBy(() -> albumService.joinAlbum(album.getId(), "testInvitationCode1"))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED.getMessage());
-        }
-    }
-
-    @Nested
     class 앨범을_삭제할_때 {
 
         @BeforeEach
@@ -984,81 +1059,6 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.deleteAlbum(5L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.SUBSCRIPTION_ACTIVE.getMessage());
-        }
-    }
-
-    @Nested
-    class 개별_앨범을_조회할_때 {
-
-        @BeforeEach
-        void setUp() {
-            Member member =
-                    Member.createMember(
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                            "testNickname",
-                            "testProfileImageUrl");
-            memberRepository.save(member);
-            given(memberUtil.getCurrentMember()).willReturn(member);
-
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
-
-            Participant participant1 =
-                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
-            Participant participant2 =
-                    Participant.createParticipant(member, album2, ParticipantRole.STANDARD);
-            participantRepository.saveAll(List.of(participant1, participant2));
-        }
-
-        @Test
-        void 유효한_요청인_경우_앨범_정보를_반환한다() {
-            // when
-            AlbumInfoResponse response = albumService.getAlbum(1L);
-
-            // then
-            assertThat(response)
-                    .extracting(
-                            "title",
-                            "coverUrl",
-                            "albumPlan",
-                            "capacityUsed",
-                            "totalCapacity",
-                            "hostName",
-                            "numOfParticipants")
-                    .containsExactly(
-                            "testAlbum1",
-                            "testURL1",
-                            AlbumPlan.BASIC,
-                            new BigDecimal("0.00"),
-                            new BigDecimal("3"),
-                            "testNickname",
-                            1);
-        }
-
-        @Test
-        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> albumService.getAlbum(999L))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 앨범_참여자가_아닌_경우_에외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> albumService.getAlbum(3L))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
-        }
-
-        @Test
-        void 앨범에_방장이_없는_경우_에외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> albumService.getAlbum(2L))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.ALBUM_HOST_NOT_FOUND.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -881,8 +881,8 @@ class AlbumServiceTest extends IntegrationTest {
         void PRO_플랜으로_필터링하면_PRO_앨범만_조회한다() {
             // given
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbumsByPlan(
-                            AlbumPlan.PRO, null, 1, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByCondition(
+                            AlbumPlan.PRO, null, null, 1, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(
@@ -892,10 +892,40 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 앨범_이름으로_필터링하면_일치하는_앨범만_조회한다() {
+            // given
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, "title2", null, 1, SortDirection.DESC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().get(0).albumId()).isEqualTo(2),
+                    () -> assertThat(response.content().get(0).title()).isEqualTo("testTitle2"),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void PRO_플랜과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_조회한다() {
+            // given
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbumsByCondition(
+                            AlbumPlan.PRO, "title3", null, 1, SortDirection.DESC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().get(0).albumId()).isEqualTo(3),
+                    () -> assertThat(response.content().get(0).title()).isEqualTo("testTitle3"),
+                    () -> assertThat(response.content().get(0).plan()).isEqualTo(AlbumPlan.PRO),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
         void 정렬_조건이_ASC이면_albumId를_오름차순으로_조회한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbumsByPlan(null, null, 3, SortDirection.ASC);
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, null, null, 3, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
@@ -910,7 +940,8 @@ class AlbumServiceTest extends IntegrationTest {
         void 정렬_조건이_DESC이면_albumId를_내림차순으로_조회한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbumsByPlan(null, null, 3, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, null, null, 3, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
@@ -925,7 +956,8 @@ class AlbumServiceTest extends IntegrationTest {
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbumsByPlan(null, null, 3, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, null, null, 3, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
@@ -937,7 +969,8 @@ class AlbumServiceTest extends IntegrationTest {
         void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbumsByPlan(null, null, 1, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, null, null, 1, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
@@ -952,7 +985,8 @@ class AlbumServiceTest extends IntegrationTest {
 
             // when
             SliceResponse<AlbumListResponse> response =
-                    albumService.getParticipatingAlbumsByPlan(null, null, 10, SortDirection.DESC);
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, null, null, 10, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #152 

---
## 📌 작업 내용 및 특이사항
* 기존 앨범 목록 조회 API에 키워드 필터링 기능을 추가했습니다.
* keyword 파라미터를 통해 앨범 이름 기준으로 검색할 수 있도록 했습니다.
* 기존 플랜 필터링 로직과 함께 동작합니다.