### PR TITLE
feat: 구독 해지 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
@@ -16,7 +16,7 @@ public class SubscriptionController {
 
     private final SubscriptionService subscriptionService;
 
-    @PostMapping
+    @DeleteMapping
     @Operation(summary = "구독 해지", description = "유료 앨범의 구독을 해지합니다.")
     public ResponseEntity<Void> subscriptionCancel(@PathVariable Long albumId) {
         subscriptionService.cancelSubscription(albumId);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
@@ -1,0 +1,25 @@
+package org.cherrypic.domain.subscription.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.album.dto.response.*;
+import org.cherrypic.domain.subscription.service.SubscriptionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/albums/{albumId}/subscriptions")
+@RequiredArgsConstructor
+@Tag(name = "8. 구독 API", description = "구독 관련 API입니다.")
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    @PostMapping
+    @Operation(summary = "구독 해지", description = "유료 앨범의 구독을 해지합니다.")
+    public ResponseEntity<Void> subscriptionCancel(@PathVariable Long albumId) {
+        subscriptionService.cancelSubscription(albumId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/exception/SubscriptionErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/exception/SubscriptionErrorCode.java
@@ -1,0 +1,18 @@
+package org.cherrypic.domain.subscription.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum SubscriptionErrorCode implements BaseErrorCode {
+    SUBSCRIPTION_NOT_FOUND(404, "구독 정보가 존재하지 않습니다."),
+    SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN(400, "BASIC 플랜은 구독 기능을 지원하지 않습니다."),
+    SUBSCRIPTION_ALREADY_CANCELED(409, "이미 해지된 구독입니다."),
+    SUBSCRIPTION_ALREADY_ENDED(400, "이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/repository/SubscriptionRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/repository/SubscriptionRepository.java
@@ -1,6 +1,9 @@
 package org.cherrypic.domain.subscription.repository;
 
+import java.util.Optional;
 import org.cherrypic.subscription.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {}
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+    Optional<Subscription> findByAlbumId(Long albumId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
@@ -1,0 +1,5 @@
+package org.cherrypic.domain.subscription.service;
+
+public interface SubscriptionService {
+    void cancelSubscription(Long albumId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -81,7 +81,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     }
 
     private void validateSubscriptionNotCanceled(SubscriptionStatus status) {
-        if (status == SubscriptionStatus.CANCELLED) {
+        if (status == SubscriptionStatus.CANCELED) {
             throw new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_CANCELED);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -1,0 +1,94 @@
+package org.cherrypic.domain.subscription.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SubscriptionServiceImpl implements SubscriptionService {
+
+    private final MemberUtil memberUtil;
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final AlbumRepository albumRepository;
+    private final ParticipantRepository participantRepository;
+
+    @Override
+    public void cancelSubscription(Long albumId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionSupported(album.getPlan());
+
+        final Subscription subscription = getSubscriptionByAlbumId(album.getId());
+
+        validateSubscriptionNotExpired(subscription.getEndAt());
+        validateSubscriptionNotCanceled(subscription.getStatus());
+
+        subscription.cancelSubscription();
+    }
+
+    private Album getAlbumById(Long albumId) {
+        return albumRepository
+                .findById(albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+
+    private Participant getParticipantByMemberIdAndAlbumId(Long memberId, Long albumId) {
+        return participantRepository
+                .findByMemberIdAndAlbumId(memberId, albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
+    private void validateAlbumHost(Long memberId, Long albumId) {
+        Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
+
+        if (!participant.getRole().equals(ParticipantRole.HOST)) {
+            throw new CustomException(AlbumErrorCode.NOT_ALBUM_HOST);
+        }
+    }
+
+    private void validateSubscriptionSupported(AlbumPlan plan) {
+        if (plan == AlbumPlan.BASIC) {
+            throw new CustomException(
+                    SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN);
+        }
+    }
+
+    private Subscription getSubscriptionByAlbumId(Long albumId) {
+        return subscriptionRepository
+                .findByAlbumId(albumId)
+                .orElseThrow(
+                        () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
+    private void validateSubscriptionNotCanceled(SubscriptionStatus status) {
+        if (status == SubscriptionStatus.CANCELLED) {
+            throw new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_CANCELED);
+        }
+    }
+
+    private void validateSubscriptionNotExpired(LocalDateTime endAt) {
+        if (endAt.isBefore(LocalDateTime.now())) {
+            throw new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_ENDED);
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -1,0 +1,174 @@
+package org.cherrypic.subscription.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cherrypic.domain.album.dto.response.*;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.subscription.controller.SubscriptionController;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
+import org.cherrypic.domain.subscription.service.SubscriptionService;
+import org.cherrypic.exception.CustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(SubscriptionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SubscriptionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private SubscriptionService subscriptionService;
+
+    @Nested
+    class 구독_해지_요청_시 {
+
+        @Test
+        void 유효한_요청이면_구독을_해지하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            willDoNothing().given(subscriptionService).cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void BASIC_플랜인_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(
+                            new CustomException(
+                                    SubscriptionErrorCode
+                                            .SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.data.code")
+                                    .value("SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN"))
+                    .andExpect(jsonPath("$.data.message").value("BASIC 플랜은 구독 기능을 지원하지 않습니다."));
+        }
+
+        @Test
+        void 구독이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("구독 정보가 존재하지 않습니다."));
+        }
+
+        @Test
+        void 이미_해지된_구독이면_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_CANCELED))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
+                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_ALREADY_CANCELED"))
+                    .andExpect(jsonPath("$.data.message").value("이미 해지된 구독입니다."));
+        }
+
+        @Test
+        void 종료된_구독이면_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_ENDED))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_ALREADY_ENDED"))
+                    .andExpect(jsonPath("$.data.message").value("이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -1,0 +1,158 @@
+package org.cherrypic.subscription.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
+import org.cherrypic.domain.subscription.service.SubscriptionService;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class SubscriptionServiceTest extends IntegrationTest {
+
+    @Autowired private SubscriptionService subscriptionService;
+    @Autowired private SubscriptionRepository subscriptionRepository;
+    @Autowired private AlbumRepository albumRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private ParticipantRepository participantRepository;
+
+    @MockitoBean private MemberUtil memberUtil;
+
+    @Nested
+    class 구독을_해지할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.PRO, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, false);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.PREMIUM, false);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.PREMIUM, false);
+            Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumPlan.PREMIUM, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5, album6));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.HOST);
+            Participant participant3 =
+                    Participant.createParticipant(member, album3, ParticipantRole.HOST);
+            Participant participant4 =
+                    Participant.createParticipant(member, album4, ParticipantRole.STANDARD);
+            Participant participant5 =
+                    Participant.createParticipant(member, album5, ParticipantRole.HOST);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4, participant5));
+
+            Subscription subscription1 =
+                    Subscription.createSubscription(member, album2, LocalDateTime.now());
+            Subscription subscription2 =
+                    Subscription.createSubscription(
+                            member, album3, LocalDateTime.of(2025, 1, 1, 0, 0));
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2));
+        }
+
+        @Test
+        void 유효한_요청이면_구독을_해지한다() {
+            // when
+            subscriptionService.cancelSubscription(2L);
+
+            // then
+            Subscription subscription = subscriptionRepository.findByAlbumId(2L).get();
+            Assertions.assertAll(
+                    () ->
+                            assertThat(subscription)
+                                    .extracting("id", "status")
+                                    .containsExactly(1L, SubscriptionStatus.CANCELED));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(6L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(4L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void BASIC_플랜인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(
+                            SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN
+                                    .getMessage());
+        }
+
+        @Test
+        void 구독이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(5L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 이미_해지된_구독이면_예외가_발생한다() {
+            // given
+            subscriptionService.cancelSubscription(2L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_CANCELED.getMessage());
+        }
+
+        @Test
+        void 종료된_구독이면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(3L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_ENDED.getMessage());
+        }
+    }
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -68,6 +68,6 @@ public class Subscription extends BaseTimeEntity {
     }
 
     public void cancelSubscription() {
-        this.status = SubscriptionStatus.CANCELLED;
+        this.status = SubscriptionStatus.CANCELED;
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -66,4 +66,8 @@ public class Subscription extends BaseTimeEntity {
                 .nextBillingAt(paidAt.plusMonths(1).plusDays(1))
                 .build();
     }
+
+    public void cancelSubscription() {
+        this.status = SubscriptionStatus.CANCELLED;
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/enums/SubscriptionStatus.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/enums/SubscriptionStatus.java
@@ -2,6 +2,6 @@ package org.cherrypic.subscription.enums;
 
 public enum SubscriptionStatus {
     ACTIVE,
-    CANCELLED,
+    CANCELED,
     EXPIRED
 }

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -45,7 +45,7 @@ CREATE TABLE subscription (
                               id BIGINT AUTO_INCREMENT PRIMARY KEY,
                               member_id BIGINT NOT NULL,
                               album_id BIGINT UNIQUE,
-                              status VARCHAR(255) NOT NULL CHECK (status IN ('ACTIVE','CANCELLED','EXPIRED')),
+                              status VARCHAR(255) NOT NULL CHECK (status IN ('ACTIVE','CANCELED','EXPIRED')),
                               start_at DATETIME(6),
                               end_at DATETIME(6),
                               next_billing_at DATETIME(6),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #143 

---
## 📌 작업 내용 및 특이사항
* 유료 앨범에 대한 구독 해지 API를 구현했습니다.
  * BASIC 플랜에서의 해지 요청 및 이미 해지되었거나 종료된 구독에 대한 요청을 예외 처리했습니다.

---
## 📚 참고사항
* 구독 해지를 하더라도, 종료일은 시작일(또는 갱신일)로부터 한 달 뒤로 유지됩니다.
* 구독 기간 중 방장은 구독 해지 후 다른 참가자에게 권한을 위임할 수 있으며, 위임받은 참가자는 종료일 이전이라면 구독을 이어서 갱신할 수 있습니다.
* 종료일 이후 14일의 유예 기간이 지나면 앨범은 스케줄러를 통해 자동 삭제될 예정입니다.