### PR TITLE
feat: 임시 앨범 생성 기능 구현 

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
@@ -1,0 +1,29 @@
+package org.cherrypic.domain.tempalbum.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.tempalbum.dto.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.service.TempAlbumService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "9. 임시 앨범 API", description = "임시 앨범 관련 API입니다.")
+public class TempAlbumController {
+
+    private final TempAlbumService tempAlbumService;
+
+    @PostMapping("/album/{albumId}/temp-album")
+    @Operation(summary = "임시 앨범 생성 API", description = "임시 앨범을 생성합니다.")
+    public ResponseEntity<Void> tempAlbumCreate(
+            @PathVariable Long albumId, @Valid @RequestBody TempAlbumCreateRequest request) {
+        tempAlbumService.createTempAlbum(albumId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/TempAlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/TempAlbumCreateRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.tempalbum.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record TempAlbumCreateRequest(
+        @NotEmpty(message = "임시 앨범으로 공유할 사진들은 비워둘 수 없습니다.")
+                @Schema(description = "임시 앨범으로 공유할 사진들의 ID", example = "[1,2,3,4]")
+                List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/TempAlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/TempAlbumCreateRequest.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record TempAlbumCreateRequest(
-        @NotEmpty(message = "임시 앨범으로 공유할 사진들은 비워둘 수 없습니다.")
-                @Schema(description = "임시 앨범으로 공유할 사진들의 ID", example = "[1,2,3,4]")
+        @NotEmpty(message = "임시 앨범으로 공유할 이미지 ID들은 비워둘 수 없습니다.")
+                @Schema(description = "임시 앨범으로 공유할 이미지들의 ID", example = "[1,2,3,4]")
                 List<Long> imageIds) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/repository/TempAlbumImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/repository/TempAlbumImageRepository.java
@@ -1,0 +1,6 @@
+package org.cherrypic.domain.tempalbum.repository;
+
+import org.cherrypic.tempalbum.TempAlbumImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TempAlbumImageRepository extends JpaRepository<TempAlbumImage, Long> {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/repository/TempAlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/repository/TempAlbumRepository.java
@@ -1,0 +1,6 @@
+package org.cherrypic.domain.tempalbum.repository;
+
+import org.cherrypic.tempalbum.TempAlbum;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TempAlbumRepository extends JpaRepository<TempAlbum, Long> {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
@@ -1,0 +1,8 @@
+package org.cherrypic.domain.tempalbum.service;
+
+import org.cherrypic.domain.tempalbum.dto.TempAlbumCreateRequest;
+
+public interface TempAlbumService {
+
+    void createTempAlbum(Long albumId, TempAlbumCreateRequest request);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
@@ -1,9 +1,8 @@
 package org.cherrypic.domain.tempalbum.service;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumPlan;
@@ -22,9 +21,11 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.tempalbum.TempAlbum;
 import org.cherrypic.tempalbum.TempAlbumImage;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class TempAlbumServiceImpl implements TempAlbumService {
 
     private final MemberUtil memberUtil;
@@ -60,17 +61,15 @@ public class TempAlbumServiceImpl implements TempAlbumService {
         tempAlbumRepository.save(tempAlbum);
     }
 
-    private Date getExpirationByAlbumPlan(AlbumPlan albumPlan) {
-        Date expiration = new Date();
-        long expTimeMillis = expiration.getTime();
+    private LocalDate getExpirationByAlbumPlan(AlbumPlan albumPlan) {
+        LocalDate expiration = LocalDate.now();
 
         if (AlbumPlan.BASIC == albumPlan) {
-            expTimeMillis += TimeUnit.DAYS.toMillis(3);
+            expiration = expiration.plusDays(3);
         } else {
-            expTimeMillis += TimeUnit.DAYS.toMillis(14);
+            expiration = expiration.plusDays(14);
         }
 
-        expiration.setTime(expTimeMillis);
         return expiration;
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
@@ -1,0 +1,105 @@
+package org.cherrypic.domain.tempalbum.service;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.image.repository.ImageRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.tempalbum.dto.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.repository.TempAlbumRepository;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.image.entity.Image;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.tempalbum.TempAlbum;
+import org.cherrypic.tempalbum.TempAlbumImage;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TempAlbumServiceImpl implements TempAlbumService {
+
+    private final MemberUtil memberUtil;
+
+    private final ParticipantRepository participantRepository;
+    private final ImageRepository imageRepository;
+    private final AlbumRepository albumRepository;
+    private final TempAlbumRepository tempAlbumRepository;
+
+    @Override
+    public void createTempAlbum(Long albumId, TempAlbumCreateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateParticipantAuthority(currentMember.getId(), album.getId());
+
+        List<Long> distinctImageIds =
+                request.imageIds().stream().filter(Objects::nonNull).distinct().toList();
+        final List<Image> images = imageRepository.findAllById(distinctImageIds);
+
+        validateImagesInAlbum(images, album);
+
+        TempAlbum tempAlbum =
+                TempAlbum.createTempAlbum(
+                        album, currentMember, getExpirationByAlbumPlan(album.getPlan()));
+
+        List<TempAlbumImage> tempAlbumImages =
+                images.stream()
+                        .map(image -> TempAlbumImage.createTempAlbumImage(tempAlbum, image))
+                        .toList();
+
+        tempAlbum.addTempAlbumImages(tempAlbumImages);
+        tempAlbumRepository.save(tempAlbum);
+    }
+
+    private Date getExpirationByAlbumPlan(AlbumPlan albumPlan) {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+
+        if (AlbumPlan.BASIC == albumPlan) {
+            expTimeMillis += TimeUnit.DAYS.toMillis(3);
+        } else {
+            expTimeMillis += TimeUnit.DAYS.toMillis(14);
+        }
+
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    private void validateParticipantAuthority(Long memberId, Long albumId) {
+        Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
+
+        if (participant.getRole().equals(ParticipantRole.LIMITED)) {
+            throw new CustomException(AlbumErrorCode.LIMITED_AUTHORITY);
+        }
+    }
+
+    private void validateImagesInAlbum(List<Image> images, Album album) {
+        boolean containsNotInAlbum =
+                images.stream().anyMatch(ei -> !ei.getAlbum().getId().equals(album.getId()));
+
+        if (containsNotInAlbum) {
+            throw new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM);
+        }
+    }
+
+    private Participant getParticipantByMemberIdAndAlbumId(Long memberId, Long albumId) {
+        return participantRepository
+                .findByMemberIdAndAlbumId(memberId, albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
+    private Album getAlbumById(Long albumId) {
+        return albumRepository
+                .findById(albumId)
+                .orElseThrow(() -> new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -55,8 +55,8 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 @RecordApplicationEvents
 class ImageServiceTest extends IntegrationTest {
 
-    @MockitoBean MemberUtil memberUtil;
-    @MockitoBean S3Util s3Util;
+    @MockitoBean private MemberUtil memberUtil;
+    @MockitoBean private S3Util s3Util;
 
     @Autowired private ImageService imageService;
     @Autowired private ApplicationEvents applicationEvents;

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/controller/TempAlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/controller/TempAlbumControllerTest.java
@@ -1,0 +1,170 @@
+package org.cherrypic.tempalbum.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.tempalbum.controller.TempAlbumController;
+import org.cherrypic.domain.tempalbum.dto.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.service.TempAlbumService;
+import org.cherrypic.exception.CustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(TempAlbumController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TempAlbumControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private TempAlbumService tempAlbumService;
+
+    @Nested
+    class 임시_앨범을_생성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_임시_앨범을_생성하고_임시_앨범에_이미지를_저장하며_NO_CONTENT를_반환한다() throws Exception {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 2L));
+
+            willDoNothing().given(tempAlbumService).createTempAlbum(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/album/1/temp-album")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(tempAlbumService)
+                    .createTempAlbum(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/album/1/temp-album")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_임시_앨범을_생성하면_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(tempAlbumService)
+                    .createTempAlbum(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/album/1/temp-album")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_임시_앨범을_생성하면_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY))
+                    .given(tempAlbumService)
+                    .createTempAlbum(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/album/1/temp-album")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Test
+        void 앨범에_속하지_않은_이미지를_추가하면_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 2L));
+
+            willThrow(new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM))
+                    .given(tempAlbumService)
+                    .createTempAlbum(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/album/1/temp-album")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("IMAGES_NOT_IN_ALBUM"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속해 있지 않은 이미지가 포함되어 있습니다."));
+        }
+
+        @Test
+        void 임시_앨범으로_공유할_이미지_ID들을_비워두면_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of());
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/album/1/temp-album")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(
+                            jsonPath("$.data.message").value("임시 앨범으로 공유할 이미지 ID들은 비워둘 수 없습니다."));
+        }
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
@@ -1,0 +1,160 @@
+package org.cherrypic.tempalbum.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.cherrypic.IntegrationTest;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.domain.album.exception.AlbumErrorCode;
+import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.image.repository.ImageRepository;
+import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.tempalbum.dto.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.repository.TempAlbumImageRepository;
+import org.cherrypic.domain.tempalbum.repository.TempAlbumRepository;
+import org.cherrypic.domain.tempalbum.service.TempAlbumService;
+import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.util.MemberUtil;
+import org.cherrypic.global.util.TransactionUtil;
+import org.cherrypic.image.entity.Image;
+import org.cherrypic.member.entity.Member;
+import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.participant.entity.Participant;
+import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.tempalbum.TempAlbum;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class TempAlbumServiceTest extends IntegrationTest {
+
+    @MockitoBean private MemberUtil memberUtil;
+    @Autowired private TransactionUtil transactionUtil;
+
+    @Autowired private TempAlbumService tempAlbumService;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private AlbumRepository albumRepository;
+    @Autowired private ParticipantRepository participantRepository;
+    @Autowired private ImageRepository imageRepository;
+    @Autowired private TempAlbumRepository tempAlbumRepository;
+    @Autowired private TempAlbumImageRepository tempAlbumImageRepository;
+
+    @Nested
+    class 임시_앨범을_생성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
+
+            Image image1 =
+                    Image.createImage(album1, member.getId(), "testImageUrl1", LocalDateTime.now());
+            Image image2 =
+                    Image.createImage(album1, member.getId(), "testImageUrl2", LocalDateTime.now());
+            Image image3 =
+                    Image.createImage(album2, member.getId(), "testImageUrl3", LocalDateTime.now());
+            Image image4 =
+                    Image.createImage(album3, member.getId(), "testImageUrl4", LocalDateTime.now());
+            imageRepository.saveAll(List.of(image1, image2, image3, image4));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
+            participantRepository.saveAll(List.of(participant1, participant2));
+        }
+
+        @Test
+        void 유효한_요청이면_임시_앨범을_생성하고_임시_앨범에_이미지를_저장한다() {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 2L));
+
+            // when
+            tempAlbumService.createTempAlbum(1L, request);
+
+            // then
+            TempAlbum tempAlbum =
+                    transactionUtil.getResult(
+                            () -> {
+                                TempAlbum loadedTempAlbum = tempAlbumRepository.findById(1L).get();
+                                loadedTempAlbum.getTempAlbumImages().get(0);
+                                return loadedTempAlbum;
+                            });
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(tempAlbum)
+                                    .extracting("member.id", "album.id", "expiredAt")
+                                    .containsExactly(1L, 1L, LocalDate.now().plusDays(3)),
+                    () ->
+                            assertThat(tempAlbum.getTempAlbumImages())
+                                    .extracting("id", "tempAlbum.id", "image.id")
+                                    .containsExactly(tuple(1L, 1L, 1L), tuple(2L, 1L, 2L)));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> tempAlbumService.createTempAlbum(999L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_사용자가_임시_앨범을_생성하면_예외가_발생한다() {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(4L));
+
+            // when & then
+            assertThatThrownBy(() -> tempAlbumService.createTempAlbum(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void LIMITED_권한의_사용자가_임시_앨범을_생성하면_예외가_발생한다() {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(3L));
+
+            // when & then
+            assertThatThrownBy(() -> tempAlbumService.createTempAlbum(2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 앨범에_속하지_않은_이미지를_추가하면_예외가_발생한다() {
+            // given
+            TempAlbumCreateRequest request = new TempAlbumCreateRequest(List.of(1L, 4L));
+
+            // when & then
+            assertThatThrownBy(() -> tempAlbumService.createTempAlbum(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.IMAGES_NOT_IN_ALBUM.getMessage());
+        }
+    }
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -19,7 +19,7 @@ import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.subscription.entity.Subscription;
-import org.cherrypic.tempalbum.TempAlbumImage;
+import org.cherrypic.tempalbum.TempAlbum;
 
 @Getter
 @Entity
@@ -60,7 +60,7 @@ public class Album extends BaseTimeEntity {
     private List<Image> images = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<TempAlbumImage> tempAlbumImages = new ArrayList<>();
+    private List<TempAlbum> tempAlbumImages = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Album(

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -19,6 +19,7 @@ import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.tempalbum.TempAlbumImage;
 
 @Getter
 @Entity
@@ -57,6 +58,9 @@ public class Album extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TempAlbumImage> tempAlbumImages = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Album(

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/TempAlbum.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/TempAlbum.java
@@ -1,0 +1,52 @@
+package org.cherrypic.tempalbum;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.cherrypic.album.entity.Album;
+import org.cherrypic.common.model.BaseTimeEntity;
+import org.cherrypic.member.entity.Member;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TempAlbum extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id")
+    private Album album;
+
+    @NotNull private Date expiredAt;
+
+    @OneToMany(mappedBy = "tempAlbum", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TempAlbumImage> tempAlbumImages = new ArrayList<>();
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private TempAlbum(Album album, Member member, Date expiredAt) {
+        this.album = album;
+        this.member = member;
+        this.expiredAt = expiredAt;
+    }
+
+    public static TempAlbum createTempAlbum(Album album, Member member, Date expiredAt) {
+        return TempAlbum.builder().album(album).member(member).expiredAt(expiredAt).build();
+    }
+
+    public void addTempAlbumImages(List<TempAlbumImage> images) {
+        this.tempAlbumImages.addAll(images);
+    }
+}

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/TempAlbum.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/TempAlbum.java
@@ -2,8 +2,8 @@ package org.cherrypic.tempalbum;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,19 +30,19 @@ public class TempAlbum extends BaseTimeEntity {
     @JoinColumn(name = "album_id")
     private Album album;
 
-    @NotNull private Date expiredAt;
+    @NotNull private LocalDate expiredAt;
 
     @OneToMany(mappedBy = "tempAlbum", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TempAlbumImage> tempAlbumImages = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private TempAlbum(Album album, Member member, Date expiredAt) {
+    private TempAlbum(Album album, Member member, LocalDate expiredAt) {
         this.album = album;
         this.member = member;
         this.expiredAt = expiredAt;
     }
 
-    public static TempAlbum createTempAlbum(Album album, Member member, Date expiredAt) {
+    public static TempAlbum createTempAlbum(Album album, Member member, LocalDate expiredAt) {
         return TempAlbum.builder().album(album).member(member).expiredAt(expiredAt).build();
     }
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/TempAlbumImage.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/TempAlbumImage.java
@@ -1,0 +1,37 @@
+package org.cherrypic.tempalbum;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.cherrypic.common.model.BaseTimeEntity;
+import org.cherrypic.image.entity.Image;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TempAlbumImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "temp_album_id")
+    private TempAlbum tempAlbum;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private TempAlbumImage(TempAlbum tempAlbum, Image image) {
+        this.tempAlbum = tempAlbum;
+        this.image = image;
+    }
+
+    public static TempAlbumImage createTempAlbumImage(TempAlbum tempAlbum, Image image) {
+        return TempAlbumImage.builder().tempAlbum(tempAlbum).image(image).build();
+    }
+}

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -126,3 +126,34 @@ CREATE TABLE notification (
                              CONSTRAINT fk_notification_receiver FOREIGN KEY (receiver_id) REFERENCES member (id),
                              CONSTRAINT fk_notification_album FOREIGN KEY (album_id) REFERENCES album (id)
 );
+
+
+CREATE TABLE temp_album (
+                            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                            member_id BIGINT NOT NULL,
+                            album_id BIGINT NOT NULL,
+                            expired_at DATE NOT NULL,
+                            created_at DATETIME(6) NOT NULL,
+                            updated_at DATETIME(6) NOT NULL,
+
+                            CONSTRAINT fk_temp_album_member
+                                FOREIGN KEY (member_id) REFERENCES member (id),
+
+                            CONSTRAINT fk_temp_album_album
+                                FOREIGN KEY (album_id) REFERENCES album (id)
+);
+
+
+CREATE TABLE temp_album_image (
+                                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                  temp_album_id BIGINT NOT NULL,
+                                  image_id BIGINT NOT NULL,
+                                  created_at DATETIME(6) NOT NULL,
+                                  updated_at DATETIME(6) NOT NULL,
+
+                                  CONSTRAINT fk_temp_album_image_temp_album
+                                      FOREIGN KEY (temp_album_id) REFERENCES temp_album (id),
+
+                                  CONSTRAINT fk_temp_album_image_image
+                                      FOREIGN KEY (image_id) REFERENCES image (id)
+);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #168

---
## 📌 작업 내용 및 특이사항
- 임시 앨범 생성 기능을 구현했습니다.
- 임시 앨범과 관련된 엔티티를 설계하고 flyway에 추가했습니다.
- 새로운 Controller를 만들고 9번을 임시 앨범관련 API로 만들었습니다.

---
## 📚 참고사항
- 정책적인 세부 사항의 변동을 고려해서 아직 일부 validation이 구현되지 않았습니다.