### PR TITLE
feat: 참가자 권한 변경 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -29,7 +29,11 @@ public enum AlbumErrorCode implements BaseErrorCode {
     HOST_LEAVE_NOT_ALLOWED(403, "방장은 앨범을 나갈 수 없습니다."),
     HOST_SELF_KICK_NOT_ALLOWED(400, "방장은 자기 자신을 강퇴할 수 없습니다."),
 
+    HOST_SELF_ROLE_CHANGE_NOT_ALLOWED(400, "방장은 자기 자신의 권한을 직접 변경할 수 없습니다."),
+
     PARTICIPANT_NOT_IN_ALBUM(400, "해당 참가자는 이 앨범에 속해 있지 않습니다."),
+
+    SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED(400, "구독 중인 앨범에서는 방장 권한을 넘길 수 없습니다."),
 
     ALBUM_CAPACITY_EXCEEDED(400, "앨범의 용량을 초과했습니다."),
     IMAGES_NOT_IN_ALBUM(400, "앨범에 속해 있지 않은 이미지가 포함되어 있습니다.");

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -29,6 +29,8 @@ public enum AlbumErrorCode implements BaseErrorCode {
     HOST_LEAVE_NOT_ALLOWED(403, "방장은 앨범을 나갈 수 없습니다."),
     HOST_SELF_KICK_NOT_ALLOWED(400, "방장은 자기 자신을 강퇴할 수 없습니다."),
 
+    PERMISSION_CONTROL_NOT_AVAILABLE(400, "참가자 권한 변경 기능이 비활성화된 앨범입니다."),
+
     HOST_SELF_ROLE_CHANGE_NOT_ALLOWED(400, "방장은 자기 자신의 권한을 직접 변경할 수 없습니다."),
 
     PARTICIPANT_NOT_IN_ALBUM(400, "해당 참가자는 이 앨범에 속해 있지 않습니다."),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/controller/ParticipantController.java
@@ -3,7 +3,9 @@ package org.cherrypic.domain.participant.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.participant.dto.request.ParticipantRoleUpdateRequest;
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.service.ParticipantService;
 import org.cherrypic.global.annotation.PageSize;
@@ -33,6 +35,16 @@ public class ParticipantController {
     public ResponseEntity<Void> participantKick(
             @PathVariable Long albumId, @PathVariable Long participantId) {
         participantService.kickParticipant(albumId, participantId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{participantId}/role")
+    @Operation(summary = "참가자 권한 변경", description = "앨범 방장이 특정 참가자의 권한을 변경합니다.")
+    public ResponseEntity<Void> participantRoleUpdate(
+            @PathVariable Long albumId,
+            @PathVariable Long participantId,
+            @Valid @RequestBody ParticipantRoleUpdateRequest request) {
+        participantService.updateParticipantRole(albumId, participantId, request);
         return ResponseEntity.noContent().build();
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/dto/request/ParticipantRoleUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/dto/request/ParticipantRoleUpdateRequest.java
@@ -1,0 +1,10 @@
+package org.cherrypic.domain.participant.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.global.annotation.Enum;
+import org.cherrypic.participant.enums.ParticipantRole;
+
+public record ParticipantRoleUpdateRequest(
+        @Enum(message = "참가자 권한은 비워둘 수 없으며, HOST, STANDARD, LIMITED만 지원됩니다.")
+                @Schema(description = "참가자 권한", example = "STANDARD")
+                ParticipantRole role) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
@@ -9,6 +9,8 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum ParticipantErrorCode implements BaseErrorCode {
     PARTICIPANT_NOT_FOUND(404, "참가자를 찾을 수 없습니다."),
 
+    ROLE_ALREADY_ASSIGNED(400, "이미 해당 권한이 할당되어 있습니다."),
+
     MISSING_CURSOR_PAIR(400, "lastNickname과 lastParticipantId는 요청에 함께 포함되어야 합니다. 하나만 포함할 수는 없습니다.");
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/exception/ParticipantErrorCode.java
@@ -9,7 +9,7 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum ParticipantErrorCode implements BaseErrorCode {
     PARTICIPANT_NOT_FOUND(404, "참가자를 찾을 수 없습니다."),
 
-    ROLE_ALREADY_ASSIGNED(400, "이미 해당 권한이 할당되어 있습니다."),
+    ROLE_ALREADY_ASSIGNED(409, "이미 해당 권한이 부여되어 있습니다."),
 
     MISSING_CURSOR_PAIR(400, "lastNickname과 lastParticipantId는 요청에 함께 포함되어야 합니다. 하나만 포함할 수는 없습니다.");
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantService.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.participant.service;
 
+import org.cherrypic.domain.participant.dto.request.ParticipantRoleUpdateRequest;
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.global.pagination.SliceResponse;
 
@@ -7,6 +8,9 @@ public interface ParticipantService {
     void leaveAlbum(Long albumId);
 
     void kickParticipant(Long albumId, Long participantId);
+
+    void updateParticipantRole(
+            Long albumId, Long participantId, ParticipantRoleUpdateRequest request);
 
     SliceResponse<ParticipantListResponse> getParticipants(
             Long albumId, String lastNickname, Long lastParticipantId, int size);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumPlan;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.notification.repository.NotificationRepository;
+import org.cherrypic.domain.participant.dto.request.ParticipantRoleUpdateRequest;
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
@@ -16,6 +18,7 @@ import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.data.domain.Slice;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
@@ -66,6 +69,30 @@ public class ParticipantServiceImpl implements ParticipantService {
             notificationRepository.deleteByReceiverIdAndAlbumId(
                     target.getMember().getId(), album.getId());
         } catch (ObjectOptimisticLockingFailureException ignored) {
+        }
+    }
+
+    @Override
+    public void updateParticipantRole(
+            Long albumId, Long participantId, ParticipantRoleUpdateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+        final Participant requester =
+                getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
+        final Participant target = getParticipantById(participantId);
+
+        validateAlbumHost(requester);
+        validateSelfRoleChange(requester, target);
+        validateParticipantBelongsToAlbum(target, album);
+
+        final ParticipantRole newRole = request.role();
+
+        validateNotSameRole(target, newRole);
+
+        target.changeRole(newRole);
+        if (newRole == ParticipantRole.HOST) {
+            validateSubscriptionInactive(album);
+            requester.changeRole(ParticipantRole.STANDARD);
         }
     }
 
@@ -147,9 +174,29 @@ public class ParticipantServiceImpl implements ParticipantService {
         }
     }
 
+    private void validateSelfRoleChange(Participant requester, Participant target) {
+        if (requester.getId().equals(target.getId())) {
+            throw new CustomException(AlbumErrorCode.HOST_SELF_ROLE_CHANGE_NOT_ALLOWED);
+        }
+    }
+
     private void validateParticipantBelongsToAlbum(Participant target, Album album) {
         if (!target.getAlbum().getId().equals(album.getId())) {
             throw new CustomException(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM);
+        }
+    }
+
+    private void validateSubscriptionInactive(Album album) {
+        if (album.getPlan() == AlbumPlan.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.ACTIVE) {
+            throw new CustomException(AlbumErrorCode.SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED);
+        }
+    }
+
+    private void validateNotSameRole(Participant target, ParticipantRole role) {
+        if (target.getRole() == role) {
+            throw new CustomException(ParticipantErrorCode.ROLE_ALREADY_ASSIGNED);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -82,6 +82,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         final Participant target = getParticipantById(participantId);
 
         validateAlbumHost(requester);
+        validatePermissionControlAvailable(album);
         validateSelfRoleChange(requester, target);
         validateParticipantBelongsToAlbum(target, album);
 
@@ -171,6 +172,12 @@ public class ParticipantServiceImpl implements ParticipantService {
     private void validateSelfKick(Participant requester, Participant target) {
         if (requester.getId().equals(target.getId())) {
             throw new CustomException(AlbumErrorCode.HOST_SELF_KICK_NOT_ALLOWED);
+        }
+    }
+
+    private void validatePermissionControlAvailable(Album album) {
+        if (album.getPlan() == AlbumPlan.BASIC || !album.getPermissionControl()) {
+            throw new CustomException(AlbumErrorCode.PERMISSION_CONTROL_NOT_AVAILABLE);
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -447,6 +447,30 @@ class ParticipantControllerTest {
                     .andExpect(jsonPath("$.data.message").value("구독 중인 앨범에서는 방장 권한을 넘길 수 없습니다."));
         }
 
+        @Test
+        void 권한_변경_기능이_비활성화된_앨범의_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(AlbumErrorCode.PERMISSION_CONTROL_NOT_AVAILABLE))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("PERMISSION_CONTROL_NOT_AVAILABLE"))
+                    .andExpect(jsonPath("$.data.message").value("참가자 권한 변경 기능이 비활성화된 앨범입니다."));
+        }
+
         @ParameterizedTest
         @NullSource
         @EmptySource

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.participant.controller.ParticipantController;
+import org.cherrypic.domain.participant.dto.request.ParticipantRoleUpdateRequest;
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.service.ParticipantService;
@@ -19,11 +20,14 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -221,6 +225,251 @@ class ParticipantControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("PARTICIPANT_NOT_IN_ALBUM"))
                     .andExpect(jsonPath("$.data.message").value("해당 참가자는 이 앨범에 속해 있지 않습니다."));
+        }
+    }
+
+    @Nested
+    class 참가자_권한_변경_요청_시 {
+
+        @Test
+        void 유효한_요청이면_앨범_방장이_참가자의_권한을_변경하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willDoNothing().given(participantService).updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 권한_변경_요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 권한_변경_요청자가_앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void 앨범_방장이_자기_자신의_권한을_변경하려는_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(AlbumErrorCode.HOST_SELF_ROLE_CHANGE_NOT_ALLOWED))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("HOST_SELF_ROLE_CHANGE_NOT_ALLOWED"))
+                    .andExpect(jsonPath("$.data.message").value("방장은 자기 자신의 권한을 직접 변경할 수 없습니다."));
+        }
+
+        @Test
+        void 권한_변경_대상_참가자가_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(ParticipantErrorCode.PARTICIPANT_NOT_FOUND))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("PARTICIPANT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("참가자를 찾을 수 없습니다."));
+        }
+
+        @Test
+        void 권한_변경_대상이_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("PARTICIPANT_NOT_IN_ALBUM"))
+                    .andExpect(jsonPath("$.data.message").value("해당 참가자는 이 앨범에 속해 있지 않습니다."));
+        }
+
+        @Test
+        void 현재_권한과_같은_권한으로_변경하려는_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.STANDARD);
+
+            willThrow(new CustomException(ParticipantErrorCode.ROLE_ALREADY_ASSIGNED))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
+                    .andExpect(jsonPath("$.data.code").value("ROLE_ALREADY_ASSIGNED"))
+                    .andExpect(jsonPath("$.data.message").value("이미 해당 권한이 부여되어 있습니다."));
+        }
+
+        @Test
+        void 구독_중인_앨범에서_방장_권한을_넘기려는_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.HOST);
+
+            willThrow(
+                            new CustomException(
+                                    AlbumErrorCode.SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.data.code")
+                                    .value("SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED"))
+                    .andExpect(jsonPath("$.data.message").value("구독 중인 앨범에서는 방장 권한을 넘길 수 없습니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" ", "HOSTT", "STANDARDD", "LIMITEDD"})
+        void 참가자_권한이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String role) throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.from(role));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("참가자 권한은 비워둘 수 없으며, HOST, STANDARD, LIMITED만 지원됩니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -307,11 +307,12 @@ class ParticipantServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
-            Album album4 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, false);
-            albumRepository.saveAll(List.of(album1, album2, album3, album4));
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.PRO, true);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.PRO, true);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, true);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.PRO, true);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
@@ -325,6 +326,10 @@ class ParticipantServiceTest extends IntegrationTest {
                     Participant.createParticipant(member1, album4, ParticipantRole.HOST);
             Participant participant6 =
                     Participant.createParticipant(member2, album4, ParticipantRole.STANDARD);
+            Participant participant7 =
+                    Participant.createParticipant(member1, album5, ParticipantRole.HOST);
+            Participant participant8 =
+                    Participant.createParticipant(member2, album5, ParticipantRole.STANDARD);
             participantRepository.saveAll(
                     List.of(
                             participant1,
@@ -332,12 +337,20 @@ class ParticipantServiceTest extends IntegrationTest {
                             participant3,
                             participant4,
                             participant5,
-                            participant6));
+                            participant6,
+                            participant7,
+                            participant8));
 
-            Subscription subscription =
+            // 15일 전에 시작되어 현재는 해지된 구독
+            Subscription subscription1 =
+                    Subscription.createSubscription(
+                            member1, album1, LocalDateTime.now().minusDays(15));
+            subscription1.cancel();
+            // 구독 중인 앨범
+            Subscription subscription2 =
                     Subscription.createSubscription(
                             member1, album4, LocalDateTime.now().minusDays(15));
-            subscriptionRepository.save(subscription);
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2));
         }
 
         @Test
@@ -467,6 +480,18 @@ class ParticipantServiceTest extends IntegrationTest {
                     .hasMessage(
                             AlbumErrorCode.SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED
                                     .getMessage());
+        }
+
+        @Test
+        void 권한_변경_기능이_비활성화된_앨범의_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(5L, 8L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.PERMISSION_CONTROL_NOT_AVAILABLE.getMessage());
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
@@ -12,10 +13,12 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.notification.repository.NotificationRepository;
+import org.cherrypic.domain.participant.dto.request.ParticipantRoleUpdateRequest;
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.participant.service.ParticipantService;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.util.MemberUtil;
@@ -26,6 +29,7 @@ import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.notification.enums.NotificationType;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.entity.Subscription;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -39,6 +43,7 @@ class ParticipantServiceTest extends IntegrationTest {
     @Autowired private AlbumRepository albumRepository;
     @Autowired private ParticipantRepository participantRepository;
     @Autowired private NotificationRepository notificationRepository;
+    @Autowired private SubscriptionRepository subscriptionRepository;
 
     @MockitoBean private MemberUtil memberUtil;
 
@@ -281,6 +286,187 @@ class ParticipantServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> participantService.kickParticipant(1L, 3L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM.getMessage());
+        }
+    }
+
+    @Nested
+    class 참가자의_권한을_변경할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album4 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member2, album1, ParticipantRole.STANDARD);
+            Participant participant3 =
+                    Participant.createParticipant(member2, album3, ParticipantRole.HOST);
+            Participant participant4 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.STANDARD);
+            Participant participant5 =
+                    Participant.createParticipant(member1, album4, ParticipantRole.HOST);
+            Participant participant6 =
+                    Participant.createParticipant(member2, album4, ParticipantRole.STANDARD);
+            participantRepository.saveAll(
+                    List.of(
+                            participant1,
+                            participant2,
+                            participant3,
+                            participant4,
+                            participant5,
+                            participant6));
+
+            Subscription subscription =
+                    Subscription.createSubscription(
+                            member1, album4, LocalDateTime.now().minusDays(15));
+            subscriptionRepository.save(subscription);
+        }
+
+        @Test
+        void 참가자의_권한을_HOST로_변경하면_이전_방장은_STANDARD가_된다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.HOST);
+
+            // when
+            participantService.updateParticipantRole(1L, 2L, request);
+
+            // then
+            Album album =
+                    transactionUtil.getResult(
+                            () -> {
+                                Album loadedAlbum = albumRepository.findById(1L).get();
+                                loadedAlbum.getParticipants().size();
+                                return loadedAlbum;
+                            });
+            Participant previousHost = album.getParticipants().get(0);
+            Participant previousStandard = album.getParticipants().get(1);
+
+            Assertions.assertAll(
+                    () ->
+                            assertThat(previousHost)
+                                    .extracting("id", "role")
+                                    .containsExactly(1L, ParticipantRole.STANDARD),
+                    () ->
+                            assertThat(previousStandard)
+                                    .extracting("id", "role")
+                                    .containsExactly(2L, ParticipantRole.HOST));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(999L, 2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 권한_변경_요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(2L, 2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 권한_변경_요청자가_앨범_방장이_아닌_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(3L, 3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void 앨범_방장이_자기_자신의_권한을_변경하려는_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(1L, 1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.HOST_SELF_ROLE_CHANGE_NOT_ALLOWED.getMessage());
+        }
+
+        @Test
+        void 권한_변경_대상_참가자가_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(1L, 999L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ParticipantErrorCode.PARTICIPANT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 권한_변경_대상이_앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(1L, 3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.PARTICIPANT_NOT_IN_ALBUM.getMessage());
+        }
+
+        @Test
+        void 현재_권한과_같은_권한으로_변경하려는_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.STANDARD);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(1L, 2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ParticipantErrorCode.ROLE_ALREADY_ASSIGNED.getMessage());
+        }
+
+        @Test
+        void 구독_중인_앨범에서_방장_권한을_넘기려는_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.HOST);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(4L, 6L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(
+                            AlbumErrorCode.SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED
+                                    .getMessage());
         }
     }
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
@@ -50,4 +50,8 @@ public class Participant extends BaseTimeEntity {
     public void assignFavorites() {
         this.favorites = Favorites.createFavorites(this);
     }
+
+    public void changeRole(ParticipantRole role) {
+        this.role = role;
+    }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/enums/ParticipantRole.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/enums/ParticipantRole.java
@@ -1,7 +1,19 @@
 package org.cherrypic.participant.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.stream.Stream;
+
 public enum ParticipantRole {
     HOST,
     STANDARD,
-    LIMITED
+    LIMITED,
+    ;
+
+    @JsonCreator
+    public static ParticipantRole from(String role) {
+        return Stream.of(values())
+                .filter(p -> p.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -60,9 +60,7 @@ CREATE TABLE participant (
                              id BIGINT AUTO_INCREMENT PRIMARY KEY,
                              member_id BIGINT NOT NULL,
                              album_id BIGINT NOT NULL,
-                             role VARCHAR(255) NOT NULL CHECK (role IN ('HOST','STANDARD','LIMITED')),
-                             password VARCHAR(255),
-                             created_at DATETIME(6) NOT NULL,
+                             role VARCHAR(255) NOT NULL CHECK (role IN ('HOST','STANDARD','LIMITED')),g                             created_at DATETIME(6) NOT NULL,
                              updated_at DATETIME(6) NOT NULL,
                              CONSTRAINT fk_participant_member FOREIGN KEY (member_id) REFERENCES member (id),
                              CONSTRAINT fk_participant_album FOREIGN KEY (album_id) REFERENCES album (id)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #173 

---
## 📌 작업 내용 및 특이사항
* 참가자의 권한을 방장이 변경할 수 있도록 기능을 구현했습니다.
* 권한은 HOST, STANDARD, READ_ONLY 중 선택 가능하며, HOST로 변경 시 기존 방장은 자동으로 STANDARD로 변경됩니다.
* 구독 중인 앨범에서는 방장 권한을 위임할 수 없도록 예외 처리를 추가했습니다. (정기결제 관리 이슈로 인해 이전 방장의 결제를 해지해야 하기 때문입니다)
* 참가자 권한 변경 기능과 관련된 다양한 예외 케이스를 처리했습니다.
* 동일한 권한으로의 변경 시도나 본인의 권한을 직접 변경하려는 경우 등을 검증하고, BASIC 앨범은 애초에 권한 부여 기능을 지원하지 않기 때문에 이를 예외로 처리했습니다.
* 또한, PRO 및 PREMIUM 앨범이라도 권한 부여 기능이 꺼져 있을 수 있으므로 해당 설정 값이 false인 경우도 별도로 예외를 발생시키도록 했습니다.

---
## 📚 참고사항
* 현재 구독이 종료된 앨범에서도 여러 앨범 관련 API 호출이 가능한 상태입니다.
* 향후 Interceptor를 도입해 구독 종료된 앨범의 접근을 제한할 예정입니다. (AOP는 전역 적용 특성상 부적절하다고 판단)
