### PR TITLE
feat: 앨범 이미지 삭제 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteNotificationEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteNotificationEvent.java
@@ -2,18 +2,19 @@ package org.cherrypic.domain.album.event;
 
 import java.util.List;
 
-public record AlbumDeleteEvent(
+public record AlbumDeleteNotificationEvent(
         Long albumId,
         Long senderId,
         String hostNickname,
         String albumTitle,
         List<Long> receiverIds) {
-    public static AlbumDeleteEvent of(
+    public static AlbumDeleteNotificationEvent of(
             Long albumId,
             Long senderId,
             String hostNickname,
             String albumTitle,
             List<Long> receiverIds) {
-        return new AlbumDeleteEvent(albumId, senderId, hostNickname, albumTitle, receiverIds);
+        return new AlbumDeleteNotificationEvent(
+                albumId, senderId, hostNickname, albumTitle, receiverIds);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteNotificationSendEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumDeleteNotificationSendEvent.java
@@ -2,19 +2,19 @@ package org.cherrypic.domain.album.event;
 
 import java.util.List;
 
-public record AlbumDeleteNotificationEvent(
+public record AlbumDeleteNotificationSendEvent(
         Long albumId,
         Long senderId,
         String hostNickname,
         String albumTitle,
         List<Long> receiverIds) {
-    public static AlbumDeleteNotificationEvent of(
+    public static AlbumDeleteNotificationSendEvent of(
             Long albumId,
             Long senderId,
             String hostNickname,
             String albumTitle,
             List<Long> receiverIds) {
-        return new AlbumDeleteNotificationEvent(
+        return new AlbumDeleteNotificationSendEvent(
                 albumId, senderId, hostNickname, albumTitle, receiverIds);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumImageBatchDeleteEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumImageBatchDeleteEvent.java
@@ -1,7 +1,0 @@
-package org.cherrypic.domain.album.event;
-
-public record AlbumImageBatchDeleteEvent(Long albumId) {
-    public static AlbumImageBatchDeleteEvent of(Long albumId) {
-        return new AlbumImageBatchDeleteEvent(albumId);
-    }
-}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumImageBatchDeleteEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumImageBatchDeleteEvent.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.album.event;
+
+public record AlbumImageBatchDeleteEvent(Long albumId) {
+    public static AlbumImageBatchDeleteEvent of(Long albumId) {
+        return new AlbumImageBatchDeleteEvent(albumId);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumImagesDeleteEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/event/AlbumImagesDeleteEvent.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.album.event;
+
+public record AlbumImagesDeleteEvent(Long albumId) {
+    public static AlbumImagesDeleteEvent of(Long albumId) {
+        return new AlbumImagesDeleteEvent(albumId);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -31,7 +31,9 @@ public enum AlbumErrorCode implements BaseErrorCode {
 
     PARTICIPANT_NOT_IN_ALBUM(400, "해당 참가자는 이 앨범에 속해 있지 않습니다."),
 
-    ALBUM_CAPACITY_EXCEEDED(400, "앨범의 용량을 초과했습니다.");
+    ALBUM_CAPACITY_EXCEEDED(400, "앨범의 용량을 초과했습니다."),
+    IMAGES_NOT_IN_ALBUM(400, "앨범에 속해 있지 않은 이미지가 포함되어 있습니다.");
+    ;
 
     private final int status;
     private final String message;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -97,7 +97,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         validateAlbumHost(currentMember.getId(), album.getId());
 
-        if (request.coverUrl() != null && album.getCoverUrl() != null) {
+        if (album.getCoverUrl() != null && !album.getCoverUrl().equals(request.coverUrl())) {
             s3Util.deleteFileFromS3(album.getCoverUrl());
         }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -13,11 +13,14 @@ import org.cherrypic.domain.album.event.AlbumImagesDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
+import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.event.ImageDeleteEvent;
+import org.cherrypic.domain.image.event.ImagesDeleteEvent;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
+import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -47,6 +50,7 @@ public class AlbumServiceImpl implements AlbumService {
     private final ParticipantRepository participantRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final InvitationCodeRepository invitationCodeRepository;
+    private final EventRepository eventRepository;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -211,6 +215,10 @@ public class AlbumServiceImpl implements AlbumService {
         validateAlbumHost(currentMember.getId(), album.getId());
         validateSubscriptionInactive(album);
         validateRemainingParticipants(album, currentMember);
+
+        final List<Event> events = eventRepository.findAllByAlbumId(album.getId());
+        eventPublisher.publishEvent(
+                ImagesDeleteEvent.of(events.stream().map(Event::getCoverUrl).toList()));
 
         eventPublisher.publishEvent(AlbumImagesDeleteEvent.of(album.getId()));
         if (album.getCoverUrl() != null) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -20,6 +20,7 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
@@ -38,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlbumServiceImpl implements AlbumService {
 
     private final MemberUtil memberUtil;
+    private final S3Util s3Util;
     private final InvitationLinkService invitationLinkService;
 
     private final AlbumRepository albumRepository;
@@ -94,6 +96,10 @@ public class AlbumServiceImpl implements AlbumService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+
+        if (request.coverUrl() != null && album.getCoverUrl() != null) {
+            s3Util.deleteFileFromS3(album.getCoverUrl());
+        }
 
         album.updateAlbum(request.title(), request.coverUrl());
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -9,7 +9,7 @@ import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.event.AlbumDeleteNotificationSendEvent;
-import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
+import org.cherrypic.domain.album.event.AlbumImagesDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
@@ -22,7 +22,6 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
-import org.cherrypic.global.util.S3Util;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
@@ -41,7 +40,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlbumServiceImpl implements AlbumService {
 
     private final MemberUtil memberUtil;
-    private final S3Util s3Util;
     private final InvitationLinkService invitationLinkService;
 
     private final AlbumRepository albumRepository;
@@ -214,7 +212,7 @@ public class AlbumServiceImpl implements AlbumService {
         validateSubscriptionInactive(album);
         validateRemainingParticipants(album, currentMember);
 
-        eventPublisher.publishEvent(AlbumImageBatchDeleteEvent.of(album.getId()));
+        eventPublisher.publishEvent(AlbumImagesDeleteEvent.of(album.getId()));
         if (album.getCoverUrl() != null) {
             eventPublisher.publishEvent(ImageDeleteEvent.of(album.getCoverUrl()));
         }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -212,6 +212,11 @@ public class AlbumServiceImpl implements AlbumService {
         validateSubscriptionInactive(album);
         validateRemainingParticipants(album, currentMember);
 
+        s3Util.deleteAllAlbumImagesInBatchFromS3(album.getId());
+        if (album.getCoverUrl() != null) {
+            s3Util.deleteFileFromS3(album.getCoverUrl());
+        }
+
         albumRepository.delete(album);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -8,7 +8,7 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
-import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
+import org.cherrypic.domain.album.event.AlbumDeleteNotificationSendEvent;
 import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
@@ -322,7 +322,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         if (!otherMemberIds.isEmpty()) {
             eventPublisher.publishEvent(
-                    AlbumDeleteNotificationEvent.of(
+                    AlbumDeleteNotificationSendEvent.of(
                             album.getId(),
                             member.getId(),
                             member.getNickname(),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -8,7 +8,7 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
-import org.cherrypic.domain.album.event.AlbumDeleteEvent;
+import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
@@ -320,7 +320,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         if (!otherMemberIds.isEmpty()) {
             eventPublisher.publishEvent(
-                    AlbumDeleteEvent.of(
+                    AlbumDeleteNotificationEvent.of(
                             album.getId(),
                             member.getId(),
                             member.getNickname(),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -9,9 +9,11 @@ import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
+import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
+import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
@@ -98,7 +100,7 @@ public class AlbumServiceImpl implements AlbumService {
         validateAlbumHost(currentMember.getId(), album.getId());
 
         if (album.getCoverUrl() != null && !album.getCoverUrl().equals(request.coverUrl())) {
-            s3Util.deleteFileFromS3(album.getCoverUrl());
+            eventPublisher.publishEvent(ImageDeleteEvent.of(album.getCoverUrl()));
         }
 
         album.updateAlbum(request.title(), request.coverUrl());
@@ -212,9 +214,9 @@ public class AlbumServiceImpl implements AlbumService {
         validateSubscriptionInactive(album);
         validateRemainingParticipants(album, currentMember);
 
-        s3Util.deleteAllAlbumImagesInBatchFromS3(album.getId());
+        eventPublisher.publishEvent(AlbumImageBatchDeleteEvent.of(album.getId()));
         if (album.getCoverUrl() != null) {
-            s3Util.deleteFileFromS3(album.getCoverUrl());
+            eventPublisher.publishEvent(ImageDeleteEvent.of(album.getCoverUrl()));
         }
 
         albumRepository.delete(album);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
@@ -1,6 +1,10 @@
 package org.cherrypic.domain.event.repository;
 
+import java.util.List;
 import org.cherrypic.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {}
+public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
+
+    List<Event> findAllByAlbumId(Long albumId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -15,6 +15,7 @@ import org.cherrypic.domain.event.dto.response.EventListResponse;
 import org.cherrypic.domain.event.dto.response.EventUpdateResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
+import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
@@ -30,6 +31,7 @@ import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Slice;
 import org.springframework.retry.annotation.Backoff;
@@ -50,6 +52,8 @@ public class EventServiceImpl implements EventService {
     private final EventRepository eventRepository;
     private final ImageRepository imageRepository;
     private final EventImageRepository eventImageRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public EventCreateResponse createEvent(EventCreateRequest request) {
@@ -72,7 +76,7 @@ public class EventServiceImpl implements EventService {
         validateParticipantAuthority(currentMember, event.getAlbum());
 
         if (event.getCoverUrl() != null && !event.getCoverUrl().equals(request.coverUrl())) {
-            s3Util.deleteFileFromS3(event.getCoverUrl());
+            eventPublisher.publishEvent(ImageDeleteEvent.of(event.getCoverUrl()));
         }
 
         event.updateEvent(request.title(), request.coverUrl());
@@ -102,7 +106,7 @@ public class EventServiceImpl implements EventService {
         validateParticipantAuthority(currentMember, event.getAlbum());
 
         if (event.getCoverUrl() != null) {
-            s3Util.deleteFileFromS3(event.getCoverUrl());
+            eventPublisher.publishEvent(ImageDeleteEvent.of(event.getCoverUrl()));
         }
 
         eventRepository.delete(event);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -25,6 +25,7 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
@@ -42,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventServiceImpl implements EventService {
 
     private final MemberUtil memberUtil;
+    private final S3Util s3Util;
 
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
@@ -68,6 +70,10 @@ public class EventServiceImpl implements EventService {
         final Event event = getEventById(eventId);
 
         validateParticipantAuthority(currentMember, event.getAlbum());
+
+        if (request.coverUrl() != null && event.getCoverUrl() != null) {
+            s3Util.deleteFileFromS3(event.getCoverUrl());
+        }
 
         event.updateEvent(request.title(), request.coverUrl());
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -71,7 +71,7 @@ public class EventServiceImpl implements EventService {
 
         validateParticipantAuthority(currentMember, event.getAlbum());
 
-        if (request.coverUrl() != null && event.getCoverUrl() != null) {
+        if (event.getCoverUrl() != null && !event.getCoverUrl().equals(request.coverUrl())) {
             s3Util.deleteFileFromS3(event.getCoverUrl());
         }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -26,7 +26,6 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
-import org.cherrypic.global.util.S3Util;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
@@ -45,7 +44,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventServiceImpl implements EventService {
 
     private final MemberUtil memberUtil;
-    private final S3Util s3Util;
 
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -101,6 +101,10 @@ public class EventServiceImpl implements EventService {
 
         validateParticipantAuthority(currentMember, event.getAlbum());
 
+        if (event.getCoverUrl() != null) {
+            s3Util.deleteFileFromS3(event.getCoverUrl());
+        }
+
         eventRepository.delete(event);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
+import org.cherrypic.domain.image.dto.request.AlbumImageDeleteRequest;
 import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
@@ -100,5 +101,13 @@ public class ImageController {
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
         return imageService.getEventImages(eventId, lastEventImageId, size, direction);
+    }
+
+    @DeleteMapping("albums/{albumId}/images")
+    @Operation(summary = "앨범 이미지 삭제", description = "앨범의 이미지를 삭제합니다.")
+    public ResponseEntity<Void> albumImageDelete(
+            @PathVariable Long albumId, @Valid @RequestBody AlbumImageDeleteRequest request) {
+        imageService.deleteAlbumImage(albumId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -38,22 +38,22 @@ public class ImageController {
         return imageService.createMemberProfileImageUploadUrl(request);
     }
 
-    @PostMapping("/albums/{albumId}/cover-upload-url")
+    @PostMapping("/albums/cover-upload-url")
     @Operation(
             summary = "앨범 커버 이미지 Presigned URL 생성",
             description = "앨범 커버 이미지 업로드를 위한 Presigned URL을 생성합니다.")
     public PresignedUrlResponse albumCoverImageUploadUrlCreate(
-            @PathVariable Long albumId, @Valid @RequestBody ImageUploadRequest request) {
-        return imageService.createAlbumCoverImageUploadUrl(albumId, request);
+            @Valid @RequestBody ImageUploadRequest request) {
+        return imageService.createAlbumCoverImageUploadUrl(request);
     }
 
-    @PostMapping("/events/{eventId}/cover-upload-url")
+    @PostMapping("/events/cover-upload-url")
     @Operation(
             summary = "이벤트 커버 이미지 Presigned URL 생성",
             description = "이벤트 커버 이미지 업로드를 위한 Presigned URL을 생성합니다.")
     public PresignedUrlResponse eventCoverImageUploadUrlCreate(
-            @PathVariable Long eventId, @Valid @RequestBody ImageUploadRequest request) {
-        return imageService.createEventCoverImageUploadUrl(eventId, request);
+            @Valid @RequestBody ImageUploadRequest request) {
+        return imageService.createEventCoverImageUploadUrl(request);
     }
 
     @PostMapping("/albums/{albumId}/images")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageDeleteRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageDeleteRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record AlbumImageDeleteRequest(
+        @NotEmpty(message = "삭제하고자 하는 이미지 ID는 비워둘 수 없습니다.")
+                @Schema(description = "삭제하고자 하는 이미지들의 ID", example = "[1,2,3,4]")
+                List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageDeleteRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageDeleteRequest.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record AlbumImageDeleteRequest(
-        @NotEmpty(message = "삭제하고자 하는 이미지 ID는 비워둘 수 없습니다.")
+        @NotEmpty(message = "삭제하고자 하는 이미지 ID들은 비워둘 수 없습니다.")
                 @Schema(description = "삭제하고자 하는 이미지들의 ID", example = "[1,2,3,4]")
                 List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageDeleteEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageDeleteEvent.java
@@ -1,0 +1,7 @@
+package org.cherrypic.domain.image.event;
+
+public record ImageDeleteEvent(String imageUrl) {
+    public static ImageDeleteEvent of(String imageUrl) {
+        return new ImageDeleteEvent(imageUrl);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageEventListener.java
@@ -16,7 +16,7 @@ public class ImageEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleAlbumImageDeleteEvent(AlbumImagesDeleteEvent event) {
+    public void handleAlbumImagesDeleteEvent(AlbumImagesDeleteEvent event) {
         s3Util.deleteAllAlbumImagesInBatchFromS3(event.albumId());
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageEventListener.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.image.event;
 
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
+import org.cherrypic.domain.album.event.AlbumImagesDeleteEvent;
 import org.cherrypic.global.util.S3Util;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -16,7 +16,7 @@ public class ImageEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleAlbumImageDeleteEvent(AlbumImageBatchDeleteEvent event) {
+    public void handleAlbumImageDeleteEvent(AlbumImagesDeleteEvent event) {
         s3Util.deleteAllAlbumImagesInBatchFromS3(event.albumId());
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImageEventListener.java
@@ -1,0 +1,28 @@
+package org.cherrypic.domain.image.event;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
+import org.cherrypic.global.util.S3Util;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+
+    private final S3Util s3Util;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAlbumImageDeleteEvent(AlbumImageBatchDeleteEvent event) {
+        s3Util.deleteAllAlbumImagesInBatchFromS3(event.albumId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleImageDeleteEvent(ImageDeleteEvent event) {
+        s3Util.deleteFileFromS3(event.imageUrl());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImagesDeleteEvent.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/event/ImagesDeleteEvent.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.image.event;
+
+import java.util.List;
+
+public record ImagesDeleteEvent(List<String> imageUrls) {
+    public static ImagesDeleteEvent of(List<String> imageUrls) {
+        return new ImagesDeleteEvent(imageUrls);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -14,9 +14,9 @@ import org.cherrypic.global.pagination.SortDirection;
 public interface ImageService {
     PresignedUrlResponse createMemberProfileImageUploadUrl(ImageUploadRequest request);
 
-    PresignedUrlResponse createAlbumCoverImageUploadUrl(Long albumId, ImageUploadRequest request);
+    PresignedUrlResponse createAlbumCoverImageUploadUrl(ImageUploadRequest request);
 
-    PresignedUrlResponse createEventCoverImageUploadUrl(Long eventId, ImageUploadRequest request);
+    PresignedUrlResponse createEventCoverImageUploadUrl(ImageUploadRequest request);
 
     PresignedUrlsResponse createAlbumFileUploadUrls(Long albumId, AlbumFileUploadRequest request);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -1,6 +1,7 @@
 package org.cherrypic.domain.image.service;
 
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
+import org.cherrypic.domain.image.dto.request.AlbumImageDeleteRequest;
 import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
@@ -26,4 +27,6 @@ public interface ImageService {
             Long eventId, Long lastImageId, int size, SortDirection direction);
 
     void deleteUploadFailedFile(UploadFailedFileDeleteRequest request);
+
+    void deleteAlbumImage(Long albumId, AlbumImageDeleteRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -78,7 +78,7 @@ public class ImageServiceImpl implements ImageService {
         String presignedUrl =
                 s3Util.createPresignedUrl(
                         ImageType.ALBUM_COVER,
-                        currentMember.getId(),
+                        album.getId(),
                         request.fileExtension(),
                         request.md5Hash());
 
@@ -97,7 +97,7 @@ public class ImageServiceImpl implements ImageService {
         String presignedUrl =
                 s3Util.createPresignedUrl(
                         ImageType.EVENT_COVER,
-                        currentMember.getId(),
+                        event.getId(),
                         request.fileExtension(),
                         request.md5Hash());
 
@@ -122,7 +122,7 @@ public class ImageServiceImpl implements ImageService {
                                 req ->
                                         s3Util.createPresignedUrl(
                                                 ImageType.ALBUM_IMAGE,
-                                                currentMember.getId(),
+                                                album.getId(),
                                                 req.fileExtension(),
                                                 req.md5Hashes()))
                         .toList();

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -20,6 +20,7 @@ import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.FileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
+import org.cherrypic.domain.image.event.ImagesDeleteEvent;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
@@ -33,6 +34,7 @@ import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +51,8 @@ public class ImageServiceImpl implements ImageService {
     private final ImageRepository imageRepository;
     private final EventRepository eventRepository;
     private final ParticipantRepository participantRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public PresignedUrlResponse createMemberProfileImageUploadUrl(ImageUploadRequest request) {
@@ -202,7 +206,8 @@ public class ImageServiceImpl implements ImageService {
 
         validateImagesInAlbum(images, album);
 
-        s3Util.deleteFilesInBatchFromS3(images.stream().map(Image::getUrl).toList());
+        eventPublisher.publishEvent(
+                ImagesDeleteEvent.of(images.stream().map(Image::getUrl).toList()));
         imageRepository.deleteAllInBatch(images);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -194,7 +194,7 @@ public class ImageServiceImpl implements ImageService {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumById(albumId);
 
-        validateParticipantAuthority(currentMember, album);
+        validateParticipantAuthority(currentMember.getId(), album.getId());
 
         List<Long> distinctImageIds =
                 request.imageIds().stream().filter(Objects::nonNull).distinct().toList();
@@ -279,16 +279,6 @@ public class ImageServiceImpl implements ImageService {
 
         if (!participant.getRole().equals(ParticipantRole.HOST)) {
             throw new CustomException(AlbumErrorCode.NOT_ALBUM_HOST);
-        }
-    }
-
-    private void validateParticipantAuthority(Member member, Album album) {
-
-        Participant participant = getParticipantByMemberIdAndAlbumId(member.getId(), album.getId());
-
-        boolean isLimited = participant.getRole().equals(ParticipantRole.LIMITED);
-        if (isLimited) {
-            throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
         }
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -1,14 +1,8 @@
 package org.cherrypic.domain.image.service;
 
-import com.amazonaws.HttpMethod;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.Headers;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
@@ -17,6 +11,7 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
+import org.cherrypic.domain.image.dto.request.AlbumImageDeleteRequest;
 import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
@@ -33,12 +28,11 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
-import org.cherrypic.helper.SpringEnvironmentHelper;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
-import org.cherrypic.s3.S3Properties;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,9 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ImageServiceImpl implements ImageService {
 
     private final MemberUtil memberUtil;
-    private final SpringEnvironmentHelper springEnvironmentHelper;
-    private final AmazonS3 amazonS3;
-    private final S3Properties s3Properties;
+    private final S3Util s3Util;
 
     private final AlbumRepository albumRepository;
     private final ImageRepository imageRepository;
@@ -65,7 +57,7 @@ public class ImageServiceImpl implements ImageService {
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
-                createPresignedUrl(
+                s3Util.createPresignedUrl(
                         ImageType.MEMBER_PROFILE,
                         currentMember.getId(),
                         request.fileExtension(),
@@ -84,7 +76,7 @@ public class ImageServiceImpl implements ImageService {
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
-                createPresignedUrl(
+                s3Util.createPresignedUrl(
                         ImageType.ALBUM_COVER,
                         currentMember.getId(),
                         request.fileExtension(),
@@ -103,7 +95,7 @@ public class ImageServiceImpl implements ImageService {
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
-                createPresignedUrl(
+                s3Util.createPresignedUrl(
                         ImageType.EVENT_COVER,
                         currentMember.getId(),
                         request.fileExtension(),
@@ -128,7 +120,7 @@ public class ImageServiceImpl implements ImageService {
                 request.payloads().stream()
                         .map(
                                 req ->
-                                        createPresignedUrl(
+                                        s3Util.createPresignedUrl(
                                                 ImageType.ALBUM_IMAGE,
                                                 currentMember.getId(),
                                                 req.fileExtension(),
@@ -197,57 +189,21 @@ public class ImageServiceImpl implements ImageService {
         imageRepository.deleteAllInBatch(images);
     }
 
-    private String createPresignedUrl(
-            ImageType imageType, Long targetId, FileExtension fileExtension, String md5Hash) {
-        String imageKey = UUID.randomUUID().toString();
-        String fileName = createFileName(imageType, targetId, imageKey, fileExtension);
+    @Override
+    public void deleteAlbumImage(Long albumId, AlbumImageDeleteRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
 
-        GeneratePresignedUrlRequest generatePresignedUrlRequest =
-                generatePresignedUrlRequest(
-                        s3Properties.bucket(), fileName, fileExtension.getExtension());
+        validateParticipantAuthority(currentMember, album);
 
-        generatePresignedUrlRequest.addRequestParameter(
-                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+        List<Long> distinctImageIds =
+                request.imageIds().stream().filter(Objects::nonNull).distinct().toList();
+        List<Image> images = imageRepository.findAllById(distinctImageIds);
 
-        generatePresignedUrlRequest.addRequestParameter(Headers.CONTENT_MD5, md5Hash);
+        validateImagesInAlbum(images, album);
 
-        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
-    }
-
-    private String createFileName(
-            ImageType imageType, Long targetId, String imageKey, FileExtension fileExtension) {
-        return springEnvironmentHelper.getCurrentProfile()
-                + "/"
-                + imageType.getType()
-                + "/"
-                + targetId
-                + "/"
-                + imageKey
-                + "."
-                + fileExtension.getExtension();
-    }
-
-    private GeneratePresignedUrlRequest generatePresignedUrlRequest(
-            String bucket, String fileName, String imageFileExtension) {
-        GeneratePresignedUrlRequest generatePresignedUrlRequest =
-                new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
-                        .withKey(fileName)
-                        .withContentType("image/" + imageFileExtension)
-                        .withExpiration(getPresignedUrlExpiration());
-
-        generatePresignedUrlRequest.addRequestParameter(
-                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
-
-        return generatePresignedUrlRequest;
-    }
-
-    private Date getPresignedUrlExpiration() {
-        Date expiration = new Date();
-        long expTimeMillis = expiration.getTime();
-        expTimeMillis += TimeUnit.MINUTES.toMillis(1);
-        expiration.setTime(expTimeMillis);
-
-        return expiration;
+        s3Util.deleteFilesFromS3(images.stream().map(Image::getUrl).toList());
+        imageRepository.deleteAllInBatch(images);
     }
 
     private Album getAlbumById(Long albumId) {
@@ -323,6 +279,25 @@ public class ImageServiceImpl implements ImageService {
 
         if (!participant.getRole().equals(ParticipantRole.HOST)) {
             throw new CustomException(AlbumErrorCode.NOT_ALBUM_HOST);
+        }
+    }
+
+    private void validateParticipantAuthority(Member member, Album album) {
+
+        Participant participant = getParticipantByMemberIdAndAlbumId(member.getId(), album.getId());
+
+        boolean isLimited = participant.getRole().equals(ParticipantRole.LIMITED);
+        if (isLimited) {
+            throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
+        }
+    }
+
+    private void validateImagesInAlbum(List<Image> images, Album album) {
+        boolean containsNotInAlbum =
+                images.stream().anyMatch(ei -> !ei.getAlbum().getId().equals(album.getId()));
+
+        if (containsNotInAlbum) {
+            throw new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -202,7 +202,7 @@ public class ImageServiceImpl implements ImageService {
 
         validateImagesInAlbum(images, album);
 
-        s3Util.deleteFilesFromS3(images.stream().map(Image::getUrl).toList());
+        s3Util.deleteFilesInBatchFromS3(images.stream().map(Image::getUrl).toList());
         imageRepository.deleteAllInBatch(images);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -71,18 +71,15 @@ public class ImageServiceImpl implements ImageService {
     }
 
     @Override
-    public PresignedUrlResponse createAlbumCoverImageUploadUrl(
-            Long albumId, ImageUploadRequest request) {
+    public PresignedUrlResponse createAlbumCoverImageUploadUrl(ImageUploadRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Album album = getAlbumById(albumId);
 
-        validateAlbumHost(currentMember.getId(), album.getId());
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
                 s3Util.createPresignedUrl(
                         ImageType.ALBUM_COVER,
-                        album.getId(),
+                        currentMember.getId(),
                         request.fileExtension(),
                         request.md5Hash());
 
@@ -90,18 +87,15 @@ public class ImageServiceImpl implements ImageService {
     }
 
     @Override
-    public PresignedUrlResponse createEventCoverImageUploadUrl(
-            Long eventId, ImageUploadRequest request) {
+    public PresignedUrlResponse createEventCoverImageUploadUrl(ImageUploadRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final Event event = getEventById(eventId);
 
-        validateParticipantAuthority(currentMember.getId(), event.getAlbum().getId());
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
                 s3Util.createPresignedUrl(
                         ImageType.EVENT_COVER,
-                        event.getId(),
+                        currentMember.getId(),
                         request.fileExtension(),
                         request.md5Hash());
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -8,7 +8,6 @@ import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.dto.response.MemberProfileUpdateResponse;
 import org.cherrypic.domain.notification.service.FcmTokenService;
 import org.cherrypic.global.util.MemberUtil;
-import org.cherrypic.global.util.S3Util;
 import org.cherrypic.member.entity.Member;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberUtil memberUtil;
-    private final S3Util s3Util;
     private final FcmTokenService fcmTokenService;
 
     private final ApplicationEventPublisher eventPublisher;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package org.cherrypic.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
@@ -9,6 +10,7 @@ import org.cherrypic.domain.notification.service.FcmTokenService;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.global.util.S3Util;
 import org.cherrypic.member.entity.Member;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,8 @@ public class MemberServiceImpl implements MemberService {
     private final MemberUtil memberUtil;
     private final S3Util s3Util;
     private final FcmTokenService fcmTokenService;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional(readOnly = true)
@@ -34,7 +38,7 @@ public class MemberServiceImpl implements MemberService {
 
         if (currentMember.getProfileImageUrl() != null
                 && !currentMember.getProfileImageUrl().equals(request.profileImageUrl())) {
-            s3Util.deleteFileFromS3(currentMember.getProfileImageUrl());
+            eventPublisher.publishEvent(ImageDeleteEvent.of(currentMember.getProfileImageUrl()));
         }
 
         currentMember.updateMember(request.nickname(), request.profileImageUrl());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.dto.response.MemberProfileUpdateResponse;
 import org.cherrypic.domain.notification.service.FcmTokenService;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberUtil memberUtil;
+    private final S3Util s3Util;
     private final FcmTokenService fcmTokenService;
 
     @Override
@@ -29,6 +31,10 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberProfileUpdateResponse updateProfile(MemberProfileUpdateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
+
+        if (request.profileImageUrl() != null && currentMember.getProfileImageUrl() != null) {
+            s3Util.deleteFileFromS3(currentMember.getProfileImageUrl());
+        }
 
         currentMember.updateMember(request.nickname(), request.profileImageUrl());
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -32,7 +32,8 @@ public class MemberServiceImpl implements MemberService {
     public MemberProfileUpdateResponse updateProfile(MemberProfileUpdateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        if (request.profileImageUrl() != null && currentMember.getProfileImageUrl() != null) {
+        if (currentMember.getProfileImageUrl() != null
+                && !currentMember.getProfileImageUrl().equals(request.profileImageUrl())) {
             s3Util.deleteFileFromS3(currentMember.getProfileImageUrl());
         }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/NotificationEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/NotificationEventListener.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.notification.event;
 
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
+import org.cherrypic.domain.album.event.AlbumDeleteNotificationSendEvent;
 import org.cherrypic.domain.notification.service.NotificationService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -19,7 +19,7 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleAlbumDeleteNotificationEvent(AlbumDeleteNotificationEvent event) {
+    public void handleAlbumDeleteNotificationEvent(AlbumDeleteNotificationSendEvent event) {
         notificationService.sendAlbumDeleteNotification(
                 event.albumId(),
                 event.senderId(),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/NotificationEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/NotificationEventListener.java
@@ -19,7 +19,7 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleAlbumDeleteNotificationEvent(AlbumDeleteNotificationSendEvent event) {
+    public void handleAlbumDeleteNotificationSendEvent(AlbumDeleteNotificationSendEvent event) {
         notificationService.sendAlbumDeleteNotification(
                 event.albumId(),
                 event.senderId(),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/NotificationEventListener.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/event/NotificationEventListener.java
@@ -1,7 +1,7 @@
 package org.cherrypic.domain.notification.event;
 
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.domain.album.event.AlbumDeleteEvent;
+import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
 import org.cherrypic.domain.notification.service.NotificationService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -12,14 +12,14 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class AlbumDeleteEventListener {
+public class NotificationEventListener {
 
     private final NotificationService notificationService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleAlbumDeleteEvent(AlbumDeleteEvent event) {
+    public void handleAlbumDeleteNotificationEvent(AlbumDeleteNotificationEvent event) {
         notificationService.sendAlbumDeleteNotification(
                 event.albumId(),
                 event.senderId(),

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -32,12 +32,7 @@ public class S3Util {
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 generatePresignedUrlRequest(
-                        s3Properties.bucket(), fileName, fileExtension.getExtension());
-
-        generatePresignedUrlRequest.addRequestParameter(
-                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
-
-        generatePresignedUrlRequest.addRequestParameter(Headers.CONTENT_MD5, md5Hash);
+                        s3Properties.bucket(), fileName, fileExtension.getExtension(), md5Hash);
 
         return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
     }
@@ -56,7 +51,7 @@ public class S3Util {
     }
 
     private GeneratePresignedUrlRequest generatePresignedUrlRequest(
-            String bucket, String fileName, String imageFileExtension) {
+            String bucket, String fileName, String imageFileExtension, String md5Hash) {
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
                         .withKey(fileName)
@@ -65,6 +60,8 @@ public class S3Util {
 
         generatePresignedUrlRequest.addRequestParameter(
                 Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        generatePresignedUrlRequest.addRequestParameter(Headers.CONTENT_MD5, md5Hash);
 
         return generatePresignedUrlRequest;
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -69,7 +69,7 @@ public class S3Util {
         return generatePresignedUrlRequest;
     }
 
-    public void deleteFilesFromS3(List<String> urls) {
+    public void deleteFilesInBatchFromS3(List<String> urls) {
         String bucket = s3Properties.bucket();
         List<DeleteObjectsRequest.KeyVersion> keys =
                 urls.stream()
@@ -81,15 +81,16 @@ public class S3Util {
         amazonS3.deleteObjects(request);
     }
 
-    /**
-     * ex)
-     * https://s3.ap-northeast-2.amazonaws.com/cherrypic-bucket-test/local/album-image/1/df09a055.jpeg?X-Amz-...
-     * 인코딩 직전까지 파씽
-     */
+    public void deleteFileFromS3(String url) {
+        String bucket = s3Properties.bucket();
+        String objectKey = extractObjectKey(url);
+        amazonS3.deleteObject(bucket, objectKey);
+    }
+
     private String extractObjectKey(String url) {
         String bucket = s3Properties.bucket();
         int idx = url.indexOf(bucket) + bucket.length() + 1;
-        return url.substring(idx, url.contains("?") ? url.indexOf("?") : url.length());
+        return url.substring(idx);
     }
 
     private Date getPresignedUrlExpiration() {

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -15,7 +15,10 @@ import org.cherrypic.domain.image.enums.FileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
 import org.cherrypic.helper.SpringEnvironmentHelper;
 import org.cherrypic.s3.S3Properties;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -66,6 +69,8 @@ public class S3Util {
         return generatePresignedUrlRequest;
     }
 
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteFilesInBatchFromS3(List<String> urls) {
         String bucket = s3Properties.bucket();
         List<DeleteObjectsRequest.KeyVersion> keys =
@@ -78,6 +83,8 @@ public class S3Util {
         amazonS3.deleteObjects(request);
     }
 
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteFileFromS3(String url) {
         String bucket = s3Properties.bucket();
         String objectKey = extractObjectKey(url);

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -1,0 +1,103 @@
+package org.cherrypic.global.util;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.image.enums.FileExtension;
+import org.cherrypic.domain.image.enums.ImageType;
+import org.cherrypic.helper.SpringEnvironmentHelper;
+import org.cherrypic.s3.S3Properties;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+    private final AmazonS3 amazonS3;
+    private final S3Properties s3Properties;
+
+    public String createPresignedUrl(
+            ImageType imageType, Long targetId, FileExtension fileExtension, String md5Hash) {
+        String imageKey = UUID.randomUUID().toString();
+        String fileName = createFileName(imageType, targetId, imageKey, fileExtension);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                generatePresignedUrlRequest(
+                        s3Properties.bucket(), fileName, fileExtension.getExtension());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        generatePresignedUrlRequest.addRequestParameter(Headers.CONTENT_MD5, md5Hash);
+
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
+
+    private String createFileName(
+            ImageType imageType, Long targetId, String imageKey, FileExtension fileExtension) {
+        return springEnvironmentHelper.getCurrentProfile()
+                + "/"
+                + imageType.getType()
+                + "/"
+                + targetId
+                + "/"
+                + imageKey
+                + "."
+                + fileExtension.getExtension();
+    }
+
+    private GeneratePresignedUrlRequest generatePresignedUrlRequest(
+            String bucket, String fileName, String imageFileExtension) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
+                        .withKey(fileName)
+                        .withContentType("image/" + imageFileExtension)
+                        .withExpiration(getPresignedUrlExpiration());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        return generatePresignedUrlRequest;
+    }
+
+    public void deleteFilesFromS3(List<String> urls) {
+        String bucket = s3Properties.bucket();
+        List<DeleteObjectsRequest.KeyVersion> keys =
+                urls.stream()
+                        .map(this::extractObjectKey)
+                        .map(DeleteObjectsRequest.KeyVersion::new)
+                        .toList();
+
+        DeleteObjectsRequest request = new DeleteObjectsRequest(bucket).withKeys(keys);
+        amazonS3.deleteObjects(request);
+    }
+
+    /**
+     * ex)
+     * https://s3.ap-northeast-2.amazonaws.com/cherrypic-bucket-test/local/album-image/1/df09a055.jpeg?X-Amz-...
+     * 인코딩 직전까지 파씽
+     */
+    private String extractObjectKey(String url) {
+        String bucket = s3Properties.bucket();
+        int idx = url.indexOf(bucket) + bucket.length() + 1;
+        return url.substring(idx, url.contains("?") ? url.indexOf("?") : url.length());
+    }
+
+    private Date getPresignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += TimeUnit.MINUTES.toMillis(1);
+        expiration.setTime(expTimeMillis);
+
+        return expiration;
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -3,9 +3,7 @@ package org.cherrypic.global.util;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.*;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -81,6 +79,39 @@ public class S3Util {
 
         DeleteObjectsRequest request = new DeleteObjectsRequest(bucket).withKeys(keys);
         amazonS3.deleteObjects(request);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void deleteAllAlbumImagesInBatchFromS3(Long albumId) {
+        String bucket = s3Properties.bucket();
+        String prefix =
+                springEnvironmentHelper.getCurrentProfile()
+                        + "/"
+                        + ImageType.ALBUM_IMAGE.getType()
+                        + "/"
+                        + albumId
+                        + "/";
+
+        ListObjectsV2Request listReq =
+                new ListObjectsV2Request().withBucketName(bucket).withPrefix(prefix);
+
+        ListObjectsV2Result result;
+        do {
+            result = amazonS3.listObjectsV2(listReq);
+
+            List<DeleteObjectsRequest.KeyVersion> keys =
+                    result.getObjectSummaries().stream()
+                            .map(S3ObjectSummary::getKey)
+                            .map(DeleteObjectsRequest.KeyVersion::new)
+                            .toList();
+
+            if (!keys.isEmpty()) {
+                amazonS3.deleteObjects(new DeleteObjectsRequest(bucket).withKeys(keys));
+            }
+
+            listReq.setContinuationToken(result.getNextContinuationToken());
+        } while (result.isTruncated());
     }
 
     @Async

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -67,8 +67,6 @@ public class S3Util {
         return generatePresignedUrlRequest;
     }
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteFilesInBatchFromS3(List<String> urls) {
         String bucket = s3Properties.bucket();
         List<DeleteObjectsRequest.KeyVersion> keys =
@@ -81,8 +79,6 @@ public class S3Util {
         amazonS3.deleteObjects(request);
     }
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteAllAlbumImagesInBatchFromS3(Long albumId) {
         String bucket = s3Properties.bucket();
         String prefix =

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -13,10 +13,7 @@ import org.cherrypic.domain.image.enums.FileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
 import org.cherrypic.helper.SpringEnvironmentHelper;
 import org.cherrypic.s3.S3Properties;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -110,8 +107,6 @@ public class S3Util {
         } while (result.isTruncated());
     }
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteFileFromS3(String url) {
         String bucket = s3Properties.bucket();
         String objectKey = extractObjectKey(url);

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -21,7 +21,7 @@ import org.cherrypic.domain.album.dto.response.AlbumInfoResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.event.AlbumDeleteNotificationSendEvent;
-import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
+import org.cherrypic.domain.album.event.AlbumImagesDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
@@ -1081,7 +1081,7 @@ class AlbumServiceTest extends IntegrationTest {
             albumService.deleteAlbum(1L);
 
             // then
-            var events = applicationEvents.stream(AlbumImageBatchDeleteEvent.class).toList();
+            var events = applicationEvents.stream(AlbumImagesDeleteEvent.class).toList();
             assertThat(events).hasSize(1);
             assertThat(events.getFirst().albumId()).isEqualTo(1L);
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -3,8 +3,6 @@ package org.cherrypic.album.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -23,12 +21,15 @@ import org.cherrypic.domain.album.dto.response.AlbumInfoResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
 import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
+import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.favorites.repository.FavoritesRepository;
+import org.cherrypic.domain.image.event.ImageDeleteEvent;
+import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
@@ -42,6 +43,7 @@ import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.global.util.S3Util;
 import org.cherrypic.global.util.TransactionUtil;
+import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.participant.entity.Participant;
@@ -72,6 +74,7 @@ class AlbumServiceTest extends IntegrationTest {
     @Autowired private FavoritesRepository favoritesRepository;
     @Autowired private InvitationCodeRepository invitationCodeRepository;
     @Autowired private EventRepository eventRepository;
+    @Autowired private ImageRepository imageRepository;
 
     @MockitoBean private MemberUtil memberUtil;
     @MockitoBean private S3Util s3Util;
@@ -398,7 +401,7 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 앨범_커버_URL이_교체되는_경우_S3에서_삭제되는_로직이_호출된다() {
+        void 앨범_커버_URL이_교체되는_경우_S3에서_이미지를_삭제하는_이벤트를_발행한다() {
             // given
             AlbumUpdateRequest request =
                     new AlbumUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
@@ -407,7 +410,9 @@ class AlbumServiceTest extends IntegrationTest {
             albumService.updateAlbum(1L, request);
 
             // then
-            verify(s3Util, times(1)).deleteFileFromS3("testURL1");
+            var events = applicationEvents.stream(ImageDeleteEvent.class).toList();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst().imageUrl()).isEqualTo("testURL1");
         }
 
         @Test
@@ -1037,6 +1042,9 @@ class AlbumServiceTest extends IntegrationTest {
             Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.PRO, false);
             albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
 
+            Image image = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());
+            imageRepository.save(image);
+
             subscriptionRepository.save(
                     Subscription.createSubscription(member1, album5, LocalDateTime.now()));
 
@@ -1068,13 +1076,14 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청일_경우_S3에_존재하는_앨범_관련_이미지들도_삭제된다() {
+        void 유효한_요청일_경우_S3에_존재하는_앨범_이미지들을_삭제하는_이벤트를_발행한다() {
             // when
             albumService.deleteAlbum(1L);
 
             // then
-            verify(s3Util, times(1)).deleteAllAlbumImagesInBatchFromS3(1L);
-            verify(s3Util, times(1)).deleteFileFromS3("testURL1");
+            var events = applicationEvents.stream(AlbumImageBatchDeleteEvent.class).toList();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst().albumId()).isEqualTo(1L);
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -1068,6 +1068,16 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 유효한_요청일_경우_S3에_존재하는_앨범_관련_이미지들도_삭제된다() {
+            // when
+            albumService.deleteAlbum(1L);
+
+            // then
+            verify(s3Util, times(1)).deleteAllAlbumImagesInBatchFromS3(1L);
+            verify(s3Util, times(1)).deleteFileFromS3("testURL1");
+        }
+
+        @Test
         void 앨범이_존재하지_않는_경우_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> albumService.deleteAlbum(999L))

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -41,7 +41,6 @@ import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
-import org.cherrypic.global.util.S3Util;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
@@ -77,7 +76,6 @@ class AlbumServiceTest extends IntegrationTest {
     @Autowired private ImageRepository imageRepository;
 
     @MockitoBean private MemberUtil memberUtil;
-    @MockitoBean private S3Util s3Util;
 
     @Nested
     class 앨범을_생성할_때 {

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -20,7 +20,7 @@ import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumInfoResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
-import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
+import org.cherrypic.domain.album.event.AlbumDeleteNotificationSendEvent;
 import org.cherrypic.domain.album.event.AlbumImageBatchDeleteEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
@@ -1117,7 +1117,7 @@ class AlbumServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST.getMessage());
 
-            var events = applicationEvents.stream(AlbumDeleteNotificationEvent.class).toList();
+            var events = applicationEvents.stream(AlbumDeleteNotificationSendEvent.class).toList();
             Assertions.assertAll(
                     () -> assertThat(events).hasSize(1),
                     () -> assertThat(events.getFirst().albumId()).isEqualTo(3L));

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -3,6 +3,8 @@ package org.cherrypic.album.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -38,6 +40,7 @@ import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
@@ -71,6 +74,7 @@ class AlbumServiceTest extends IntegrationTest {
     @Autowired private EventRepository eventRepository;
 
     @MockitoBean private MemberUtil memberUtil;
+    @MockitoBean private S3Util s3Util;
 
     @Nested
     class 앨범을_생성할_때 {
@@ -391,6 +395,19 @@ class AlbumServiceTest extends IntegrationTest {
                                             "testUpdatedTitle",
                                             "testUpdatedCoverUrl",
                                             AlbumPlan.BASIC));
+        }
+
+        @Test
+        void 앨범_커버_URL이_교체되는_경우_S3에서_삭제되는_로직이_호출된다() {
+            // given
+            AlbumUpdateRequest request =
+                    new AlbumUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
+
+            // when
+            albumService.updateAlbum(1L, request);
+
+            // then
+            verify(s3Util, times(1)).deleteFileFromS3("testURL1");
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -22,7 +22,7 @@ import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumInfoResponse;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.domain.album.dto.response.InvitationLinkCreateResponse;
-import org.cherrypic.domain.album.event.AlbumDeleteEvent;
+import org.cherrypic.domain.album.event.AlbumDeleteNotificationEvent;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
@@ -1108,7 +1108,7 @@ class AlbumServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.OTHER_PARTICIPANTS_EXIST.getMessage());
 
-            var events = applicationEvents.stream(AlbumDeleteEvent.class).toList();
+            var events = applicationEvents.stream(AlbumDeleteNotificationEvent.class).toList();
             Assertions.assertAll(
                     () -> assertThat(events).hasSize(1),
                     () -> assertThat(events.getFirst().albumId()).isEqualTo(3L));

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -29,6 +29,7 @@ import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.favorites.repository.FavoritesRepository;
 import org.cherrypic.domain.image.event.ImageDeleteEvent;
+import org.cherrypic.domain.image.event.ImagesDeleteEvent;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
@@ -1082,6 +1083,28 @@ class AlbumServiceTest extends IntegrationTest {
             var events = applicationEvents.stream(AlbumImagesDeleteEvent.class).toList();
             assertThat(events).hasSize(1);
             assertThat(events.getFirst().albumId()).isEqualTo(1L);
+        }
+
+        @Test
+        void 유효한_요청일_경우_S3에_존재하는_앨범_커버를_삭제하는_이벤트를_발행한다() {
+            // when
+            albumService.deleteAlbum(1L);
+
+            // then
+            var events = applicationEvents.stream(ImageDeleteEvent.class).toList();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst().imageUrl()).isEqualTo("testURL1");
+        }
+
+        @Test
+        void 유효한_요청일_경우_S3에_존재하는_이벤트_커버들을_삭제하는_이벤트를_발행한다() {
+            // when
+            albumService.deleteAlbum(1L);
+
+            // then
+            var events = applicationEvents.stream(ImagesDeleteEvent.class).toList();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst().imageUrls()).isEqualTo(List.of("testCoverUrl1"));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -289,6 +289,15 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 유효한_요청일_경우_이벤트_커버가_S3에서_삭제된다() {
+            // when
+            eventService.deleteEvent(1L);
+
+            // then
+            verify(s3Util, times(1)).deleteFileFromS3("testEventCoverUrl1");
+        }
+
+        @Test
         void 존재하지_않는_이벤트를_삭제하면_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> eventService.deleteEvent(999L))

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -3,7 +3,7 @@ package org.cherrypic.event.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.*;
 
 import jakarta.persistence.EntityManager;
 import java.sql.SQLIntegrityConstraintViolationException;
@@ -34,6 +34,7 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
@@ -64,6 +65,7 @@ public class EventServiceTest extends IntegrationTest {
     @Autowired private EntityManager em;
 
     @MockitoBean MemberUtil memberUtil;
+    @MockitoBean S3Util s3Util;
 
     @Nested
     class 이벤트를_생성할_때 {
@@ -189,6 +191,19 @@ public class EventServiceTest extends IntegrationTest {
             assertThat(event)
                     .extracting("id", "album.id", "title", "coverUrl")
                     .containsExactly(1L, 1L, "changedTestEventTitle", "changedTestEventCoverUrl");
+        }
+
+        @Test
+        void 이벤트_커버_URL이_교체되는_경우_S3에서_삭제되는_로직이_호출된다() {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
+
+            // when
+            eventService.updateEvent(1L, request);
+
+            // then
+            verify(s3Util, times(1)).deleteFileFromS3("testEventCoverUrl1");
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -35,7 +35,6 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
-import org.cherrypic.global.util.S3Util;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
@@ -69,7 +68,6 @@ public class EventServiceTest extends IntegrationTest {
     @Autowired private EntityManager em;
 
     @MockitoBean MemberUtil memberUtil;
-    @MockitoBean S3Util s3Util;
 
     @Nested
     class 이벤트를_생성할_때 {
@@ -198,7 +196,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 이벤트_커버_URL이_교체되는_경우_S3에서_삭제되는_로직이_호출된다() {
+        void 이벤트_커버_URL이_교체되는_경우_S3에서_이미지를_삭제하는_이벤트를_발행한다() {
             // given
             EventUpdateRequest request =
                     new EventUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
@@ -295,7 +293,7 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청일_경우_이벤트_커버를_삭제하는_이벤트를_발행한다() {
+        void 유효한_요청일_경우_S3에서_이벤트_커버_이미지를_삭제하는_이벤트를_발행한다() {
             // when
             eventService.deleteEvent(1L);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -23,6 +23,7 @@ import org.cherrypic.domain.event.dto.response.EventListResponse;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.event.service.EventService;
+import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
@@ -49,13 +50,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
+@RecordApplicationEvents
 public class EventServiceTest extends IntegrationTest {
 
     @Autowired private TransactionUtil transactionUtil;
 
     @Autowired private EventService eventService;
-
+    @Autowired private ApplicationEvents applicationEvents;
     @Autowired private EventRepository eventRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
@@ -203,7 +207,9 @@ public class EventServiceTest extends IntegrationTest {
             eventService.updateEvent(1L, request);
 
             // then
-            verify(s3Util, times(1)).deleteFileFromS3("testEventCoverUrl1");
+            var events = applicationEvents.stream(ImageDeleteEvent.class).toList();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst().imageUrl()).isEqualTo("testEventCoverUrl1");
         }
 
         @Test
@@ -289,12 +295,14 @@ public class EventServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청일_경우_이벤트_커버가_S3에서_삭제된다() {
+        void 유효한_요청일_경우_이벤트_커버를_삭제하는_이벤트를_발행한다() {
             // when
             eventService.deleteEvent(1L);
 
             // then
-            verify(s3Util, times(1)).deleteFileFromS3("testEventCoverUrl1");
+            var events = applicationEvents.stream(ImageDeleteEvent.class).toList();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst().imageUrl()).isEqualTo("testEventCoverUrl1");
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -13,6 +13,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.image.controller.ImageController;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
+import org.cherrypic.domain.image.dto.request.AlbumImageDeleteRequest;
 import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
@@ -1210,6 +1211,140 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("Presigned URL은 비워둘 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 앨범_이미지_삭제_요청_시 {
+
+        @Test
+        void 유효한_요청이면_이미지를_삭제하고_NO_CONTENT를_반환한다() throws Exception {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            willDoNothing().given(imageService).deleteAlbumImage(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/albums/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 앨범이_존재하지_않을_경우_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(imageService)
+                    .deleteAlbumImage(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/albums/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_앨범_이미지를_삭제하면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(imageService)
+                    .deleteAlbumImage(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/albums/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_앨범_이미지를_삭제하면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY))
+                    .given(imageService)
+                    .deleteAlbumImage(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/albums/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_이미지가_포함되어_있으면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM))
+                    .given(imageService)
+                    .deleteAlbumImage(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/albums/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("IMAGES_NOT_IN_ALBUM"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속해 있지 않은 이미지가 포함되어 있습니다."));
+        }
+
+        @Test
+        void 삭제하고자_하는_앨범_ID를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of());
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            delete("/albums/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("삭제하고자 하는 이미지 ID는 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -1329,7 +1329,7 @@ class ImageControllerTest {
         }
 
         @Test
-        void 삭제하고자_하는_앨범_ID를_비워두면_예외가_발생한다() throws Exception {
+        void 삭제하고자_하는_이미지_ID들을_비워두면_예외가_발생한다() throws Exception {
             // given
             AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of());
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -278,7 +278,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/cover-upload-url")
+                            post("/events/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -301,7 +301,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/cover-upload-url")
+                            post("/events/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -326,7 +326,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/cover-upload-url")
+                            post("/events/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -156,12 +156,12 @@ class ImageControllerTest {
 
             PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
 
-            given(imageService.createAlbumCoverImageUploadUrl(1L, request)).willReturn(response);
+            given(imageService.createAlbumCoverImageUploadUrl(request)).willReturn(response);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/cover-upload-url")
+                            post("/albums/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -172,83 +172,17 @@ class ImageControllerTest {
         }
 
         @Test
-        void 앨범이_존재하지_않을_경우_에외가_발생한다() throws Exception {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
-
-            given(imageService.createAlbumCoverImageUploadUrl(999L, request))
-                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/999/cover-upload-url")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
-        }
-
-        @Test
-        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
-
-            given(imageService.createAlbumCoverImageUploadUrl(1L, request))
-                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/1/cover-upload-url")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
-        }
-
-        @Test
-        void HOST가_아닌_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
-
-            given(imageService.createAlbumCoverImageUploadUrl(1L, request))
-                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/1/cover-upload-url")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
-                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
-        }
-
-        @Test
         void 동영상_확장자를_입력할_경우_예외가_발생한다() throws Exception {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
 
-            given(imageService.createAlbumCoverImageUploadUrl(1L, request))
+            given(imageService.createAlbumCoverImageUploadUrl(request))
                     .willThrow(new CustomException(ImageErrorCode.NOT_IMAGE_EXTENSION));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/cover-upload-url")
+                            post("/albums/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -271,7 +205,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/cover-upload-url")
+                            post("/albums/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -296,7 +230,7 @@ class ImageControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/albums/1/cover-upload-url")
+                            post("/albums/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -318,12 +252,12 @@ class ImageControllerTest {
 
             PresignedUrlResponse response = new PresignedUrlResponse("testPresignedUrl");
 
-            given(imageService.createEventCoverImageUploadUrl(1L, request)).willReturn(response);
+            given(imageService.createEventCoverImageUploadUrl(request)).willReturn(response);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events/1/cover-upload-url")
+                            post("/events/cover-upload-url")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -334,77 +268,11 @@ class ImageControllerTest {
         }
 
         @Test
-        void 이벤트가_존재하지_않을_경우_에외가_발생한다() throws Exception {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
-
-            given(imageService.createEventCoverImageUploadUrl(999L, request))
-                    .willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/events/999/cover-upload-url")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
-        }
-
-        @Test
-        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
-
-            given(imageService.createEventCoverImageUploadUrl(1L, request))
-                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/events/1/cover-upload-url")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
-        }
-
-        @Test
-        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() throws Exception {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
-
-            given(imageService.createEventCoverImageUploadUrl(1L, request))
-                    .willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/events/1/cover-upload-url")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
-                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
-        }
-
-        @Test
         void 동영상_확장자를_입력할_경우_예외가_발생한다() throws Exception {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
 
-            given(imageService.createEventCoverImageUploadUrl(1L, request))
+            given(imageService.createEventCoverImageUploadUrl(request))
                     .willThrow(new CustomException(ImageErrorCode.NOT_IMAGE_EXTENSION));
 
             // when & then

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -1344,7 +1344,7 @@ class ImageControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("삭제하고자 하는 이미지 ID는 비워둘 수 없습니다."));
+                    .andExpect(jsonPath("$.data.message").value("삭제하고자 하는 이미지 ID들은 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -1,6 +1,7 @@
 package org.cherrypic.image.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,6 +25,7 @@ import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.FileExtension;
+import org.cherrypic.domain.image.enums.ImageType;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
@@ -80,6 +82,13 @@ class ImageServiceTest extends IntegrationTest {
         void 유효한_요청이면_회원_프로필_이미지용_Presigned_URL을_생성한다() {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+            given(
+                            s3Util.createPresignedUrl(
+                                    ImageType.MEMBER_PROFILE,
+                                    1L,
+                                    FileExtension.JPEG,
+                                    "testMd5Hash"))
+                    .willReturn("http://localhost/local/member-profile/1/some-uuid.jpeg");
 
             // when
             PresignedUrlResponse response = imageService.createMemberProfileImageUploadUrl(request);
@@ -132,6 +141,10 @@ class ImageServiceTest extends IntegrationTest {
         void 유효한_요청이면_앨범_커버_이미지용_Presigned_URL을_생성한다() {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+            given(
+                            s3Util.createPresignedUrl(
+                                    ImageType.ALBUM_COVER, 1L, FileExtension.JPEG, "testMd5Hash"))
+                    .willReturn("http://localhost/local/album-cover/1/some-uuid.jpeg");
 
             // when
             PresignedUrlResponse response =
@@ -222,6 +235,10 @@ class ImageServiceTest extends IntegrationTest {
         void 유효한_요청이면_이벤트_커버_이미지용_Presigned_URL을_생성한다() {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
+            given(
+                            s3Util.createPresignedUrl(
+                                    ImageType.EVENT_COVER, 1L, FileExtension.JPEG, "testMd5Hash"))
+                    .willReturn("http://localhost/local/event-cover/1/some-uuid.jpeg");
 
             // when
             PresignedUrlResponse response =
@@ -319,6 +336,14 @@ class ImageServiceTest extends IntegrationTest {
                                             FileExtension.JPEG,
                                             "testMd5Hash2",
                                             LocalDateTime.now())));
+            given(
+                            s3Util.createPresignedUrl(
+                                    eq(ImageType.ALBUM_IMAGE),
+                                    eq(1L),
+                                    eq(FileExtension.JPEG),
+                                    anyString()))
+                    .willReturn(
+                            "http://localhost/local/album-image/1/some-uuid.jpeg?Content-MD5=testMd5Hash");
 
             // when
             PresignedUrlsResponse response = imageService.createAlbumFileUploadUrls(1L, request);

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -91,7 +91,16 @@ class ImageServiceTest extends IntegrationTest {
                                     1L,
                                     FileExtension.JPEG,
                                     "testMd5Hash"))
-                    .willReturn("http://localhost/local/member-profile/1/some-uuid.jpeg");
+                    .willReturn(
+                            "\"https://my-bucket.s3.ap-northeast-2.amazonaws.com/local/member-profile/1/660e8400-e29b-41d4-a716-446655440000.jpeg\"\n"
+                                    + "                                    + \"?X-Amz-Algorithm=AWS4-HMAC-SHA256\"\n"
+                                    + "                                    + \"&X-Amz-Date=20250824T130000Z\"\n"
+                                    + "                                    + \"&X-Amz-SignedHeaders=host\"\n"
+                                    + "                                    + \"&X-Amz-Expires=60\"\n"
+                                    + "                                    + \"&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20250824/ap-northeast-2/s3/aws4_request\"\n"
+                                    + "                                    + \"&X-Amz-Signature=abcdef0123456789...\"\n"
+                                    + "                                    + \"&x-amz-acl=public-read\"\n"
+                                    + "                                    + \"&Content-MD5=testMd5Hash\"");
 
             // when
             PresignedUrlResponse response = imageService.createMemberProfileImageUploadUrl(request);

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -3,8 +3,6 @@ package org.cherrypic.image.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -26,6 +24,7 @@ import org.cherrypic.domain.image.dto.response.PresignedUrlResponse;
 import org.cherrypic.domain.image.dto.response.PresignedUrlsResponse;
 import org.cherrypic.domain.image.enums.FileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
+import org.cherrypic.domain.image.event.ImagesDeleteEvent;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
@@ -50,13 +49,17 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
+@RecordApplicationEvents
 class ImageServiceTest extends IntegrationTest {
 
     @MockitoBean MemberUtil memberUtil;
     @MockitoBean S3Util s3Util;
 
     @Autowired private ImageService imageService;
+    @Autowired private ApplicationEvents applicationEvents;
     @Autowired private ParticipantRepository participantRepository;
     @Autowired private EventRepository eventRepository;
     @Autowired private ImageRepository imageRepository;
@@ -795,7 +798,7 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 앨범_이미지가_삭제되는_경우_S3에서_삭제되는_로직이_호출된다() {
+        void 앨범_이미지를_삭제하는_경우_S3에서_이미지를_삭제하는_이벤트를_발행한다() {
             // given
             AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
 
@@ -803,7 +806,9 @@ class ImageServiceTest extends IntegrationTest {
             imageService.deleteAlbumImage(1L, request);
 
             // then
-            verify(s3Util, times(1)).deleteFilesInBatchFromS3(List.of("testUrl1", "testUrl2"));
+            var events = applicationEvents.stream(ImagesDeleteEvent.class).toList();
+            assertThat(events.getFirst().imageUrls())
+                    .containsExactlyInAnyOrder("testUrl1", "testUrl2");
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -159,8 +159,7 @@ class ImageServiceTest extends IntegrationTest {
                                     + "&Content-MD5=testMd5Hash");
 
             // when
-            PresignedUrlResponse response =
-                    imageService.createAlbumCoverImageUploadUrl(1L, request);
+            PresignedUrlResponse response = imageService.createAlbumCoverImageUploadUrl(request);
 
             // then
             assertThat(response.presignedUrl())
@@ -169,45 +168,12 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 앨범이_존재하지_않을_경우_에외가_발생한다() {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
-
-            // when & then
-            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(999L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
-
-            // when & then
-            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(3L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
-        }
-
-        @Test
-        void HOST가_아닌_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
-
-            // when & then
-            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(2L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
-        }
-
-        @Test
         void 동영상_확장자를_입력할_경우_예외가_발생한다() {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
 
             // when & then
-            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(1L, request))
+            assertThatThrownBy(() -> imageService.createAlbumCoverImageUploadUrl(request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ImageErrorCode.NOT_IMAGE_EXTENSION.getMessage());
         }
@@ -262,8 +228,7 @@ class ImageServiceTest extends IntegrationTest {
                                     + "&Content-MD5=testMd5Hash");
 
             // when
-            PresignedUrlResponse response =
-                    imageService.createEventCoverImageUploadUrl(1L, request);
+            PresignedUrlResponse response = imageService.createEventCoverImageUploadUrl(request);
 
             // then
             assertThat(response.presignedUrl())
@@ -272,45 +237,12 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 이벤트가_존재하지_않을_경우_에외가_발생한다() {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
-
-            // when & then
-            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(999L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 앨범에_속하지_않은_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
-
-            // when & then
-            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(3L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
-        }
-
-        @Test
-        void LIMITED_권한의_사용자가_Presigned_Url을_요청하면_예외가_발생한다() {
-            // given
-            ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
-
-            // when & then
-            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(2L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
-        }
-
-        @Test
         void 동영상_확장자를_입력할_경우_예외가_발생한다() {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.MKV, "testMd5Hash");
 
             // when & then
-            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(1L, request))
+            assertThatThrownBy(() -> imageService.createEventCoverImageUploadUrl(request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ImageErrorCode.NOT_IMAGE_EXTENSION.getMessage());
         }
@@ -364,15 +296,24 @@ class ImageServiceTest extends IntegrationTest {
                                     eq(FileExtension.JPEG),
                                     anyString()))
                     .willReturn(
-                            "https://my-bucket.s3.ap-northeast-2.amazonaws.com/local/album-image/1/550e8400-e29b-41d4-a716-446655440000.jpeg\n"
-                                    + "?X-Amz-Algorithm=AWS4-HMAC-SHA256\n"
-                                    + "&X-Amz-Date=20250824T130000Z\n"
-                                    + "&X-Amz-SignedHeaders=host\n"
-                                    + "&X-Amz-Expires=60\n"
-                                    + "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20250824/ap-northeast-2/s3/aws4_request\n"
-                                    + "&X-Amz-Signature=0123456789abcdef...\n"
-                                    + "&x-amz-acl=public-read\n"
-                                    + "&Content-MD5=testMd5Hash");
+                            "https://my-bucket.s3.ap-northeast-2.amazonaws.com/local/album-image/1/550e8400-e29b-41d4-a716-446655440000.jpeg"
+                                    + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                                    + "&X-Amz-Date=20250824T130000Z"
+                                    + "&X-Amz-SignedHeaders=host"
+                                    + "&X-Amz-Expires=60"
+                                    + "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20250824/ap-northeast-2/s3/aws4_request"
+                                    + "&X-Amz-Signature=0123456789abcdef..."
+                                    + "&x-amz-acl=public-read"
+                                    + "&Content-MD5=testMd5Hash1",
+                            "https://my-bucket.s3.ap-northeast-2.amazonaws.com/local/album-image/1/660e8400-e29b-41d4-a716-446655440000.jpeg"
+                                    + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                                    + "&X-Amz-Date=20250824T130000Z"
+                                    + "&X-Amz-SignedHeaders=host"
+                                    + "&X-Amz-Expires=60"
+                                    + "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20250824/ap-northeast-2/s3/aws4_request"
+                                    + "&X-Amz-Signature=abcdef0123456789..."
+                                    + "&x-amz-acl=public-read"
+                                    + "&Content-MD5=testMd5Hash2");
 
             // when
             PresignedUrlsResponse response = imageService.createAlbumFileUploadUrls(1L, request);

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -147,7 +147,16 @@ class ImageServiceTest extends IntegrationTest {
             given(
                             s3Util.createPresignedUrl(
                                     ImageType.ALBUM_COVER, 1L, FileExtension.JPEG, "testMd5Hash"))
-                    .willReturn("http://localhost/local/album-cover/1/some-uuid.jpeg");
+                    .willReturn(
+                            "https://test-bucket.s3.ap-northeast-2.amazonaws.com/local/album-cover/1/550e8400-e29b-41d4-a716-446655440000.jpeg\n"
+                                    + "?X-Amz-Algorithm=AWS4-HMAC-SHA256\n"
+                                    + "&X-Amz-Date=20250824T130000Z\n"
+                                    + "&X-Amz-SignedHeaders=host\n"
+                                    + "&X-Amz-Expires=60\n"
+                                    + "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20250824/ap-northeast-2/s3/aws4_request\n"
+                                    + "&X-Amz-Signature=0123456789abcdef...\n"
+                                    + "&x-amz-acl=public-read\n"
+                                    + "&Content-MD5=testMd5Hash");
 
             // when
             PresignedUrlResponse response =
@@ -241,7 +250,16 @@ class ImageServiceTest extends IntegrationTest {
             given(
                             s3Util.createPresignedUrl(
                                     ImageType.EVENT_COVER, 1L, FileExtension.JPEG, "testMd5Hash"))
-                    .willReturn("http://localhost/local/event-cover/1/some-uuid.jpeg");
+                    .willReturn(
+                            "https://my-bucket.s3.ap-northeast-2.amazonaws.com/local/event-cover/1/550e8400-e29b-41d4-a716-446655440000.jpeg\n"
+                                    + "?X-Amz-Algorithm=AWS4-HMAC-SHA256\n"
+                                    + "&X-Amz-Date=20250824T130000Z\n"
+                                    + "&X-Amz-SignedHeaders=host\n"
+                                    + "&X-Amz-Expires=60\n"
+                                    + "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20250824/ap-northeast-2/s3/aws4_request\n"
+                                    + "&X-Amz-Signature=0123456789abcdef...\n"
+                                    + "&x-amz-acl=public-read\n"
+                                    + "&Content-MD5=testMd5Hash");
 
             // when
             PresignedUrlResponse response =
@@ -346,7 +364,15 @@ class ImageServiceTest extends IntegrationTest {
                                     eq(FileExtension.JPEG),
                                     anyString()))
                     .willReturn(
-                            "http://localhost/local/album-image/1/some-uuid.jpeg?Content-MD5=testMd5Hash");
+                            "https://my-bucket.s3.ap-northeast-2.amazonaws.com/local/album-image/1/550e8400-e29b-41d4-a716-446655440000.jpeg\n"
+                                    + "?X-Amz-Algorithm=AWS4-HMAC-SHA256\n"
+                                    + "&X-Amz-Date=20250824T130000Z\n"
+                                    + "&X-Amz-SignedHeaders=host\n"
+                                    + "&X-Amz-Expires=60\n"
+                                    + "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20250824/ap-northeast-2/s3/aws4_request\n"
+                                    + "&X-Amz-Signature=0123456789abcdef...\n"
+                                    + "&x-amz-acl=public-read\n"
+                                    + "&Content-MD5=testMd5Hash");
 
             // when
             PresignedUrlsResponse response = imageService.createAlbumFileUploadUrls(1L, request);

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -2,6 +2,8 @@ package org.cherrypic.image.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -14,6 +16,7 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.dto.request.AlbumFileUploadRequest;
+import org.cherrypic.domain.image.dto.request.AlbumImageDeleteRequest;
 import org.cherrypic.domain.image.dto.request.ImageUploadRequest;
 import org.cherrypic.domain.image.dto.request.UploadFailedFileDeleteRequest;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
@@ -33,6 +36,7 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
@@ -48,6 +52,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 class ImageServiceTest extends IntegrationTest {
 
     @MockitoBean MemberUtil memberUtil;
+    @MockitoBean S3Util s3Util;
 
     @Autowired private ImageService imageService;
     @Autowired private ParticipantRepository participantRepository;
@@ -719,6 +724,105 @@ class ImageServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> imageService.deleteUploadFailedFile(request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ImageErrorCode.PRESIGNED_IMAGES_NOT_MINE.getMessage());
+        }
+    }
+
+    @Nested
+    class 앨범_이미지를_삭제할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+
+            Image image1 = Image.createImage(album1, 1L, "testUrl1", LocalDateTime.now());
+            Image image2 = Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now());
+            Image image3 = Image.createImage(album2, 1L, "testUrl3", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3));
+        }
+
+        @Test
+        void 유효한_요청이면_앨범_이미지를_삭제한다() {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            // when
+            imageService.deleteAlbumImage(1L, request);
+
+            // then
+            assertThat(imageRepository.findAllById(List.of(1L, 2L))).isEmpty();
+        }
+
+        @Test
+        void 앨범_이미지가_삭제되는_경우_S3에서_삭제되는_로직이_호출된다() {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            // when
+            imageService.deleteAlbumImage(1L, request);
+
+            // then
+            verify(s3Util, times(1)).deleteFilesInBatchFromS3(List.of("testUrl1", "testUrl2"));
+        }
+
+        @Test
+        void 앨범이_존재하지_않을_경우_예외가_발생한다() {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.deleteAlbumImage(999L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_앨범_이미지를_삭제하면_예외가_발생한다() {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.deleteAlbumImage(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_앨범_이미지를_삭제하면_예외가_발생한다() {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.deleteAlbumImage(2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_이미지가_포함되어_있으면_예외가_발생한다() {
+            // given
+            AlbumImageDeleteRequest request = new AlbumImageDeleteRequest(List.of(1L, 3L));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.deleteAlbumImage(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.IMAGES_NOT_IN_ALBUM.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -1,6 +1,8 @@
 package org.cherrypic.member.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
@@ -9,6 +11,7 @@ import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.member.service.MemberService;
+import org.cherrypic.global.util.S3Util;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
@@ -21,6 +24,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class MemberServiceTest extends IntegrationTest {
 
@@ -30,6 +34,8 @@ class MemberServiceTest extends IntegrationTest {
 
     @Autowired private MemberService memberService;
     @Autowired private MemberRepository memberRepository;
+
+    @MockitoBean private S3Util s3Util;
 
     @BeforeEach
     void setUp() {
@@ -97,6 +103,19 @@ class MemberServiceTest extends IntegrationTest {
                     () ->
                             assertThat(member.getProfileImageUrl())
                                     .isEqualTo("updateProfileImageUrl"));
+        }
+
+        @Test
+        void 프로필_이미지_URL이_교체되는_경우_S3에서_삭제되는_로직이_호출된다() {
+            // given
+            MemberProfileUpdateRequest request =
+                    new MemberProfileUpdateRequest("updateNickname", "updateProfileImageUrl");
+
+            // when
+            memberService.updateProfile(request);
+
+            // then
+            verify(s3Util, times(1)).deleteFileFromS3("testProfileImageUrl");
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -1,11 +1,10 @@
 package org.cherrypic.member.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
+import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
@@ -25,7 +24,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
+@RecordApplicationEvents
 class MemberServiceTest extends IntegrationTest {
 
     @Autowired private TransactionUtil transactionUtil;
@@ -34,6 +36,8 @@ class MemberServiceTest extends IntegrationTest {
 
     @Autowired private MemberService memberService;
     @Autowired private MemberRepository memberRepository;
+
+    @Autowired private ApplicationEvents applicationEvents;
 
     @MockitoBean private S3Util s3Util;
 
@@ -115,7 +119,9 @@ class MemberServiceTest extends IntegrationTest {
             memberService.updateProfile(request);
 
             // then
-            verify(s3Util, times(1)).deleteFileFromS3("testProfileImageUrl");
+            var events = applicationEvents.stream(ImageDeleteEvent.class).toList();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst().imageUrl()).isEqualTo("testProfileImageUrl");
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -10,7 +10,6 @@ import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.member.service.MemberService;
-import org.cherrypic.global.util.S3Util;
 import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
@@ -23,7 +22,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 
@@ -38,8 +36,6 @@ class MemberServiceTest extends IntegrationTest {
     @Autowired private MemberRepository memberRepository;
 
     @Autowired private ApplicationEvents applicationEvents;
-
-    @MockitoBean private S3Util s3Util;
 
     @BeforeEach
     void setUp() {
@@ -110,7 +106,7 @@ class MemberServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 프로필_이미지_URL이_교체되는_경우_S3에서_삭제되는_로직이_호출된다() {
+        void 프로필_이미지_URL이_교체되는_경우_S3에서_이미지를_삭제하는_이벤트를_발행한다() {
             // given
             MemberProfileUpdateRequest request =
                     new MemberProfileUpdateRequest("updateNickname", "updateProfileImageUrl");


### PR DESCRIPTION
## 🌱 관련 이슈
- close #156 

---
## 📌 작업 내용 및 특이사항
- 앨범 이미지 삭제 API를 구현했습니다.
- 삭제할 때 S3에서도 삭제되도록 구현했습니다.
- 기존에 S3와 관련된 메서드들은 여러곳에서 호출될 수 있기에 S3Util로 정리되었습니다.
- 프로필 수정, 이벤트 커버 수정, 앨범 커버 수정시에 기존 URL이 바뀌는 경우 예전 url을 s3에서 삭제하도록 추가했습니다.
- S3의 삭제로직은 비동기로 처리되도록 구현이 되었고 리스너와 분리되었습니다.
- S3와 관련된 로직은 다양하게 쓰이기 때문에 S3Util을 분리했습니다.
- 앨범 커버와 이벤트 커버는 생성과 동시에 저장되어야 하기 때문에 앨범 ID와 이벤트 ID를 받지 않도록 했습니다.

---
## 📚 참고사항
- s3 삭제 로직에 대한 테스트 verify로 호출 여부만 확인했습니다.