### PR TITLE
feat: 구독 갱신 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
@@ -2,8 +2,10 @@ package org.cherrypic.domain.subscription.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.domain.album.dto.response.*;
+import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
 import org.cherrypic.domain.subscription.service.SubscriptionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,5 +23,12 @@ public class SubscriptionController {
     public ResponseEntity<Void> subscriptionCancel(@PathVariable Long albumId) {
         subscriptionService.cancelSubscription(albumId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/renew")
+    @Operation(summary = "구독 갱신", description = "해지된 유료 앨범의 구독을 다시 갱신합니다.")
+    public SubscriptionRenewResponse subscriptionRenew(
+            @PathVariable Long albumId, @Valid @RequestBody SubscriptionRenewRequest request) {
+        return subscriptionService.renewSubscription(albumId, request);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/dto/request/SubscriptionRenewRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/dto/request/SubscriptionRenewRequest.java
@@ -1,0 +1,9 @@
+package org.cherrypic.domain.subscription.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record SubscriptionRenewRequest(
+        @NotNull(message = "결제 ID는 비워둘 수 없습니다.")
+                @Schema(description = "결제 검증 후 받은 결제 ID", example = "1")
+                Long paymentId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/dto/response/SubscriptionRenewResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/dto/response/SubscriptionRenewResponse.java
@@ -1,0 +1,36 @@
+package org.cherrypic.domain.subscription.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
+
+public record SubscriptionRenewResponse(
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "구독 시작일", example = "2024-08-21")
+                LocalDateTime subscriptionStartAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "구독 종료일", example = "2024-09-20")
+                LocalDateTime subscriptionEndAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "다음 결제일", example = "2024-09-21")
+                LocalDateTime subscriptionNextBillingAt,
+        @Schema(description = "구독 상태", example = "ACTIVE") SubscriptionStatus status) {
+    public static SubscriptionRenewResponse from(Subscription subscription) {
+        return new SubscriptionRenewResponse(
+                subscription.getStartAt(),
+                subscription.getEndAt(),
+                subscription.getNextBillingAt(),
+                subscription.getStatus());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/exception/SubscriptionErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/exception/SubscriptionErrorCode.java
@@ -9,8 +9,6 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum SubscriptionErrorCode implements BaseErrorCode {
     SUBSCRIPTION_NOT_FOUND(404, "구독 정보가 존재하지 않습니다."),
     SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN(400, "BASIC 플랜은 구독 기능을 지원하지 않습니다."),
-    SUBSCRIPTION_ALREADY_CANCELED(409, "이미 해지된 구독입니다."),
-    SUBSCRIPTION_ALREADY_ENDED(400, "이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
@@ -1,5 +1,10 @@
 package org.cherrypic.domain.subscription.service;
 
+import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
+
 public interface SubscriptionService {
     void cancelSubscription(Long albumId);
+
+    SubscriptionRenewResponse renewSubscription(Long albumId, SubscriptionRenewRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -6,6 +6,10 @@ import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
+import org.cherrypic.domain.payment.repository.PaymentRepository;
+import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
 import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.exception.CustomException;
@@ -13,6 +17,8 @@ import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.payment.entity.Payment;
+import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.subscription.entity.Subscription;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +33,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     private final SubscriptionRepository subscriptionRepository;
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
+    private final PaymentRepository paymentRepository;
 
     @Override
     public void cancelSubscription(Long albumId) {
@@ -34,11 +41,33 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
-        validateSubscriptionSupported(album.getPlan());
+        validateSubscriptionSupported(album);
 
         final Subscription subscription = getSubscriptionByAlbumId(album.getId());
 
         subscription.cancel();
+    }
+
+    @Override
+    public SubscriptionRenewResponse renewSubscription(
+            Long albumId, SubscriptionRenewRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionSupported(album);
+
+        final Payment payment = getPaidPaymentById(request.paymentId());
+
+        validatePaymentMemberMismatch(payment, currentMember);
+
+        payment.updatePayment(PaymentPurpose.RENEWAL, album);
+
+        final Subscription subscription = getSubscriptionByAlbumId(album.getId());
+
+        subscription.renew();
+
+        return SubscriptionRenewResponse.from(subscription);
     }
 
     private Album getAlbumById(Long albumId) {
@@ -61,8 +90,8 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         }
     }
 
-    private void validateSubscriptionSupported(AlbumPlan plan) {
-        if (plan == AlbumPlan.BASIC) {
+    private void validateSubscriptionSupported(Album album) {
+        if (album.getPlan() == AlbumPlan.BASIC) {
             throw new CustomException(
                     SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN);
         }
@@ -73,5 +102,17 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .findByAlbumId(albumId)
                 .orElseThrow(
                         () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
+    private Payment getPaidPaymentById(Long paymentId) {
+        return paymentRepository
+                .findById(paymentId)
+                .orElseThrow(() -> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    private void validatePaymentMemberMismatch(Payment payment, Member member) {
+        if (!payment.getMember().getId().equals(member.getId())) {
+            throw new CustomException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH);
+        }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -226,6 +226,8 @@ class AlbumServiceTest extends IntegrationTest {
                         new AlbumCreateRequest(
                                 "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, true);
 
+                LocalDateTime startAt = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+
                 // when
                 albumService.createAlbum(request);
 
@@ -275,25 +277,16 @@ class AlbumServiceTest extends IntegrationTest {
                                                 subscription
                                                         .getStartAt()
                                                         .truncatedTo(ChronoUnit.MINUTES))
-                                        .isEqualTo(
-                                                LocalDateTime.now()
-                                                        .truncatedTo(ChronoUnit.MINUTES)),
+                                        .isEqualTo(startAt),
                         () ->
                                 assertThat(subscription.getEndAt().truncatedTo(ChronoUnit.MINUTES))
-                                        .isEqualTo(
-                                                LocalDateTime.now()
-                                                        .truncatedTo(ChronoUnit.MINUTES)
-                                                        .plusMonths(1)),
+                                        .isEqualTo(startAt.plusMonths(1)),
                         () ->
                                 assertThat(
                                                 subscription
                                                         .getNextBillingAt()
                                                         .truncatedTo(ChronoUnit.MINUTES))
-                                        .isEqualTo(
-                                                LocalDateTime.now()
-                                                        .truncatedTo(ChronoUnit.MINUTES)
-                                                        .plusMonths(1)
-                                                        .plusDays(1)));
+                                        .isEqualTo(startAt.plusMonths(1).minusDays(3)));
             }
 
             @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -174,8 +174,8 @@ class SubscriptionControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALREADY_ENDED"))
-                    .andExpect(jsonPath("$.data.message").value("이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_EXPIRED"))
+                    .andExpect(jsonPath("$.data.message").value("이미 만료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
         }
     }
 
@@ -477,7 +477,7 @@ class SubscriptionControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("ALREADY_ENDED"))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_EXPIRED"))
                     .andExpect(jsonPath("$.data.message").value("이미 만료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
         }
     }

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -6,18 +6,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.subscription.controller.SubscriptionController;
+import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
 import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
 import org.cherrypic.domain.subscription.service.SubscriptionService;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.payment.exception.PaymentDomainErrorCode;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
+import org.cherrypic.subscription.exception.SubscriptionDomainErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -140,7 +148,7 @@ class SubscriptionControllerTest {
         @Test
         void 이미_해지된_구독이면_예외가_발생한다() throws Exception {
             // given
-            willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_CANCELED))
+            willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_CANCELED))
                     .given(subscriptionService)
                     .cancelSubscription(1L);
 
@@ -150,14 +158,14 @@ class SubscriptionControllerTest {
             perform.andExpect(status().isConflict())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
-                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_ALREADY_CANCELED"))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_CANCELED"))
                     .andExpect(jsonPath("$.data.message").value("이미 해지된 구독입니다."));
         }
 
         @Test
         void 종료된_구독이면_예외가_발생한다() throws Exception {
             // given
-            willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_ENDED))
+            willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED))
                     .given(subscriptionService)
                     .cancelSubscription(1L);
 
@@ -167,7 +175,309 @@ class SubscriptionControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_ALREADY_ENDED"))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_ENDED"))
+                    .andExpect(jsonPath("$.data.message").value("이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 구독_갱신_요청_시 {
+
+        @Test
+        void 유효한_요청이면_구독을_갱신하고_갱신_정보를_반환한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+            SubscriptionRenewResponse response =
+                    new SubscriptionRenewResponse(
+                            LocalDateTime.of(2025, 7, 1, 0, 0),
+                            LocalDateTime.of(2025, 8, 1, 0, 0),
+                            LocalDateTime.of(2025, 8, 2, 0, 0),
+                            SubscriptionStatus.ACTIVE);
+
+            given(subscriptionService.renewSubscription(1L, request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.subscriptionStartAt").value("2025-07-01"))
+                    .andExpect(jsonPath("$.data.subscriptionEndAt").value("2025-08-01"))
+                    .andExpect(jsonPath("$.data.subscriptionNextBillingAt").value("2025-08-02"))
+                    .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void BASIC_플랜인_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(
+                            new CustomException(
+                                    SubscriptionErrorCode
+                                            .SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.data.code")
+                                    .value("SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN"))
+                    .andExpect(jsonPath("$.data.message").value("BASIC 플랜은 구독 기능을 지원하지 않습니다."));
+        }
+
+        @Test
+        void 결제가_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("PAYMENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("결제 정보가 존재하지 않습니다."));
+        }
+
+        @Test
+        void 결제한_회원과_구독을_갱신하려는_회원이_일치하지_않으면_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("PAYMENT_MEMBER_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("결제한 사용자와 일치하지 않습니다."));
+        }
+
+        @Test
+        void 결제상태가_PAID가_아니면_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(PaymentDomainErrorCode.NOT_PAID));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_PAID"))
+                    .andExpect(jsonPath("$.data.message").value("아직 결제가 완료되지 않았습니다."));
+        }
+
+        @Test
+        void 결제가_이미_사용된_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(PaymentDomainErrorCode.ALREADY_USED_PAYMENT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_USED_PAYMENT"))
+                    .andExpect(jsonPath("$.data.message").value("해당 결제는 이미 사용되었습니다."));
+        }
+
+        @Test
+        void 결제의_목적이_구독_갱신과_일치하지_않으면_예외가_발생한다() throws Exception {
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(
+                            new CustomException(PaymentDomainErrorCode.PAYMENT_PURPOSE_MISMATCH));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("PAYMENT_PURPOSE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("결제 목적이 요청하려는 작업과 일치하지 않습니다."));
+        }
+
+        @Test
+        void 구독이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("구독 정보가 존재하지 않습니다."));
+        }
+
+        @Test
+        void 이미_구독_중인_상태면_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_ACTIVE));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_ACTIVE"))
+                    .andExpect(jsonPath("$.data.message").value("이미 구독 중인 상태입니다."));
+        }
+
+        @Test
+        void 종료된_구독이면_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_ENDED"))
                     .andExpect(jsonPath("$.data.message").value("이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
         }
     }

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -395,6 +395,7 @@ class SubscriptionControllerTest {
 
         @Test
         void 결제의_목적이_구독_갱신과_일치하지_않으면_예외가_발생한다() throws Exception {
+            // given
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 
             given(subscriptionService.renewSubscription(1L, request))

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
-import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.subscription.controller.SubscriptionController;
@@ -165,7 +164,7 @@ class SubscriptionControllerTest {
         @Test
         void 종료된_구독이면_예외가_발생한다() throws Exception {
             // given
-            willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED))
+            willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_EXPIRED))
                     .given(subscriptionService)
                     .cancelSubscription(1L);
 
@@ -461,12 +460,12 @@ class SubscriptionControllerTest {
         }
 
         @Test
-        void 종료된_구독이면_예외가_발생한다() throws Exception {
+        void 만료된_구독이면_예외가_발생한다() throws Exception {
             // given
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 
             given(subscriptionService.renewSubscription(1L, request))
-                    .willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED));
+                    .willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_EXPIRED));
 
             // when & then
             ResultActions perform =
@@ -479,7 +478,7 @@ class SubscriptionControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("ALREADY_ENDED"))
-                    .andExpect(jsonPath("$.data.message").value("이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
+                    .andExpect(jsonPath("$.data.message").value("이미 만료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -310,7 +310,7 @@ class SubscriptionServiceTest extends IntegrationTest {
                                             subscription
                                                     .getNextBillingAt()
                                                     .truncatedTo(ChronoUnit.MINUTES))
-                                    .isEqualTo(previousEndAt.plusMonths(1).plusDays(1)));
+                                    .isEqualTo(previousEndAt.plusMonths(1).minusDays(3)));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -270,7 +270,7 @@ class SubscriptionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 유효한_요청이면_구독을_갱신하고_결제에_앨범을_정상_연결한다() {
+        void 유효한_요청이면_구독을_갱신하고_결제에_앨범을_연결한다() {
             // given
             Subscription canceledSubscription = subscriptionRepository.findById(1L).get();
             LocalDateTime previousEndAt =
@@ -303,17 +303,14 @@ class SubscriptionServiceTest extends IntegrationTest {
                                     .extracting("id", "member.id", "album.id", "status")
                                     .containsExactly(1L, 1L, 1L, SubscriptionStatus.ACTIVE),
                     () ->
-                            assertThat(subscription.getStartAt().truncatedTo(ChronoUnit.MINUTES))
-                                    .isEqualTo(previousEndAt.plusDays(1)),
-                    () ->
                             assertThat(subscription.getEndAt().truncatedTo(ChronoUnit.MINUTES))
-                                    .isEqualTo(previousEndAt.plusMonths(1).plusDays(1)),
+                                    .isEqualTo(previousEndAt.plusMonths(1)),
                     () ->
                             assertThat(
                                             subscription
                                                     .getNextBillingAt()
                                                     .truncatedTo(ChronoUnit.MINUTES))
-                                    .isEqualTo(previousEndAt.plusMonths(1).plusDays(2)));
+                                    .isEqualTo(previousEndAt.plusMonths(1).plusDays(1)));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
@@ -13,28 +14,40 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.payment.exception.PaymentErrorCode;
+import org.cherrypic.domain.payment.repository.PaymentRepository;
+import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
 import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.domain.subscription.service.SubscriptionService;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.payment.entity.Payment;
+import org.cherrypic.payment.enums.PaymentPurpose;
+import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.payment.exception.PaymentDomainErrorCode;
 import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
+import org.cherrypic.subscription.exception.SubscriptionDomainErrorCode;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class SubscriptionServiceTest extends IntegrationTest {
 
+    @Autowired private TransactionUtil transactionUtil;
+
     @Autowired private SubscriptionService subscriptionService;
     @Autowired private SubscriptionRepository subscriptionRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private ParticipantRepository participantRepository;
+    @Autowired private PaymentRepository paymentRepository;
 
     @MockitoBean private MemberUtil memberUtil;
 
@@ -144,7 +157,7 @@ class SubscriptionServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> subscriptionService.cancelSubscription(2L))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_CANCELED.getMessage());
+                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_CANCELED.getMessage());
         }
 
         @Test
@@ -152,7 +165,289 @@ class SubscriptionServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> subscriptionService.cancelSubscription(3L))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_ALREADY_ENDED.getMessage());
+                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_ENDED.getMessage());
+        }
+    }
+
+    @Nested
+    class 구독을_갱신할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.PRO, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.PRO, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, false);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.BASIC, false);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.PREMIUM, false);
+            Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumPlan.PREMIUM, false);
+            Album album7 = Album.createAlbum("testAlbum7", "testURL7", AlbumPlan.PREMIUM, false);
+            albumRepository.saveAll(
+                    List.of(album1, album2, album3, album4, album5, album6, album7));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.STANDARD);
+            Participant participant3 =
+                    Participant.createParticipant(member1, album4, ParticipantRole.HOST);
+            Participant participant4 =
+                    Participant.createParticipant(member1, album5, ParticipantRole.HOST);
+            Participant participant5 =
+                    Participant.createParticipant(member1, album6, ParticipantRole.HOST);
+            Participant participant6 =
+                    Participant.createParticipant(member1, album7, ParticipantRole.HOST);
+            participantRepository.saveAll(
+                    List.of(
+                            participant1,
+                            participant2,
+                            participant3,
+                            participant4,
+                            participant5,
+                            participant6));
+
+            // 15일 전에 시작되어 현재는 해지된 구독
+            Subscription subscription1 =
+                    Subscription.createSubscription(
+                            member1, album1, LocalDateTime.now().minusDays(15));
+            subscription1.cancel();
+
+            // 구독 중
+            Subscription subscription3 =
+                    Subscription.createSubscription(member1, album6, LocalDateTime.now());
+
+            // 종료된 구독
+            Subscription subscription2 =
+                    Subscription.createSubscription(
+                            member1, album7, LocalDateTime.of(2025, 7, 1, 0, 0));
+
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
+
+            // 완료된 결제
+            Payment payment1 =
+                    Payment.createPayment(member1, "testMerchantUid", 5900, PaymentPurpose.RENEWAL);
+            payment1.updatePayment(
+                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+
+            // 완료된 다른 회원의 결제
+            Payment payment2 =
+                    Payment.createPayment(member2, "testMerchantUid", 5900, PaymentPurpose.RENEWAL);
+            payment2.updatePayment(
+                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+
+            // 완료되지 않은 결제
+            Payment payment3 =
+                    Payment.createPayment(member1, "testMerchantUid", 5900, PaymentPurpose.RENEWAL);
+
+            // 유료 앨범 생성에 쓰인 완료된 결제
+            Payment payment4 =
+                    Payment.createPayment(
+                            member1, "testMerchantUid", 5900, PaymentPurpose.CREATION);
+            payment4.updatePayment(
+                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+            payment4.updatePayment(PaymentPurpose.CREATION, album1);
+
+            // 구독 업그레이드 목적으로 쓰인 결제
+            Payment payment5 =
+                    Payment.createPayment(
+                            member1, "testMerchantUid", 12900, PaymentPurpose.UPGRADE);
+            payment5.updatePayment(
+                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+
+            paymentRepository.saveAll(List.of(payment1, payment2, payment3, payment4, payment5));
+        }
+
+        @Test
+        void 유효한_요청이면_구독을_갱신하고_결제에_앨범을_정상_연결한다() {
+            // given
+            Subscription canceledSubscription = subscriptionRepository.findById(1L).get();
+            LocalDateTime previousEndAt =
+                    canceledSubscription.getEndAt().truncatedTo(ChronoUnit.MINUTES);
+
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when
+            subscriptionService.renewSubscription(1L, request);
+
+            // then
+            Album album =
+                    transactionUtil.getResult(
+                            () -> {
+                                Album loadedAlbum = albumRepository.findById(1L).get();
+                                loadedAlbum.getPayments().get(0);
+                                loadedAlbum.getSubscription();
+                                return loadedAlbum;
+                            });
+            Payment payment = album.getPayments().get(0);
+            Subscription subscription = album.getSubscription();
+
+            Assertions.assertAll(
+                    () ->
+                            assertThat(payment)
+                                    .extracting("album.id", "status")
+                                    .containsExactly(1L, PaymentStatus.PAID),
+                    () ->
+                            assertThat(subscription)
+                                    .extracting("id", "member.id", "album.id", "status")
+                                    .containsExactly(1L, 1L, 1L, SubscriptionStatus.ACTIVE),
+                    () ->
+                            assertThat(subscription.getStartAt().truncatedTo(ChronoUnit.MINUTES))
+                                    .isEqualTo(previousEndAt.plusDays(1)),
+                    () ->
+                            assertThat(subscription.getEndAt().truncatedTo(ChronoUnit.MINUTES))
+                                    .isEqualTo(previousEndAt.plusMonths(1).plusDays(1)),
+                    () ->
+                            assertThat(
+                                            subscription
+                                                    .getNextBillingAt()
+                                                    .truncatedTo(ChronoUnit.MINUTES))
+                                    .isEqualTo(previousEndAt.plusMonths(1).plusDays(2)));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(999L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void BASIC_플랜인_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(4L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(
+                            SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN
+                                    .getMessage());
+        }
+
+        @Test
+        void 결제가_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(999L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.PAYMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 결제한_회원과_구독을_갱신하려는_회원이_일치하지_않으면_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(2L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH.getMessage());
+        }
+
+        @Test
+        void 결제상태가_PAID가_아니면_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(3L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentDomainErrorCode.NOT_PAID.getMessage());
+        }
+
+        @Test
+        void 결제가_이미_사용된_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(4L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentDomainErrorCode.ALREADY_USED_PAYMENT.getMessage());
+        }
+
+        @Test
+        void 결제의_목적이_구독_갱신과_일치하지_않으면_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(5L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentDomainErrorCode.PAYMENT_PURPOSE_MISMATCH.getMessage());
+        }
+
+        @Test
+        void 구독이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(5L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 이미_구독_중인_상태면_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(6L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_ACTIVE.getMessage());
+        }
+
+        @Test
+        void 종료된_구독이면_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(7L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_ENDED.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -165,7 +165,7 @@ class SubscriptionServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> subscriptionService.cancelSubscription(3L))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_ENDED.getMessage());
+                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_EXPIRED.getMessage());
         }
     }
 
@@ -440,14 +440,14 @@ class SubscriptionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 종료된_구독이면_예외가_발생한다() {
+        void 만료된_구독이면_예외가_발생한다() {
             // given
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 
             // when & then
             assertThatThrownBy(() -> subscriptionService.renewSubscription(7L, request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_ENDED.getMessage());
+                    .hasMessage(SubscriptionDomainErrorCode.ALREADY_EXPIRED.getMessage());
         }
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -74,7 +74,7 @@ public class Subscription extends BaseTimeEntity {
             throw new CustomException(SubscriptionDomainErrorCode.ALREADY_CANCELED);
         }
         if (this.endAt.isBefore(LocalDateTime.now())) {
-            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED);
+            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_EXPIRED);
         }
 
         this.status = SubscriptionStatus.CANCELED;
@@ -82,7 +82,7 @@ public class Subscription extends BaseTimeEntity {
 
     public void renew() {
         if (this.endAt.isBefore(LocalDateTime.now())) {
-            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED);
+            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_EXPIRED);
         }
         if (this.status == SubscriptionStatus.ACTIVE) {
             throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ACTIVE);

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -79,4 +79,18 @@ public class Subscription extends BaseTimeEntity {
 
         this.status = SubscriptionStatus.CANCELED;
     }
+
+    public void renew() {
+        if (this.status == SubscriptionStatus.ACTIVE) {
+            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ACTIVE);
+        }
+        if (this.endAt.isBefore(LocalDateTime.now())) {
+            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED);
+        }
+
+        this.status = SubscriptionStatus.ACTIVE;
+        this.startAt = this.endAt.plusDays(1);
+        this.endAt = this.startAt.plusMonths(1);
+        this.nextBillingAt = this.endAt.plusDays(1);
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -65,7 +65,7 @@ public class Subscription extends BaseTimeEntity {
                 .status(SubscriptionStatus.ACTIVE)
                 .startAt(paidAt)
                 .endAt(paidAt.plusMonths(1))
-                .nextBillingAt(paidAt.plusMonths(1).plusDays(1))
+                .nextBillingAt(paidAt.plusMonths(1).minusDays(3))
                 .build();
     }
 
@@ -90,6 +90,6 @@ public class Subscription extends BaseTimeEntity {
 
         this.status = SubscriptionStatus.ACTIVE;
         this.endAt = this.endAt.plusMonths(1);
-        this.nextBillingAt = this.endAt.plusDays(1);
+        this.nextBillingAt = this.endAt.minusDays(3);
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -81,11 +81,11 @@ public class Subscription extends BaseTimeEntity {
     }
 
     public void renew() {
-        if (this.status == SubscriptionStatus.ACTIVE) {
-            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ACTIVE);
-        }
         if (this.endAt.isBefore(LocalDateTime.now())) {
             throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ENDED);
+        }
+        if (this.status == SubscriptionStatus.ACTIVE) {
+            throw new CustomException(SubscriptionDomainErrorCode.ALREADY_ACTIVE);
         }
 
         this.status = SubscriptionStatus.ACTIVE;

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -89,8 +89,7 @@ public class Subscription extends BaseTimeEntity {
         }
 
         this.status = SubscriptionStatus.ACTIVE;
-        this.startAt = this.endAt.plusDays(1);
-        this.endAt = this.startAt.plusMonths(1);
+        this.endAt = this.endAt.plusMonths(1);
         this.nextBillingAt = this.endAt.plusDays(1);
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/exception/SubscriptionDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/exception/SubscriptionDomainErrorCode.java
@@ -8,6 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum SubscriptionDomainErrorCode implements BaseErrorCode {
     ALREADY_CANCELED(409, "이미 해지된 구독입니다."),
+    ALREADY_ACTIVE(409, "이미 구독 중인 상태입니다."),
     ALREADY_ENDED(400, "이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."),
     ;
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/exception/SubscriptionDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/exception/SubscriptionDomainErrorCode.java
@@ -9,7 +9,7 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum SubscriptionDomainErrorCode implements BaseErrorCode {
     ALREADY_CANCELED(409, "이미 해지된 구독입니다."),
     ALREADY_ACTIVE(409, "이미 구독 중인 상태입니다."),
-    ALREADY_ENDED(400, "이미 종료된 구독입니다. 해지 또는 갱신할 수 없습니다."),
+    ALREADY_EXPIRED(400, "이미 만료된 구독입니다. 해지 또는 갱신할 수 없습니다."),
     ;
 
     private final int status;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #159

---
## 📌 작업 내용 및 특이사항
* 구독 갱신 API를 구현하였습니다.
* 기존 구독의 종료일을 기준으로 새로운 구독 기간을 설정하였습니다.
  * 새로운 종료일: 기존 구독의 종료일로부터 1개월 후
  * 다음 결제일: 새로운 종료일 3일 전
* 결제 시작일은 갱신 시 변경하지 않으며, 종료일만 연장되도록 처리하였습니다.
* 사용자가 제출한 결제 정보가 유효한지 검증한 뒤, 해당 결제에 앨범을 연결하고 구독을 갱신합니다.
* 본 API는 추후 구현 예정인 정기결제 로직과는 별개로, 사용자가 직접 구독을 갱신해야 하는 케이스를 처리하기 위해 제공됩니다.
  * 예를 들어, 사용자가 구독을 직접 해지한 뒤 다시 갱신하려는 경우나, 앨범의 방장 권한이 이전되어 새로운 사용자가 구독을 시작해야 하는 경우를 고려하였습니다.
  * 한 사용자가 2개월 이상 연속 구독하는 경우에는 별도의 정기결제 흐름으로 관리할 예정입니다.
* 또한, 구독 생성 시에도 다음 결제일을 종료일 3일 전으로 설정하였습니다.
  * 이는 추후 정기결제 로직과 자연스럽게 연결되도록, 결제가 종료일 이전에 이루어지는 흐름이 더 자연스럽다고 판단하여 적용하였습니다.

---
## 📚 참고사항
* 구독의 종료일이 현재 시각을 지난 경우 SubscriptionStatus를 자동으로 ENDED로 전환해야 합니다.
* 이를 위해 배치 작업 또는 스케줄러를 통해 주기적으로 상태를 갱신하는 방식으로 처리하도록 하겠습니다.