### PR TITLE
feat: 앨범 & 이벤트 커버용 Presigned Url 발급 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
-import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
@@ -33,8 +33,26 @@ public class ImageController {
             summary = "회원 프로필 이미지 Presigned URL 생성",
             description = "회원 프로필 이미지 업로드를 위한 Presigned URL을 생성합니다.")
     public PresignedUrlResponse memberProfileImageUploadUrlCreate(
-            @Valid @RequestBody MemberProfileImageUploadRequest request) {
+            @Valid @RequestBody ImageUploadRequest request) {
         return imageService.createMemberProfileImageUploadUrl(request);
+    }
+
+    @PostMapping("/albums/{albumId}/upload-url")
+    @Operation(
+            summary = "앨범 커버 이미지 Presigned URL 생성",
+            description = "앨범 커버 이미지 업로드를 위한 Presigned URL을 생성합니다.")
+    public PresignedUrlResponse albumCoverImageUploadUrlCreate(
+            @PathVariable Long albumId, @Valid @RequestBody ImageUploadRequest request) {
+        return imageService.createAlbumCoverImageUploadUrl(albumId, request);
+    }
+
+    @PostMapping("/events/{eventId}/upload-url")
+    @Operation(
+            summary = "이벤트 커버 이미지 Presigned URL 생성",
+            description = "이벤트 커버 이미지 업로드를 위한 Presigned URL을 생성합니다.")
+    public PresignedUrlResponse eventCoverImageUploadUrlCreate(
+            @PathVariable Long eventId, @Valid @RequestBody ImageUploadRequest request) {
+        return imageService.createEventCoverImageUploadUrl(eventId, request);
     }
 
     @PostMapping("/albums/{albumId}/file-upload-urls")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -28,7 +28,7 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @PostMapping("/members/me/upload-url")
+    @PostMapping("/members/profile-upload-url")
     @Operation(
             summary = "회원 프로필 이미지 Presigned URL 생성",
             description = "회원 프로필 이미지 업로드를 위한 Presigned URL을 생성합니다.")
@@ -37,7 +37,7 @@ public class ImageController {
         return imageService.createMemberProfileImageUploadUrl(request);
     }
 
-    @PostMapping("/albums/{albumId}/upload-url")
+    @PostMapping("/albums/{albumId}/cover-upload-url")
     @Operation(
             summary = "앨범 커버 이미지 Presigned URL 생성",
             description = "앨범 커버 이미지 업로드를 위한 Presigned URL을 생성합니다.")
@@ -46,7 +46,7 @@ public class ImageController {
         return imageService.createAlbumCoverImageUploadUrl(albumId, request);
     }
 
-    @PostMapping("/events/{eventId}/upload-url")
+    @PostMapping("/events/{eventId}/cover-upload-url")
     @Operation(
             summary = "이벤트 커버 이미지 Presigned URL 생성",
             description = "이벤트 커버 이미지 업로드를 위한 Presigned URL을 생성합니다.")
@@ -55,7 +55,7 @@ public class ImageController {
         return imageService.createEventCoverImageUploadUrl(eventId, request);
     }
 
-    @PostMapping("/albums/{albumId}/file-upload-urls")
+    @PostMapping("/albums/{albumId}/images")
     @Operation(
             summary = "앨범 이미지 업로드 Presigned URL들 생성",
             description = "앨범 이미지 업로드를 위한 Presigned URL들을 생성합니다.")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/ImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/ImageUploadRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import org.cherrypic.domain.image.enums.FileExtension;
 import org.cherrypic.global.annotation.Enum;
 
-public record MemberProfileImageUploadRequest(
+public record ImageUploadRequest(
         @Enum(message = "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다.")
                 @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 FileExtension fileExtension,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageType.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/enums/ImageType.java
@@ -9,7 +9,7 @@ public enum ImageType {
     MEMBER_PROFILE("member-profile", "회원 프로필 사진"),
     ALBUM_COVER("album-cover", "앨범 커버"),
     ALBUM_IMAGE("album-image", "앨범 사진"),
-    EVENT_IMAGE("event-image", "이벤트 사진"),
+    EVENT_COVER("event-cover", "이벤트 커버"),
     ;
 
     private final String type;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.image.service;
 
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
-import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
@@ -11,7 +11,11 @@ import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 
 public interface ImageService {
-    PresignedUrlResponse createMemberProfileImageUploadUrl(MemberProfileImageUploadRequest request);
+    PresignedUrlResponse createMemberProfileImageUploadUrl(ImageUploadRequest request);
+
+    PresignedUrlResponse createAlbumCoverImageUploadUrl(Long albumId, ImageUploadRequest request);
+
+    PresignedUrlResponse createEventCoverImageUploadUrl(Long eventId, ImageUploadRequest request);
 
     PresignedUrlsResponse createAlbumFileUploadUrls(Long albumId, AlbumFileUploadRequest request);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -17,7 +17,7 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
-import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
@@ -59,8 +59,7 @@ public class ImageServiceImpl implements ImageService {
     private final ParticipantRepository participantRepository;
 
     @Override
-    public PresignedUrlResponse createMemberProfileImageUploadUrl(
-            MemberProfileImageUploadRequest request) {
+    public PresignedUrlResponse createMemberProfileImageUploadUrl(ImageUploadRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
         validateImageExtension(request.fileExtension());
@@ -68,6 +67,44 @@ public class ImageServiceImpl implements ImageService {
         String presignedUrl =
                 createPresignedUrl(
                         ImageType.MEMBER_PROFILE,
+                        currentMember.getId(),
+                        request.fileExtension(),
+                        request.md5Hash());
+
+        return PresignedUrlResponse.of(presignedUrl);
+    }
+
+    @Override
+    public PresignedUrlResponse createAlbumCoverImageUploadUrl(
+            Long albumId, ImageUploadRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateParticipantAuthority(currentMember.getId(), album.getId());
+        validateImageExtension(request.fileExtension());
+
+        String presignedUrl =
+                createPresignedUrl(
+                        ImageType.ALBUM_COVER,
+                        currentMember.getId(),
+                        request.fileExtension(),
+                        request.md5Hash());
+
+        return PresignedUrlResponse.of(presignedUrl);
+    }
+
+    @Override
+    public PresignedUrlResponse createEventCoverImageUploadUrl(
+            Long eventId, ImageUploadRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Event event = getEventById(eventId);
+
+        validateParticipantAuthority(currentMember.getId(), event.getAlbum().getId());
+        validateImageExtension(request.fileExtension());
+
+        String presignedUrl =
+                createPresignedUrl(
+                        ImageType.EVENT_COVER,
                         currentMember.getId(),
                         request.fileExtension(),
                         request.md5Hash());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -80,7 +80,7 @@ public class ImageServiceImpl implements ImageService {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumById(albumId);
 
-        validateParticipantAuthority(currentMember.getId(), album.getId());
+        validateAlbumHost(currentMember.getId(), album.getId());
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
@@ -315,6 +315,14 @@ public class ImageServiceImpl implements ImageService {
     private void validateImageExtension(FileExtension extension) {
         if (!FileExtension.getImageExtensions().contains(extension)) {
             throw new CustomException(ImageErrorCode.NOT_IMAGE_EXTENSION);
+        }
+    }
+
+    private void validateAlbumHost(Long memberId, Long albumId) {
+        Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
+
+        if (!participant.getRole().equals(ParticipantRole.HOST)) {
+            throw new CustomException(AlbumErrorCode.NOT_ALBUM_HOST);
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -215,12 +215,12 @@ class ImageControllerTest {
         }
 
         @Test
-        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
+        void HOST가_아닌_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
 
             given(imageService.createAlbumCoverImageUploadUrl(1L, request))
-                    .willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY));
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
 
             // when & then
             ResultActions perform =
@@ -232,8 +232,8 @@ class ImageControllerTest {
             perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -64,7 +64,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/members/me/upload-url")
+                            post("/members/profile-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -85,7 +85,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/members/me/upload-url")
+                            post("/members/profile-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -108,7 +108,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/members/me/upload-url")
+                            post("/members/profile-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -133,7 +133,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/members/me/upload-url")
+                            post("/members/profile-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -160,7 +160,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/upload-url")
+                            post("/albums/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -181,7 +181,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/999/upload-url")
+                            post("/albums/999/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -203,7 +203,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/upload-url")
+                            post("/albums/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -225,7 +225,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/upload-url")
+                            post("/albums/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -247,7 +247,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/upload-url")
+                            post("/albums/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -270,7 +270,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/upload-url")
+                            post("/albums/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -295,7 +295,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/upload-url")
+                            post("/albums/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -322,7 +322,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/upload-url")
+                            post("/events/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -343,7 +343,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/999/upload-url")
+                            post("/events/999/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -365,7 +365,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/upload-url")
+                            post("/events/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -387,7 +387,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/upload-url")
+                            post("/events/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -409,7 +409,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/upload-url")
+                            post("/events/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -432,7 +432,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/upload-url")
+                            post("/events/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -457,7 +457,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/upload-url")
+                            post("/events/1/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -496,7 +496,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -528,7 +528,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -561,7 +561,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -594,7 +594,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -627,7 +627,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -658,7 +658,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -687,7 +687,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -716,7 +716,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -743,7 +743,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -762,7 +762,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/file-upload-urls")
+                            post("/albums/1/images")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -171,6 +171,72 @@ class ImageControllerTest {
         }
 
         @Test
+        void 앨범이_존재하지_않을_경우_에외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            given(imageService.createAlbumCoverImageUploadUrl(999L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/999/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            given(imageService.createAlbumCoverImageUploadUrl(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            given(imageService.createAlbumCoverImageUploadUrl(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Test
         void 동영상_확장자를_입력할_경우_예외가_발생한다() throws Exception {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
@@ -264,6 +330,72 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
                     .andExpect(jsonPath("$.data.presignedUrl").isNotEmpty());
+        }
+
+        @Test
+        void 이벤트가_존재하지_않을_경우_에외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            given(imageService.createEventCoverImageUploadUrl(999L, request))
+                    .willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/999/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            given(imageService.createEventCoverImageUploadUrl(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            given(imageService.createEventCoverImageUploadUrl(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -50,7 +50,7 @@ class ImageControllerTest {
     @MockitoBean private ImageService imageService;
 
     @Nested
-    class Presigned_URL을_생성_요청_시 {
+    class 프로필용_Presigned_URL_생성_요청_시 {
 
         @Test
         void 유효한_요청이면_회원_프로필_이미지용_Presigned_URL을_반환한다() throws Exception {
@@ -128,12 +128,204 @@ class ImageControllerTest {
         @ValueSource(strings = {" "})
         void MD5_해시를_비워두면_예외가_발생한다(String md5Hash) throws Exception {
             // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.from("JPG"), md5Hash);
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPG, md5Hash);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
                             post("/members/me/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("MD5 해시값은 비워둘 수 없습니다,"));
+        }
+    }
+
+    @Nested
+    class 앨범_커버용_Presigned_URL_생성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_앨범_커버_이미지용_Presigned_URL을_반환한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
+
+            given(imageService.createAlbumCoverImageUploadUrl(1L, request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.presignedUrl").isNotEmpty());
+        }
+
+        @Test
+        void 동영상_확장자를_입력할_경우_예외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            given(imageService.createAlbumCoverImageUploadUrl(1L, request))
+                    .willThrow(new CustomException(ImageErrorCode.NOT_IMAGE_EXTENSION));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_IMAGE_EXTENSION"))
+                    .andExpect(jsonPath("$.data.message").value("프로필과 커버에는 이미지 파일만 업로드 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {"JPEG1", "PDF", "TXT"})
+        void 이미지_파일_확장자가_null_또는_지원하지_않는_형식이면_예외가_발생한다(String extension) throws Exception {
+            // given
+            ImageUploadRequest request =
+                    new ImageUploadRequest(FileExtension.from(extension), "testMd5Hash");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(
+                                            "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void MD5_해시를_비워두면_예외가_발생한다(String md5Hash) throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPG, md5Hash);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("MD5 해시값은 비워둘 수 없습니다,"));
+        }
+    }
+
+    @Nested
+    class 이벤트_커버용_Presigned_URL_생성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_이벤트_커버_이미지용_Presigned_URL을_반환한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
+
+            given(imageService.createEventCoverImageUploadUrl(1L, request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.presignedUrl").isNotEmpty());
+        }
+
+        @Test
+        void 동영상_확장자를_입력할_경우_예외가_발생한다() throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            given(imageService.createEventCoverImageUploadUrl(1L, request))
+                    .willThrow(new CustomException(ImageErrorCode.NOT_IMAGE_EXTENSION));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_IMAGE_EXTENSION"))
+                    .andExpect(jsonPath("$.data.message").value("프로필과 커버에는 이미지 파일만 업로드 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {"JPEG1", "PDF", "TXT"})
+        void 이미지_파일_확장자가_null_또는_지원하지_않는_형식이면_예외가_발생한다(String extension) throws Exception {
+            // given
+            ImageUploadRequest request =
+                    new ImageUploadRequest(FileExtension.from(extension), "testMd5Hash");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/upload-url")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(
+                                            "이미지 파일의 확장자는 비워둘 수 없으며, PNG, JPG, JPEG, WEBP, HEIC, HEIF만 지원됩니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void MD5_해시를_비워두면_예외가_발생한다(String md5Hash) throws Exception {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPG, md5Hash);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -13,7 +13,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.image.controller.ImageController;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
-import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
@@ -55,8 +55,7 @@ class ImageControllerTest {
         @Test
         void 유효한_요청이면_회원_프로필_이미지용_Presigned_URL을_반환한다() throws Exception {
             // given
-            MemberProfileImageUploadRequest request =
-                    new MemberProfileImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
 
             PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
 
@@ -78,8 +77,7 @@ class ImageControllerTest {
         @Test
         void 동영상_확장자를_입력할_경우_예외가_발생한다() throws Exception {
             // given
-            MemberProfileImageUploadRequest request =
-                    new MemberProfileImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
 
             given(imageService.createMemberProfileImageUploadUrl(request))
                     .willThrow(new CustomException(ImageErrorCode.NOT_IMAGE_EXTENSION));
@@ -104,9 +102,8 @@ class ImageControllerTest {
         @ValueSource(strings = {"JPEG1", "PDF", "TXT"})
         void 이미지_파일_확장자가_null_또는_지원하지_않는_형식이면_예외가_발생한다(String extension) throws Exception {
             // given
-            MemberProfileImageUploadRequest request =
-                    new MemberProfileImageUploadRequest(
-                            FileExtension.from(extension), "testMd5Hash");
+            ImageUploadRequest request =
+                    new ImageUploadRequest(FileExtension.from(extension), "testMd5Hash");
 
             // when & then
             ResultActions perform =
@@ -131,8 +128,7 @@ class ImageControllerTest {
         @ValueSource(strings = {" "})
         void MD5_해시를_비워두면_예외가_발생한다(String md5Hash) throws Exception {
             // given
-            MemberProfileImageUploadRequest request =
-                    new MemberProfileImageUploadRequest(FileExtension.from("JPG"), md5Hash);
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.from("JPG"), md5Hash);
 
             // when & then
             ResultActions perform =

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -14,7 +14,7 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
-import org.cherrypic.domain.image.dto.request.MemberProfileImageUploadRequest;
+import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
@@ -74,8 +74,7 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 유효한_요청이면_회원_프로필_이미지용_Presigned_URL을_생성한다() {
             // given
-            MemberProfileImageUploadRequest request =
-                    new MemberProfileImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
 
             // when
             PresignedUrlResponse response = imageService.createMemberProfileImageUploadUrl(request);
@@ -90,8 +89,7 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 동영상_확장자를_입력할_경우_예외가_발생한다() {
             // given
-            MemberProfileImageUploadRequest request =
-                    new MemberProfileImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
 
             // when & then
             assertThatThrownBy(() -> imageService.createMemberProfileImageUploadUrl(request))

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -58,7 +58,7 @@ class ImageServiceTest extends IntegrationTest {
     @Autowired private EventImageRepository eventImageRepository;
 
     @Nested
-    class Presigned_URL을_생성할_때 {
+    class 프로필용_Presigned_URL을_생성할_때 {
 
         @BeforeEach
         void setUp() {
@@ -93,6 +93,181 @@ class ImageServiceTest extends IntegrationTest {
 
             // when & then
             assertThatThrownBy(() -> imageService.createMemberProfileImageUploadUrl(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ImageErrorCode.NOT_IMAGE_EXTENSION.getMessage());
+        }
+    }
+
+    @Nested
+    class 앨범_커버용_Presigned_URL을_생성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @Test
+        void 유효한_요청이면_앨범_커버_이미지용_Presigned_URL을_생성한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            // when
+            PresignedUrlResponse response =
+                    imageService.createAlbumCoverImageUploadUrl(1L, request);
+
+            // then
+            assertThat(response.presignedUrl())
+                    .containsPattern(
+                            String.format("/%s/%s/%d/[\\w\\-]+\\.jpeg", "local", "album-cover", 1));
+        }
+
+        @Test
+        void 앨범이_존재하지_않을_경우_에외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(999L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 동영상_확장자를_입력할_경우_예외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ImageErrorCode.NOT_IMAGE_EXTENSION.getMessage());
+        }
+    }
+
+    @Nested
+    class 이벤트_커버용_Presigned_URL을_생성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+
+            Event event1 = Event.createEvent(album1, "testTitle1", "testUrl1");
+            Event event2 = Event.createEvent(album2, "testTitle2", "testUrl2");
+            Event event3 = Event.createEvent(album3, "testTitle3", "testUrl3");
+            eventRepository.saveAll(List.of(event1, event2, event3));
+        }
+
+        @Test
+        void 유효한_요청이면_이벤트_커버_이미지용_Presigned_URL을_생성한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+
+            // when
+            PresignedUrlResponse response =
+                    imageService.createEventCoverImageUploadUrl(1L, request);
+
+            // then
+            assertThat(response.presignedUrl())
+                    .containsPattern(
+                            String.format("/%s/%s/%d/[\\w\\-]+\\.jpeg", "local", "event-cover", 1));
+        }
+
+        @Test
+        void 이벤트가_존재하지_않을_경우_에외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(999L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 동영상_확장자를_입력할_경우_예외가_발생한다() {
+            // given
+            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(1L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ImageErrorCode.NOT_IMAGE_EXTENSION.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -161,14 +161,14 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
-        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
+        void HOST가_아닌_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
 
             // when & then
             assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(2L, request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #154

---
## 📌 작업 내용 및 특이사항
- 앨범 & 이벤트 커버용 Presigned Url 발급 기능을 총 2개의 API로 나눠서 구현했습니다. 
- 하나의 사진을 위한 Presigned Url 발급 요청 DTO가 동일해 일반적인 이름인 ```ImageUploadRequest```로 변경했습니다.
- 응답 또한 동일한 응답인 ```PresignedUrlResponse```을 사용합니다.