### PR TITLE
feat: 임시 앨범 생성 API

### DIFF
--- a/cherrypic-api/build.gradle
+++ b/cherrypic-api/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':cherrypic-common')
     implementation project(':cherrypic-infrastructure')
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/TempAlbumRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/TempAlbumRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.album.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record TempAlbumRequest(
+        @NotEmpty(message = "임시 앨범으로 공유할 사진들은 비워둘 수 없습니다.")
+                @Schema(description = "임시 앨범으로 공유할 사진들의 ID", example = "[1,2,3,4]")
+                List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -51,7 +51,6 @@ public class AlbumServiceImpl implements AlbumService {
     private final SubscriptionRepository subscriptionRepository;
     private final InvitationCodeRepository invitationCodeRepository;
     private final EventRepository eventRepository;
-
     private final ApplicationEventPublisher eventPublisher;
 
     @Override

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -61,7 +61,7 @@ public class ImageServiceImpl implements ImageService {
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
-                s3Util.createPresignedUrl(
+                s3Util.createUploadPresignedUrl(
                         ImageType.MEMBER_PROFILE,
                         currentMember.getId(),
                         request.fileExtension(),
@@ -77,7 +77,7 @@ public class ImageServiceImpl implements ImageService {
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
-                s3Util.createPresignedUrl(
+                s3Util.createUploadPresignedUrl(
                         ImageType.ALBUM_COVER,
                         currentMember.getId(),
                         request.fileExtension(),
@@ -93,7 +93,7 @@ public class ImageServiceImpl implements ImageService {
         validateImageExtension(request.fileExtension());
 
         String presignedUrl =
-                s3Util.createPresignedUrl(
+                s3Util.createUploadPresignedUrl(
                         ImageType.EVENT_COVER,
                         currentMember.getId(),
                         request.fileExtension(),
@@ -118,7 +118,7 @@ public class ImageServiceImpl implements ImageService {
                 request.payloads().stream()
                         .map(
                                 req ->
-                                        s3Util.createPresignedUrl(
+                                        s3Util.createUploadPresignedUrl(
                                                 ImageType.ALBUM_IMAGE,
                                                 album.getId(),
                                                 req.fileExtension(),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
@@ -1,0 +1,31 @@
+package org.cherrypic.domain.tempalbum.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.album.dto.request.TempAlbumRequest;
+import org.cherrypic.domain.tempalbum.service.TempAlbumService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "9. 임시 앨범 API", description = "임시 앨범 관련 API입니다.")
+public class TempAlbumController {
+
+    private final TempAlbumService tempAlbumService;
+
+    // 로직은 QR 반환을 고려하고 있음 근데 내 임시 앨범들을 볼려면 DB에 넣어놔야 하긴할듯.
+    // 발급 제한을 두지는 않을 건지..? 이런거는 생각해봐야함 -> 용량이 부담되게 늘진 않아요 ! -> 참조 형식을 쓰기 때문 대신 원본이 삭제되면  고장날듯
+    @PostMapping("/album/{albumId}/temp-album")
+    @Operation(summary = "임시 앨범 생성 API", description = "임시 앨범을 생성합니다.")
+    public ResponseEntity<Void> tempAlbumCreate(
+            @PathVariable Long albumId, @Valid @RequestBody TempAlbumRequest request) {
+        tempAlbumService.createTempAlbum(albumId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/TempAlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/TempAlbumErrorCode.java
@@ -1,0 +1,14 @@
+package org.cherrypic.domain.tempalbum.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum TempAlbumErrorCode implements BaseErrorCode {
+    TEMP_ALBUM_UPLOAD_FAIL(503, "임시 앨범 업로드에 실패했습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/repository/TempAlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/repository/TempAlbumRepository.java
@@ -1,0 +1,4 @@
+package org.cherrypic.domain.tempalbum.repository;
+
+// 업데이트 해야함 엔티티 만들고 나서 ~
+public interface TempAlbumRepository {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
@@ -1,0 +1,8 @@
+package org.cherrypic.domain.tempalbum.service;
+
+import org.cherrypic.domain.album.dto.request.TempAlbumRequest;
+
+public interface TempAlbumService {
+
+    void createTempAlbum(Long albumId, TempAlbumRequest request);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
@@ -1,0 +1,129 @@
+package org.cherrypic.domain.tempalbum.service;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.dto.request.TempAlbumRequest;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.image.repository.ImageRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.S3Util;
+import org.cherrypic.image.entity.Image;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.s3.S3Properties;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+public class TempAlbumServiceImpl implements TempAlbumService {
+
+    private final MemberUtil memberUtil;
+    private final S3Util s3Util;
+
+    private final TemplateEngine templateEngine;
+    private final ParticipantRepository participantRepository;
+    private final ImageRepository imageRepository;
+    private final AlbumRepository albumRepository;
+
+    private final S3Properties s3Properties;
+
+    @Override
+    public void createTempAlbum(Long albumId, TempAlbumRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateParticipantAuthority(currentMember.getId(), album.getId());
+
+        List<Long> distinctImageIds =
+                request.imageIds().stream().filter(Objects::nonNull).distinct().toList();
+        final List<Image> images = imageRepository.findAllById(distinctImageIds);
+
+        validateImagesInAlbum(images, album);
+
+        Date expirationDate = getExpirationByAlbumPlan(album.getPlan());
+
+        List<String> presignedUrls =
+                images.stream()
+                        .map(
+                                image ->
+                                        s3Util.createReadOnlyPresignedUrl(
+                                                image.getUrl(), expirationDate))
+                        .toList();
+
+        String html = generateAlbumHtml(album.getTitle(), album.getTitle(), presignedUrls);
+
+        s3Util.uploadTempAlbum(
+                s3Properties.tempAlbumBucket(), createTempAlbumKey(album.getId()), html);
+    }
+
+    private String createTempAlbumKey(Long albumId) {
+        return LocalDate.now() + "/" + albumId + "/" + UUID.randomUUID().toString() + ".html";
+    }
+
+    private String generateAlbumHtml(
+            String fileTitle, String albumTitle, List<String> presignedUrls) {
+        Context context = new Context();
+        context.setVariable("bucketName", s3Properties.mainBucket());
+        context.setVariable("fileTitle", fileTitle);
+        context.setVariable("albumTitle", albumTitle);
+        context.setVariable("imageUrls", presignedUrls);
+
+        return templateEngine.process("album", context);
+    }
+
+    private Date getExpirationByAlbumPlan(AlbumPlan albumPlan) {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+
+        if (AlbumPlan.BASIC == albumPlan) {
+            expTimeMillis += TimeUnit.DAYS.toMillis(3);
+        } else {
+            expTimeMillis += TimeUnit.DAYS.toMillis(14);
+        }
+
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    private void validateParticipantAuthority(Long memberId, Long albumId) {
+        Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
+
+        if (participant.getRole().equals(ParticipantRole.LIMITED)) {
+            throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
+        }
+    }
+
+    private void validateImagesInAlbum(List<Image> images, Album album) {
+        boolean containsNotInAlbum =
+                images.stream().anyMatch(ei -> !ei.getAlbum().getId().equals(album.getId()));
+
+        if (containsNotInAlbum) {
+            throw new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM);
+        }
+    }
+
+    private Participant getParticipantByMemberIdAndAlbumId(Long memberId, Long albumId) {
+        return participantRepository
+                .findByMemberIdAndAlbumId(memberId, albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
+    private Album getAlbumById(Long albumId) {
+        return albumRepository
+                .findById(albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
@@ -1,6 +1,5 @@
 package org.cherrypic.domain.tempalbum.service;
 
-import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -63,17 +62,19 @@ public class TempAlbumServiceImpl implements TempAlbumService {
                                                 image.getUrl(), expirationDate))
                         .toList();
 
-        String html = generateAlbumHtml(album.getTitle(), album.getTitle(), presignedUrls);
+        String html = generateTempAlbumHtml(album.getTitle(), album.getTitle(), presignedUrls);
 
         s3Util.uploadTempAlbum(
-                s3Properties.tempAlbumBucket(), createTempAlbumKey(album.getId()), html);
+                s3Properties.tempAlbumBucket(),
+                createTempAlbumKey(expirationDate, album.getId()),
+                html);
     }
 
-    private String createTempAlbumKey(Long albumId) {
-        return LocalDate.now() + "/" + albumId + "/" + UUID.randomUUID().toString() + ".html";
+    private String createTempAlbumKey(Date expirationDate, Long albumId) {
+        return expirationDate + "/" + albumId + "/" + UUID.randomUUID() + ".html";
     }
 
-    private String generateAlbumHtml(
+    private String generateTempAlbumHtml(
             String fileTitle, String albumTitle, List<String> presignedUrls) {
         Context context = new Context();
         context.setVariable("bucketName", s3Properties.mainBucket());

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/S3Util.java
@@ -4,6 +4,10 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -11,6 +15,8 @@ import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.enums.FileExtension;
 import org.cherrypic.domain.image.enums.ImageType;
+import org.cherrypic.domain.tempalbum.dto.TempAlbumErrorCode;
+import org.cherrypic.exception.CustomException;
 import org.cherrypic.helper.SpringEnvironmentHelper;
 import org.cherrypic.s3.S3Properties;
 import org.springframework.stereotype.Component;
@@ -23,19 +29,43 @@ public class S3Util {
     private final AmazonS3 amazonS3;
     private final S3Properties s3Properties;
 
-    public String createPresignedUrl(
+    public String createUploadPresignedUrl(
             ImageType imageType, Long targetId, FileExtension fileExtension, String md5Hash) {
         String imageKey = UUID.randomUUID().toString();
-        String fileName = createFileName(imageType, targetId, imageKey, fileExtension);
+        String fileName = createUploadFileName(imageType, targetId, imageKey, fileExtension);
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
-                generatePresignedUrlRequest(
-                        s3Properties.bucket(), fileName, fileExtension.getExtension(), md5Hash);
+                generateUploadPresignedUrlRequest(
+                        s3Properties.mainBucket(), fileName, fileExtension.getExtension(), md5Hash);
 
         return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
     }
 
-    private String createFileName(
+    public String createReadOnlyPresignedUrl(String imageUrl, Date expirationDate) {
+
+        String fileName = extractFileName(imageUrl);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                generateReadOnlyPresignedUrlRequest(
+                        s3Properties.mainBucket(), fileName, expirationDate);
+
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
+
+    public void uploadTempAlbum(String bucket, String key, String htmlContent) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("text/html; charset=UTF-8");
+        metadata.setContentLength(htmlContent.getBytes(StandardCharsets.UTF_8).length);
+
+        try (InputStream inputStream =
+                new ByteArrayInputStream(htmlContent.getBytes(StandardCharsets.UTF_8))) {
+            amazonS3.putObject(new PutObjectRequest(bucket, key, inputStream, metadata));
+        } catch (IOException e) {
+            throw new CustomException(TempAlbumErrorCode.TEMP_ALBUM_UPLOAD_FAIL);
+        }
+    }
+
+    private String createUploadFileName(
             ImageType imageType, Long targetId, String imageKey, FileExtension fileExtension) {
         return springEnvironmentHelper.getCurrentProfile()
                 + "/"
@@ -48,7 +78,15 @@ public class S3Util {
                 + fileExtension.getExtension();
     }
 
-    private GeneratePresignedUrlRequest generatePresignedUrlRequest(
+    private GeneratePresignedUrlRequest generateReadOnlyPresignedUrlRequest(
+            String bucket, String fileName, Date expiration) {
+
+        return new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.GET)
+                .withKey(fileName)
+                .withExpiration(expiration);
+    }
+
+    private GeneratePresignedUrlRequest generateUploadPresignedUrlRequest(
             String bucket, String fileName, String imageFileExtension, String md5Hash) {
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
@@ -65,7 +103,7 @@ public class S3Util {
     }
 
     public void deleteFilesInBatchFromS3(List<String> urls) {
-        String bucket = s3Properties.bucket();
+        String bucket = s3Properties.mainBucket();
         List<DeleteObjectsRequest.KeyVersion> keys =
                 urls.stream()
                         .map(this::extractObjectKey)
@@ -77,7 +115,7 @@ public class S3Util {
     }
 
     public void deleteAllAlbumImagesInBatchFromS3(Long albumId) {
-        String bucket = s3Properties.bucket();
+        String bucket = s3Properties.mainBucket();
         String prefix =
                 springEnvironmentHelper.getCurrentProfile()
                         + "/"
@@ -108,13 +146,13 @@ public class S3Util {
     }
 
     public void deleteFileFromS3(String url) {
-        String bucket = s3Properties.bucket();
+        String bucket = s3Properties.mainBucket();
         String objectKey = extractObjectKey(url);
         amazonS3.deleteObject(bucket, objectKey);
     }
 
     private String extractObjectKey(String url) {
-        String bucket = s3Properties.bucket();
+        String bucket = s3Properties.mainBucket();
         int idx = url.indexOf(bucket) + bucket.length() + 1;
         return url.substring(idx);
     }
@@ -126,5 +164,9 @@ public class S3Util {
         expiration.setTime(expTimeMillis);
 
         return expiration;
+    }
+
+    private String extractFileName(String url) {
+        return url.substring(url.lastIndexOf("/") + 1);
     }
 }

--- a/cherrypic-api/src/main/resources/application-dev.yml
+++ b/cherrypic-api/src/main/resources/application-dev.yml
@@ -42,7 +42,8 @@ aws:
   secret-access-key: ${AWS_SECRET_ACCESS_KEY}
   region: ${AWS_REGION}
   s3:
-    bucket: ${S3_BUCKET}
+    main-bucket: ${S3_MAIN_BUCKET}
+    temp-album-bucket: ${S3_TEMP_ALBUM_BUCKET}
     endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
 
 iamport:

--- a/cherrypic-api/src/main/resources/application-local.yml
+++ b/cherrypic-api/src/main/resources/application-local.yml
@@ -45,7 +45,8 @@ aws:
   secret-access-key: ${AWS_SECRET_ACCESS_KEY}
   region: ${AWS_REGION}
   s3:
-    bucket: ${S3_BUCKET}
+    main-bucket: ${S3_MAIN_BUCKET}
+    temp-album-bucket: ${S3_TEMP_ALBUM_BUCKET}
     endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
 
 iamport:

--- a/cherrypic-api/src/main/resources/application-prod.yml
+++ b/cherrypic-api/src/main/resources/application-prod.yml
@@ -42,7 +42,8 @@ aws:
   secret-access-key: ${AWS_SECRET_ACCESS_KEY}
   region: ${AWS_REGION}
   s3:
-    bucket: ${S3_BUCKET}
+    main-bucket: ${S3_MAIN_BUCKET}
+    temp-album-bucket: ${S3_TEMP_ALBUM_BUCKET}
     endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
 
 iamport:

--- a/cherrypic-api/src/main/resources/templates/temp-album.html
+++ b/cherrypic-api/src/main/resources/templates/temp-album.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${fileTitle}"></title>
+</head>
+<body>
+<header>
+    <img th:src="|https://${bucketName}.s3.ap-northeast-2.amazonaws.com/cherrypic.png|" alt="CherryPic 로고">
+    <h1 th:text="${albumTitle}"></h1>
+</header>
+
+<main>
+    <div th:each="url : ${imageUrls}">
+        <img th:src="${url}" alt="image"/>
+    </div>
+</main>
+</body>
+</html>

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -86,7 +86,7 @@ class ImageServiceTest extends IntegrationTest {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
             given(
-                            s3Util.createPresignedUrl(
+                            s3Util.createUploadPresignedUrl(
                                     ImageType.MEMBER_PROFILE,
                                     1L,
                                     FileExtension.JPEG,
@@ -154,7 +154,7 @@ class ImageServiceTest extends IntegrationTest {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
             given(
-                            s3Util.createPresignedUrl(
+                            s3Util.createUploadPresignedUrl(
                                     ImageType.ALBUM_COVER, 1L, FileExtension.JPEG, "testMd5Hash"))
                     .willReturn(
                             "https://test-bucket.s3.ap-northeast-2.amazonaws.com/local/album-cover/1/550e8400-e29b-41d4-a716-446655440000.jpeg\n"
@@ -223,7 +223,7 @@ class ImageServiceTest extends IntegrationTest {
             // given
             ImageUploadRequest request = new ImageUploadRequest(FileExtension.JPEG, "testMd5Hash");
             given(
-                            s3Util.createPresignedUrl(
+                            s3Util.createUploadPresignedUrl(
                                     ImageType.EVENT_COVER, 1L, FileExtension.JPEG, "testMd5Hash"))
                     .willReturn(
                             "https://my-bucket.s3.ap-northeast-2.amazonaws.com/local/event-cover/1/550e8400-e29b-41d4-a716-446655440000.jpeg\n"
@@ -299,7 +299,7 @@ class ImageServiceTest extends IntegrationTest {
                                             "testMd5Hash2",
                                             LocalDateTime.now())));
             given(
-                            s3Util.createPresignedUrl(
+                            s3Util.createUploadPresignedUrl(
                                     eq(ImageType.ALBUM_IMAGE),
                                     eq(1L),
                                     eq(FileExtension.JPEG),

--- a/cherrypic-infrastructure/src/main/java/org/cherrypic/s3/S3Properties.java
+++ b/cherrypic-infrastructure/src/main/java/org/cherrypic/s3/S3Properties.java
@@ -3,4 +3,4 @@ package org.cherrypic.s3;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("aws.s3")
-public record S3Properties(String bucket, String endpoint) {}
+public record S3Properties(String mainBucket, String tempAlbumBucket, String endpoint) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #164 

---
## 📌 작업 내용 및 특이사항
- 미완성입니다.
- 아이디어는 원본 이미지를 조회하고 다운로드 할 수 있는 PresignedUrl을 만들고 그걸 바탕으로 html을 만들어서 공개 bucket에 저장합니다.
- 현재 html을 만들어서 버킷으로 등록하는 부분까지 구현되어 있습니다.

---
## 📚 참고사항
- 나중에 html들은 날짜별로 클리너를 돌려도 좋을 것 같습니다. 
- 아직 Temp Album 엔티티는 만들지 않은 상태입니다. ( PM과 상의중 )
- QR도 만들게 된다면 이미지로 만들어서 임시 앨범 버킷에 저장하면 될 것 같습니다.

임시 앨범 엔티티를 만들게 된다면,
- 임시 앨범 url
- 임시 앨범 QR code 사진 url ( 임시 앨범 버킷에 저장된)

이렇게 두개를 보관하고 있으면 될 것 같아요.