### PR TITLE
refactor: 결제 및 구독 검증 책임을 도메인 계층으로 이동

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -30,7 +30,6 @@ import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
-import org.cherrypic.payment.enums.PaymentStatus;
 import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.context.ApplicationEventPublisher;
@@ -79,16 +78,12 @@ public class AlbumServiceImpl implements AlbumService {
         if (request.plan() != AlbumPlan.BASIC) {
             final Payment payment = getPaidPaymentById(request.paymentId());
 
-            validatePaidStatus(payment);
             validatePaymentMemberMismatch(payment, currentMember);
-            validatePaymentNotUsed(payment);
-            validatePaymentPurposeForAlbumCreation(payment);
 
-            payment.updatePayment(album);
+            payment.updatePayment(PaymentPurpose.CREATION, album);
 
-            Subscription subscription =
-                    Subscription.createSubscription(currentMember, album, payment.getPaidAt());
-            subscriptionRepository.save(subscription);
+            subscriptionRepository.save(
+                    Subscription.createSubscription(currentMember, album, payment.getPaidAt()));
         }
 
         albumRepository.save(album);
@@ -278,34 +273,16 @@ public class AlbumServiceImpl implements AlbumService {
         }
     }
 
-    private void validatePaidStatus(Payment payment) {
-        if (payment.getStatus() != PaymentStatus.PAID) {
-            throw new CustomException(PaymentErrorCode.NOT_PAID);
-        }
+    private Payment getPaidPaymentById(Long paymentId) {
+        return paymentRepository
+                .findById(paymentId)
+                .orElseThrow(() -> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 
     private void validatePaymentMemberMismatch(Payment payment, Member member) {
         if (!payment.getMember().getId().equals(member.getId())) {
             throw new CustomException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH);
         }
-    }
-
-    private void validatePaymentNotUsed(Payment payment) {
-        if (payment.getAlbum() != null) {
-            throw new CustomException(PaymentErrorCode.ALREADY_USED_PAYMENT);
-        }
-    }
-
-    private void validatePaymentPurposeForAlbumCreation(Payment payment) {
-        if (payment.getPurpose() != PaymentPurpose.CREATION) {
-            throw new CustomException(PaymentErrorCode.PAYMENT_PURPOSE_MISMATCH);
-        }
-    }
-
-    private Payment getPaidPaymentById(Long paymentId) {
-        return paymentRepository
-                .findById(paymentId)
-                .orElseThrow(() -> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 
     private void validateMaxParticipantLimit(Album album) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
@@ -17,8 +17,6 @@ public enum PaymentErrorCode implements BaseErrorCode {
     IAMPORT_API_UNAVAILABLE(503, "결제 대행 시스템(Iamport)과의 통신에 실패했습니다. 잠시 후 다시 시도해주세요."),
 
     PAYMENT_MEMBER_MISMATCH(403, "결제한 사용자와 일치하지 않습니다."),
-    ALREADY_USED_PAYMENT(400, "이미 다른 앨범에 사용된 결제입니다."),
-    PAYMENT_PURPOSE_MISMATCH(400, "결제 목적이 요청하려는 작업과 일치하지 않습니다."),
 
     DOWNGRADE_NOT_ALLOWED(400, "현재 구독 플랜보다 낮은 플랜으로는 결제를 진행할 수 없습니다."),
     ;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -1,6 +1,5 @@
 package org.cherrypic.domain.subscription.service;
 
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumPlan;
@@ -15,7 +14,6 @@ import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.subscription.entity.Subscription;
-import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,10 +38,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
         final Subscription subscription = getSubscriptionByAlbumId(album.getId());
 
-        validateSubscriptionNotExpired(subscription.getEndAt());
-        validateSubscriptionNotCanceled(subscription.getStatus());
-
-        subscription.cancelSubscription();
+        subscription.cancel();
     }
 
     private Album getAlbumById(Long albumId) {
@@ -78,17 +73,5 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .findByAlbumId(albumId)
                 .orElseThrow(
                         () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
-    }
-
-    private void validateSubscriptionNotCanceled(SubscriptionStatus status) {
-        if (status == SubscriptionStatus.CANCELED) {
-            throw new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_CANCELED);
-        }
-    }
-
-    private void validateSubscriptionNotExpired(LocalDateTime endAt) {
-        if (endAt.isBefore(LocalDateTime.now())) {
-            throw new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_ENDED);
-        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -269,7 +269,7 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.success").value(false))
                         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                         .andExpect(jsonPath("$.data.code").value("NOT_PAID"))
-                        .andExpect(jsonPath("$.data.message").value("결제가 완료되지 않아 검증에 실패했습니다."));
+                        .andExpect(jsonPath("$.data.message").value("아직 결제가 완료되지 않았습니다."));
             }
 
             @Test
@@ -294,7 +294,7 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.success").value(false))
                         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                         .andExpect(jsonPath("$.data.code").value("ALREADY_USED_PAYMENT"))
-                        .andExpect(jsonPath("$.data.message").value("이미 다른 앨범에 사용된 결제입니다."));
+                        .andExpect(jsonPath("$.data.message").value("해당 결제는 이미 사용되었습니다."));
             }
 
             @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -20,6 +20,7 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.payment.exception.PaymentDomainErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -224,30 +225,6 @@ class AlbumControllerTest {
             }
 
             @Test
-            void 결제상태가_PAID가_아니면_예외가_발생한다() throws Exception {
-                // given
-                AlbumCreateRequest request =
-                        new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
-
-                given(albumService.createAlbum(request))
-                        .willThrow(new CustomException(PaymentErrorCode.NOT_PAID));
-
-                // when & then
-                ResultActions perform =
-                        mockMvc.perform(
-                                post("/albums")
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .content(objectMapper.writeValueAsString(request)));
-
-                perform.andExpect(status().isBadRequest())
-                        .andExpect(jsonPath("$.success").value(false))
-                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                        .andExpect(jsonPath("$.data.code").value("NOT_PAID"))
-                        .andExpect(jsonPath("$.data.message").value("결제가 완료되지 않아 검증에 실패했습니다."));
-            }
-
-            @Test
             void 결제한_회원과_로그인_회원이_일치하지_않으면_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
@@ -272,6 +249,30 @@ class AlbumControllerTest {
             }
 
             @Test
+            void 결제상태가_PAID가_아니면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(new CustomException(PaymentDomainErrorCode.NOT_PAID));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                        .andExpect(jsonPath("$.data.code").value("NOT_PAID"))
+                        .andExpect(jsonPath("$.data.message").value("결제가 완료되지 않아 검증에 실패했습니다."));
+            }
+
+            @Test
             void 결제가_이미_사용된_경우_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
@@ -279,7 +280,8 @@ class AlbumControllerTest {
                                 "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
-                        .willThrow(new CustomException(PaymentErrorCode.ALREADY_USED_PAYMENT));
+                        .willThrow(
+                                new CustomException(PaymentDomainErrorCode.ALREADY_USED_PAYMENT));
 
                 // when & then
                 ResultActions perform =
@@ -303,7 +305,9 @@ class AlbumControllerTest {
                                 "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
-                        .willThrow(new CustomException(PaymentErrorCode.PAYMENT_PURPOSE_MISMATCH));
+                        .willThrow(
+                                new CustomException(
+                                        PaymentDomainErrorCode.PAYMENT_PURPOSE_MISMATCH));
 
                 // when & then
                 ResultActions perform =

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -51,6 +51,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.payment.exception.PaymentDomainErrorCode;
 import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.*;
@@ -208,7 +209,7 @@ class AlbumServiceTest extends IntegrationTest {
                                 member1, "testMerchantUid", 5900, PaymentPurpose.CREATION);
                 payment3.updatePayment(
                         "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
-                payment3.updatePayment(album);
+                payment3.updatePayment(PaymentPurpose.CREATION, album);
                 // 구독 갱신 목적으로 쓰인 결제
                 Payment payment4 =
                         Payment.createPayment(
@@ -322,19 +323,6 @@ class AlbumServiceTest extends IntegrationTest {
             }
 
             @Test
-            void 결제상태가_PAID가_아니면_예외가_발생한다() {
-                // given
-                AlbumCreateRequest request =
-                        new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 2L, false);
-
-                // when & then
-                assertThatThrownBy(() -> albumService.createAlbum(request))
-                        .isInstanceOf(CustomException.class)
-                        .hasMessage(PaymentErrorCode.NOT_PAID.getMessage());
-            }
-
-            @Test
             void 결제한_회원과_로그인_회원이_일치하지_않으면_예외가_발생한다() {
                 // given
                 given(memberUtil.getCurrentMember())
@@ -351,6 +339,19 @@ class AlbumServiceTest extends IntegrationTest {
             }
 
             @Test
+            void 결제상태가_PAID가_아니면_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 2L, false);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(PaymentDomainErrorCode.NOT_PAID.getMessage());
+            }
+
+            @Test
             void 결제가_이미_사용된_경우_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
@@ -360,7 +361,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
                         .isInstanceOf(CustomException.class)
-                        .hasMessage(PaymentErrorCode.ALREADY_USED_PAYMENT.getMessage());
+                        .hasMessage(PaymentDomainErrorCode.ALREADY_USED_PAYMENT.getMessage());
             }
 
             @Test
@@ -373,7 +374,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
                         .isInstanceOf(CustomException.class)
-                        .hasMessage(PaymentErrorCode.PAYMENT_PURPOSE_MISMATCH.getMessage());
+                        .hasMessage(PaymentDomainErrorCode.PAYMENT_PURPOSE_MISMATCH.getMessage());
             }
         }
     }

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.enums.AlbumPlan;
-import org.cherrypic.common.exception.DomainErrorCode;
+import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
@@ -98,14 +98,14 @@ public class Album extends BaseTimeEntity {
 
     public void increaseCapacity(BigDecimal decimal) {
         if (this.capacityGb.add(decimal).compareTo(BigDecimal.valueOf(9999.99)) > 0) {
-            throw new CustomException(DomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT);
+            throw new CustomException(AlbumDomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT);
         }
         this.capacityGb = capacityGb.add(decimal);
     }
 
     public void decreaseCapacity(BigDecimal decimal) {
         if (this.capacityGb.subtract(decimal).compareTo(BigDecimal.ZERO) < 0) {
-            throw new CustomException(DomainErrorCode.ALBUM_CAPACITY_DECREASE_UNDER_ZERO);
+            throw new CustomException(AlbumDomainErrorCode.ALBUM_CAPACITY_DECREASE_UNDER_ZERO);
         }
         this.capacityGb = capacityGb.subtract(decimal);
     }

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/exception/AlbumDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/exception/AlbumDomainErrorCode.java
@@ -1,4 +1,4 @@
-package org.cherrypic.common.exception;
+package org.cherrypic.album.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -6,7 +6,7 @@ import org.cherrypic.exception.BaseErrorCode;
 
 @Getter
 @AllArgsConstructor
-public enum DomainErrorCode implements BaseErrorCode {
+public enum AlbumDomainErrorCode implements BaseErrorCode {
     ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "앨범 용량은 9999GB 초과로 늘릴 수 없습니다"),
     ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "앨범 용량은 0GB 미만으로 줄일 수 없습니다.");
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -9,9 +9,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
+import org.cherrypic.exception.CustomException;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.payment.exception.PaymentDomainErrorCode;
 
 @Getter
 @Entity
@@ -81,7 +83,17 @@ public class Payment extends BaseTimeEntity {
         this.paidAt = paidAt;
     }
 
-    public void updatePayment(Album album) {
+    public void updatePayment(PaymentPurpose purpose, Album album) {
+        if (this.status != PaymentStatus.PAID) {
+            throw new CustomException(PaymentDomainErrorCode.NOT_PAID);
+        }
+        if (this.album != null) {
+            throw new CustomException(PaymentDomainErrorCode.ALREADY_USED_PAYMENT);
+        }
+        if (this.purpose != purpose) {
+            throw new CustomException(PaymentDomainErrorCode.PAYMENT_PURPOSE_MISMATCH);
+        }
+
         this.album = album;
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/exception/PaymentDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/exception/PaymentDomainErrorCode.java
@@ -7,8 +7,8 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum PaymentDomainErrorCode implements BaseErrorCode {
-    NOT_PAID(400, "결제가 완료되지 않아 검증에 실패했습니다."),
-    ALREADY_USED_PAYMENT(400, "이미 다른 앨범에 사용된 결제입니다."),
+    NOT_PAID(400, "아직 결제가 완료되지 않았습니다."),
+    ALREADY_USED_PAYMENT(400, "해당 결제는 이미 사용되었습니다."),
     PAYMENT_PURPOSE_MISMATCH(400, "결제 목적이 요청하려는 작업과 일치하지 않습니다."),
     ;
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/exception/PaymentDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/exception/PaymentDomainErrorCode.java
@@ -1,0 +1,17 @@
+package org.cherrypic.payment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentDomainErrorCode implements BaseErrorCode {
+    NOT_PAID(400, "결제가 완료되지 않아 검증에 실패했습니다."),
+    ALREADY_USED_PAYMENT(400, "이미 다른 앨범에 사용된 결제입니다."),
+    PAYMENT_PURPOSE_MISMATCH(400, "결제 목적이 요청하려는 작업과 일치하지 않습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -9,8 +9,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
+import org.cherrypic.exception.CustomException;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
+import org.cherrypic.subscription.exception.SubscriptionDomainErrorCode;
 
 @Getter
 @Entity
@@ -67,7 +69,14 @@ public class Subscription extends BaseTimeEntity {
                 .build();
     }
 
-    public void cancelSubscription() {
+    public void cancel() {
+        if (this.status == SubscriptionStatus.CANCELED) {
+            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_CANCELED);
+        }
+        if (this.endAt.isBefore(LocalDateTime.now())) {
+            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED);
+        }
+
         this.status = SubscriptionStatus.CANCELED;
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/exception/SubscriptionDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/exception/SubscriptionDomainErrorCode.java
@@ -1,0 +1,16 @@
+package org.cherrypic.subscription.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum SubscriptionDomainErrorCode implements BaseErrorCode {
+    ALREADY_CANCELED(409, "이미 해지된 구독입니다."),
+    ALREADY_ENDED(400, "이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/AlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/AlbumTest.java
@@ -1,11 +1,10 @@
 package org.cherrypic.album.entity;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 import org.cherrypic.album.enums.AlbumPlan;
-import org.cherrypic.common.exception.DomainErrorCode;
+import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.exception.CustomException;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +18,7 @@ class AlbumTest {
         // when & then
         assertThatThrownBy(() -> album.increaseCapacity(BigDecimal.valueOf(10000)))
                 .isInstanceOf(CustomException.class)
-                .hasMessage(DomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT.getMessage());
+                .hasMessage(AlbumDomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT.getMessage());
     }
 
     @Test
@@ -30,6 +29,6 @@ class AlbumTest {
         // when & then
         assertThatThrownBy(() -> album.decreaseCapacity(BigDecimal.valueOf(1)))
                 .isInstanceOf(CustomException.class)
-                .hasMessage(DomainErrorCode.ALBUM_CAPACITY_DECREASE_UNDER_ZERO.getMessage());
+                .hasMessage(AlbumDomainErrorCode.ALBUM_CAPACITY_DECREASE_UNDER_ZERO.getMessage());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #166 

---
## 📌 작업 내용 및 특이사항
* 앨범 생성 시 결제 상태 검증 책임을 Payment 도메인 내부로 이동했습니다.
  * 앨범 서비스 레이어에서 결제 상태, 사용 여부, 결제 목적 등의 도메인 규칙까지 판단하고 있어 응집도가 떨어진다고 판단했습니다.
  * 따라서 앨범과의 연관관계를 맺기 전에 결제 객체 내부에서 유효성 검증을 수행하도록 구조를 개선했습니다.
* 구독 해지 시 상태 검증 로직을 Subscription 도메인으로 위임했습니다.
  * 만료 여부, 해지 여부 등의 검증 로직이 서비스에 위치해 있었으나, 해당 검증은 도메인 고유의 행위로 판단되어 책임을 이동했습니다.