### PR TITLE
refactor: 앨범 플랜, 구독 플랜 등 혼용된 용어를 앨범 유형으로 통일

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
@@ -75,11 +75,11 @@ public class AlbumController {
     @Operation(
             summary = "앨범 목록 조회",
             description =
-                    "회원이 참여 중인 앨범 목록을 커서 기반 페이징 방식으로 조회합니다. 앨범 플랜을 지정하면 해당 플랜에 해당하는 앨범만 필터링하여 조회합니다.")
+                    "회원이 참여 중인 앨범 목록을 커서 기반 페이징 방식으로 조회합니다. 앨범 유형을 지정하면 해당 유형에 해당하는 앨범만 필터링하여 조회합니다.")
     public SliceResponse<AlbumListResponse> albumsGet(
-            @Parameter(description = "앨범 플랜 (BASIC, PRO, PREMIUM). 생략 시 전체 조회")
+            @Parameter(description = "앨범 유형 (BASIC, PRO, PREMIUM). 생략 시 전체 조회")
                     @RequestParam(required = false)
-                    AlbumPlan plan,
+                    AlbumType type,
             @Parameter(description = "검색 키워드 (앨범 제목에 포함된 단어). 생략 시 전체 조회")
                     @RequestParam(required = false)
                     String keyword,
@@ -91,7 +91,7 @@ public class AlbumController {
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
         return albumService.getParticipatingAlbumsByCondition(
-                plan, keyword, lastAlbumId, size, direction);
+                type, keyword, lastAlbumId, size, direction);
     }
 
     @DeleteMapping("/{albumId}")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
@@ -16,7 +16,7 @@ public record AlbumCreateRequest(
         @Enum(message = "앨범 유형은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다.")
                 @Schema(description = "앨범 유형 (BASIC: 무료, PRO/PREMIUM: 유료)", example = "BASIC")
                 AlbumType type,
-        @Schema(description = "유료 플랜(PRO, PREMIUM)인 경우 필수. 결제 검증 후 받은 결제 ID", example = "1")
+        @Schema(description = "유료 앨범 유형(PRO, PREMIUM)인 경우 필수. 결제 검증 후 받은 결제 ID", example = "1")
                 Long paymentId,
         @NotNull(message = "권한 부여 활성화 여부는 비워둘 수 없습니다.")
                 @Schema(description = "권한 부여 활성화 여부", example = "false")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/request/AlbumCreateRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.global.annotation.Enum;
 
 public record AlbumCreateRequest(
@@ -13,9 +13,9 @@ public record AlbumCreateRequest(
                 @Size(max = 20, message = "앨범 이름은 최대 20자까지 가능합니다.")
                 String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @Enum(message = "앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다.")
-                @Schema(description = "앨범 플랜 (BASIC: 무료, PRO/PREMIUM: 유료)", example = "BASIC")
-                AlbumPlan plan,
+        @Enum(message = "앨범 유형은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다.")
+                @Schema(description = "앨범 유형 (BASIC: 무료, PRO/PREMIUM: 유료)", example = "BASIC")
+                AlbumType type,
         @Schema(description = "유료 플랜(PRO, PREMIUM)인 경우 필수. 결제 검증 후 받은 결제 ID", example = "1")
                 Long paymentId,
         @NotNull(message = "권한 부여 활성화 여부는 비워둘 수 없습니다.")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumCreateResponse.java
@@ -2,20 +2,20 @@ package org.cherrypic.domain.album.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 
 public record AlbumCreateResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan,
+        @Schema(description = "앨범 유형", example = "BASIC") AlbumType type,
         @Schema(description = "권한 부여 활성화 여부", example = "false") Boolean permissionControl) {
     public static AlbumCreateResponse from(Album album) {
         return new AlbumCreateResponse(
                 album.getId(),
                 album.getTitle(),
                 album.getCoverUrl(),
-                album.getPlan(),
+                album.getType(),
                 album.getPermissionControl());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumInfoResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumInfoResponse.java
@@ -3,12 +3,12 @@ package org.cherrypic.domain.album.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 
 public record AlbumInfoResponse(
         @Schema(description = "앨범 제목", example = "맛집 탐방") String title,
         @Schema(description = "앨범 커버 사진 url", example = "https://example.jpg") String coverUrl,
-        @Schema(description = "앨범 플랜", example = "PRO") AlbumPlan albumPlan,
+        @Schema(description = "앨범 유형", example = "PRO") AlbumType type,
         @Schema(description = "사용한 용량 (GB)", example = "2")
                 @JsonFormat(shape = JsonFormat.Shape.STRING)
                 BigDecimal capacityUsed,
@@ -18,18 +18,12 @@ public record AlbumInfoResponse(
     public static AlbumInfoResponse of(
             String title,
             String coverUrl,
-            AlbumPlan albumPlan,
+            AlbumType type,
             BigDecimal capacityUsed,
             BigDecimal totalCapacity,
             String hostName,
             Integer numOfParticipants) {
         return new AlbumInfoResponse(
-                title,
-                coverUrl,
-                albumPlan,
-                capacityUsed,
-                totalCapacity,
-                hostName,
-                numOfParticipants);
+                title, coverUrl, type, capacityUsed, totalCapacity, hostName, numOfParticipants);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
@@ -1,11 +1,11 @@
 package org.cherrypic.domain.album.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 
 public record AlbumListResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan,
+        @Schema(description = "앨범 유형", example = "BASIC") AlbumType type,
         @Schema(description = "즐겨찾기 상태", example = "true") Boolean marked) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumUpdateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumUpdateResponse.java
@@ -2,15 +2,15 @@ package org.cherrypic.domain.album.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 
 public record AlbumUpdateResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
-        @Schema(description = "앨범 플랜", example = "BASIC") AlbumPlan plan) {
+        @Schema(description = "앨범 유형", example = "BASIC") AlbumType type) {
     public static AlbumUpdateResponse from(Album album) {
         return new AlbumUpdateResponse(
-                album.getId(), album.getTitle(), album.getCoverUrl(), album.getPlan());
+                album.getId(), album.getTitle(), album.getCoverUrl(), album.getType());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -13,10 +13,10 @@ public enum AlbumErrorCode implements BaseErrorCode {
     NOT_ALBUM_PARTICIPANT(403, "앨범에 속하지 않은 사용자입니다."),
     LIMITED_AUTHORITY(403, "앨범에 대한 생성/수정 권한이 없습니다."),
 
-    PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 권한 부여 활성화가 허용되지 않습니다."),
+    PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE(400, "BASIC 유형에서는 권한 부여 활성화가 허용되지 않습니다."),
 
-    PAYMENT_REQUIRED_FOR_PAID_PLAN(400, "유료 플랜은 결제 ID가 필요합니다."),
-    PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN(400, "BASIC 플랜에서는 결제 ID가 필요하지 않습니다."),
+    PAYMENT_REQUIRED_FOR_PAID_TYPE(400, "유료 앨범 유형은 결제 ID가 필요합니다."),
+    PAYMENT_NOT_REQUIRED_FOR_BASIC_TYPE(400, "BASIC 유형에서는 결제 ID가 필요하지 않습니다."),
 
     INVITATION_CODE_NOT_FOUND(404, "앨범의 초대 코드가 만료되었습니다."),
     INVITATION_CODE_MISMATCH(400, "초대 코드가 올바르지 않습니다."),

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -6,7 +6,7 @@ import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.Slice;
 
 public interface AlbumRepositoryCustom {
-    Slice<AlbumListResponse> findAllByMemberIdAndPlanAndKeyword(
+    Slice<AlbumListResponse> findAllByMemberIdAndTypeAndKeyword(
             Long memberId,
             AlbumType type,
             String keyword,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -1,6 +1,6 @@
 package org.cherrypic.domain.album.repository;
 
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.Slice;
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Slice;
 public interface AlbumRepositoryCustom {
     Slice<AlbumListResponse> findAllByMemberIdAndPlanAndKeyword(
             Long memberId,
-            AlbumPlan plan,
+            AlbumType type,
             String keyword,
             Long lastAlbumId,
             int size,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -8,7 +8,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.springframework.data.domain.PageRequest;
@@ -25,7 +25,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
     @Override
     public Slice<AlbumListResponse> findAllByMemberIdAndPlanAndKeyword(
             Long memberId,
-            AlbumPlan plan,
+            AlbumType type,
             String keyword,
             Long lastAlbumId,
             int size,
@@ -38,13 +38,13 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                                         album.id,
                                         album.title,
                                         album.coverUrl,
-                                        album.plan,
+                                        album.type,
                                         participant.favorites.marked))
                         .from(participant)
                         .join(participant.album, album)
                         .where(
                                 participant.member.id.eq(memberId),
-                                plan != null ? album.plan.eq(plan) : null,
+                                type != null ? album.type.eq(type) : null,
                                 keyword != null ? album.title.containsIgnoreCase(keyword) : null,
                                 lastAlbumIdCondition(lastAlbumId, direction))
                         .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -23,7 +23,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<AlbumListResponse> findAllByMemberIdAndPlanAndKeyword(
+    public Slice<AlbumListResponse> findAllByMemberIdAndTypeAndKeyword(
             Long memberId,
             AlbumType type,
             String keyword,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -1,6 +1,6 @@
 package org.cherrypic.domain.album.service;
 
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
@@ -21,7 +21,7 @@ public interface AlbumService {
     AlbumInfoResponse getAlbum(Long albumId);
 
     SliceResponse<AlbumListResponse> getParticipatingAlbumsByCondition(
-            AlbumPlan plan, String keyword, Long lastAlbumId, int size, SortDirection direction);
+            AlbumType type, String keyword, Long lastAlbumId, int size, SortDirection direction);
 
     void deleteAlbum(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -58,7 +58,7 @@ public class AlbumServiceImpl implements AlbumService {
     public AlbumCreateResponse createAlbum(AlbumCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        validatePaymentRequirementForPlan(request.type(), request.paymentId());
+        validatePaymentRequirementForType(request.type(), request.paymentId());
 
         validatePermissionControl(request.type(), request.permissionControl());
 
@@ -194,12 +194,12 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<AlbumListResponse> getParticipatingAlbumsByCondition(
-            AlbumType plan, String keyword, Long lastAlbumId, int size, SortDirection direction) {
+            AlbumType type, String keyword, Long lastAlbumId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
 
         Slice<AlbumListResponse> results =
-                albumRepository.findAllByMemberIdAndPlanAndKeyword(
-                        currentMember.getId(), plan, keyword, lastAlbumId, size, direction);
+                albumRepository.findAllByMemberIdAndTypeAndKeyword(
+                        currentMember.getId(), type, keyword, lastAlbumId, size, direction);
 
         return SliceResponse.from(results);
     }
@@ -257,18 +257,18 @@ public class AlbumServiceImpl implements AlbumService {
         }
     }
 
-    private void validatePermissionControl(AlbumType plan, Boolean permissionControl) {
-        if (plan == AlbumType.BASIC && permissionControl) {
+    private void validatePermissionControl(AlbumType type, Boolean permissionControl) {
+        if (type == AlbumType.BASIC && permissionControl) {
             throw new CustomException(AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE);
         }
     }
 
-    private void validatePaymentRequirementForPlan(AlbumType plan, Long paymentId) {
-        if (plan.requiresPayment() && paymentId == null) {
+    private void validatePaymentRequirementForType(AlbumType type, Long paymentId) {
+        if (type.requiresPayment() && paymentId == null) {
             throw new CustomException(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_TYPE);
         }
 
-        if (!plan.requiresPayment() && paymentId != null) {
+        if (!type.requiresPayment() && paymentId != null) {
             throw new CustomException(AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_TYPE);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -4,7 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
@@ -58,15 +58,15 @@ public class AlbumServiceImpl implements AlbumService {
     public AlbumCreateResponse createAlbum(AlbumCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        validatePaymentRequirementForPlan(request.plan(), request.paymentId());
+        validatePaymentRequirementForPlan(request.type(), request.paymentId());
 
-        validatePermissionControl(request.plan(), request.permissionControl());
+        validatePermissionControl(request.type(), request.permissionControl());
 
         Album album =
                 Album.createAlbum(
                         request.title(),
                         request.coverUrl(),
-                        request.plan(),
+                        request.type(),
                         request.permissionControl());
 
         Participant participant =
@@ -75,7 +75,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         album.addParticipant(participant);
 
-        if (request.plan() != AlbumPlan.BASIC) {
+        if (request.type() != AlbumType.BASIC) {
             final Payment payment = getPaidPaymentById(request.paymentId());
 
             validatePaymentMemberMismatch(payment, currentMember);
@@ -113,7 +113,7 @@ public class AlbumServiceImpl implements AlbumService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
-        validatePermissionControl(album.getPlan(), true);
+        validatePermissionControl(album.getType(), true);
 
         album.togglePermissionControl();
 
@@ -184,9 +184,9 @@ public class AlbumServiceImpl implements AlbumService {
         return AlbumInfoResponse.of(
                 album.getTitle(),
                 album.getCoverUrl(),
-                album.getPlan(),
+                album.getType(),
                 album.getCapacityGb(),
-                album.getPlan().getCapacityGb(),
+                album.getType().getCapacityGb(),
                 hostName,
                 numOfParticipants);
     }
@@ -194,7 +194,7 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<AlbumListResponse> getParticipatingAlbumsByCondition(
-            AlbumPlan plan, String keyword, Long lastAlbumId, int size, SortDirection direction) {
+            AlbumType plan, String keyword, Long lastAlbumId, int size, SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
 
         Slice<AlbumListResponse> results =
@@ -257,19 +257,19 @@ public class AlbumServiceImpl implements AlbumService {
         }
     }
 
-    private void validatePermissionControl(AlbumPlan plan, Boolean permissionControl) {
-        if (plan == AlbumPlan.BASIC && permissionControl) {
-            throw new CustomException(AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN);
+    private void validatePermissionControl(AlbumType plan, Boolean permissionControl) {
+        if (plan == AlbumType.BASIC && permissionControl) {
+            throw new CustomException(AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE);
         }
     }
 
-    private void validatePaymentRequirementForPlan(AlbumPlan plan, Long paymentId) {
+    private void validatePaymentRequirementForPlan(AlbumType plan, Long paymentId) {
         if (plan.requiresPayment() && paymentId == null) {
-            throw new CustomException(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_PLAN);
+            throw new CustomException(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_TYPE);
         }
 
         if (!plan.requiresPayment() && paymentId != null) {
-            throw new CustomException(AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN);
+            throw new CustomException(AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_TYPE);
         }
     }
 
@@ -287,7 +287,7 @@ public class AlbumServiceImpl implements AlbumService {
 
     private void validateMaxParticipantLimit(Album album) {
         if (participantRepository.countByAlbumId(album.getId())
-                >= album.getPlan().getMaxParticipants()) {
+                >= album.getType().getMaxParticipants()) {
             throw new CustomException(AlbumErrorCode.ALBUM_PARTICIPANT_LIMIT_EXCEEDED);
         }
     }
@@ -324,7 +324,7 @@ public class AlbumServiceImpl implements AlbumService {
     }
 
     private void validateSubscriptionInactive(Album album) {
-        if (album.getPlan() == AlbumPlan.BASIC) return;
+        if (album.getType() == AlbumType.BASIC) return;
 
         if (album.getSubscription().getStatus() == SubscriptionStatus.ACTIVE) {
             throw new CustomException(AlbumErrorCode.SUBSCRIPTION_ACTIVE);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -249,7 +249,7 @@ public class ImageServiceImpl implements ImageService {
     }
 
     private void validateAlbumCapacity(Album album, BigDecimal additionalUpload) {
-        BigDecimal maxCapacity = album.getPlan().getCapacityGb();
+        BigDecimal maxCapacity = album.getType().getCapacityGb();
         BigDecimal current = album.getCapacityGb();
         BigDecimal afterUpload = current.add(additionalUpload);
 
@@ -270,14 +270,6 @@ public class ImageServiceImpl implements ImageService {
     private void validateImageExtension(FileExtension extension) {
         if (!FileExtension.getImageExtensions().contains(extension)) {
             throw new CustomException(ImageErrorCode.NOT_IMAGE_EXTENSION);
-        }
-    }
-
-    private void validateAlbumHost(Long memberId, Long albumId) {
-        Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
-
-        if (!participant.getRole().equals(ParticipantRole.HOST)) {
-            throw new CustomException(AlbumErrorCode.NOT_ALBUM_HOST);
         }
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.notification.repository.NotificationRepository;
@@ -176,7 +176,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     private void validatePermissionControlAvailable(Album album) {
-        if (album.getPlan() == AlbumPlan.BASIC || !album.getPermissionControl()) {
+        if (album.getType() == AlbumType.BASIC || !album.getPermissionControl()) {
             throw new CustomException(AlbumErrorCode.PERMISSION_CONTROL_NOT_AVAILABLE);
         }
     }
@@ -194,7 +194,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     }
 
     private void validateSubscriptionInactive(Album album) {
-        if (album.getPlan() == AlbumPlan.BASIC) return;
+        if (album.getType() == AlbumType.BASIC) return;
 
         if (album.getSubscription().getStatus() == SubscriptionStatus.ACTIVE) {
             throw new CustomException(AlbumErrorCode.SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
@@ -20,8 +20,8 @@ public class PaymentController {
 
     @PostMapping("/ready")
     @Operation(
-            summary = "앨범 구독 플랜 결제 준비",
-            description = "사용자가 선택한 앨범 구독 플랜에 대해 결제 요청에 필요한 정보를 생성합니다.")
+            summary = "유료 앨범 결제 준비",
+            description = "유료 앨범 유형(PRO 또는 PREMIUM)에 대해 최초 생성, 구독 갱신, 구독 업그레이드의 상황에 맞게 결제를 준비합니다.")
     public PaymentReadyResponse paymentPrepare(@Valid @RequestBody PaymentReadyRequest request) {
         return paymentService.preparePayment(request);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/request/PaymentReadyRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/request/PaymentReadyRequest.java
@@ -1,11 +1,11 @@
 package org.cherrypic.domain.payment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.global.annotation.Enum;
 
 public record PaymentReadyRequest(
-        @Enum(message = "앨범 구독 플랜은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다.")
-                @Schema(description = "앨범 구독 플랜", defaultValue = "PRO")
-                AlbumPlan plan,
+        @Enum(message = "유료 앨범 유형은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다.")
+                @Schema(description = "유료 앨범 유형", defaultValue = "PRO")
+                AlbumType type,
         @Schema(description = "앨범 ID (갱신/업그레이드 시에만 사용)", example = "1") Long albumId) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
@@ -1,22 +1,22 @@
 package org.cherrypic.domain.payment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.payment.enums.PaymentPurpose;
 
 public record PaymentReadyResponse(
-        @Schema(description = "앨범 구독 플랜", defaultValue = "PRO") AlbumPlan plan,
+        @Schema(description = "유료 앨범 유형", defaultValue = "PRO") AlbumType type,
         @Schema(description = "구독 플랜 가격", example = "3900") int price,
         @Schema(description = "결제 요청 고유 ID", example = "album_20250723_pro_1_c4f1a2b3d5e6")
                 String merchantUid,
         @Schema(description = "구매자 이름", example = "최현태") String buyerName,
         @Schema(description = "결제 목적", example = "RENEWAL") PaymentPurpose purpose) {
     public static PaymentReadyResponse of(
-            AlbumPlan plan,
+            AlbumType type,
             int price,
             String merchantUid,
             String buyerName,
             PaymentPurpose purpose) {
-        return new PaymentReadyResponse(plan, price, merchantUid, buyerName, purpose);
+        return new PaymentReadyResponse(type, price, merchantUid, buyerName, purpose);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
@@ -6,7 +6,7 @@ import org.cherrypic.payment.enums.PaymentPurpose;
 
 public record PaymentReadyResponse(
         @Schema(description = "유료 앨범 유형", defaultValue = "PRO") AlbumType type,
-        @Schema(description = "구독 플랜 가격", example = "3900") int price,
+        @Schema(description = "유료 앨범 가격", example = "3900") int price,
         @Schema(description = "결제 요청 고유 ID", example = "album_20250723_pro_1_c4f1a2b3d5e6")
                 String merchantUid,
         @Schema(description = "구매자 이름", example = "최현태") String buyerName,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum PaymentErrorCode implements BaseErrorCode {
-    UNSUPPORTED_PAYMENT_PLAN(400, "해당 플랜은 유료 결제가 필요하지 않습니다. PRO 또는 PREMIUM 플랜만 결제가 가능합니다."),
+    UNSUPPORTED_PAYMENT(400, "BASIC 유형은 결제를 지원하지 않습니다."),
 
     PAYMENT_NOT_FOUND(404, "결제 정보가 존재하지 않습니다."),
 
@@ -18,7 +18,7 @@ public enum PaymentErrorCode implements BaseErrorCode {
 
     PAYMENT_MEMBER_MISMATCH(403, "결제한 사용자와 일치하지 않습니다."),
 
-    DOWNGRADE_NOT_ALLOWED(400, "현재 구독 플랜보다 낮은 플랜으로는 결제를 진행할 수 없습니다."),
+    DOWNGRADE_NOT_ALLOWED(400, "현재 앨범 유형보다 낮은 유형으로 결제를 진행할 수 없습니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
@@ -48,22 +48,22 @@ public class PaymentServiceImpl implements PaymentService {
     public PaymentReadyResponse preparePayment(PaymentReadyRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        AlbumPlan plan = request.plan();
-        if (plan.equals(AlbumPlan.BASIC)) {
-            throw new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT_PLAN);
+        AlbumType type = request.type();
+        if (type.equals(AlbumType.BASIC)) {
+            throw new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT);
         }
 
-        int price = plan.getPrice();
-        String merchantUid = generateMerchantUid(currentMember.getId(), plan);
+        int price = type.getPrice();
+        String merchantUid = generateMerchantUid(currentMember.getId(), type);
         String buyerName = currentMember.getNickname();
 
         PaymentPurpose purpose =
-                determinePaymentPurpose(currentMember.getId(), request.albumId(), plan);
+                determinePaymentPurpose(currentMember.getId(), request.albumId(), type);
 
         Payment payment = Payment.createPayment(currentMember, merchantUid, price, purpose);
         paymentRepository.save(payment);
 
-        return PaymentReadyResponse.of(plan, price, merchantUid, buyerName, purpose);
+        return PaymentReadyResponse.of(type, price, merchantUid, buyerName, purpose);
     }
 
     @Override
@@ -107,14 +107,14 @@ public class PaymentServiceImpl implements PaymentService {
         }
     }
 
-    private String generateMerchantUid(Long memberId, AlbumPlan plan) {
+    private String generateMerchantUid(Long memberId, AlbumType type) {
         String date = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
         String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
 
-        return String.format("album_%s_%s_%d_%s", date, plan.name().toLowerCase(), memberId, uuid);
+        return String.format("album_%s_%s_%d_%s", date, type.name().toLowerCase(), memberId, uuid);
     }
 
-    private PaymentPurpose determinePaymentPurpose(Long memberId, Long albumId, AlbumPlan plan) {
+    private PaymentPurpose determinePaymentPurpose(Long memberId, Long albumId, AlbumType type) {
         if (albumId == null) {
             return PaymentPurpose.CREATION;
         }
@@ -122,13 +122,13 @@ public class PaymentServiceImpl implements PaymentService {
         final Album album = getAlbumById(albumId);
         validateAlbumHost(memberId, album.getId());
 
-        AlbumPlan currentPlan = album.getPlan();
+        AlbumType currentType = album.getType();
 
-        if (currentPlan == plan) {
+        if (currentType == type) {
             return PaymentPurpose.RENEWAL;
         }
 
-        if (plan.getPrice() > currentPlan.getPrice()) {
+        if (type.getPrice() > currentType.getPrice()) {
             return PaymentPurpose.UPGRADE;
         }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/exception/SubscriptionErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/exception/SubscriptionErrorCode.java
@@ -8,7 +8,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum SubscriptionErrorCode implements BaseErrorCode {
     SUBSCRIPTION_NOT_FOUND(404, "구독 정보가 존재하지 않습니다."),
-    SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN(400, "BASIC 플랜은 구독 기능을 지원하지 않습니다."),
+    SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE(400, "BASIC 유형은 구독 기능을 지원하지 않습니다."),
     ;
 
     private final int status;

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -2,7 +2,7 @@ package org.cherrypic.domain.subscription.service;
 
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
@@ -91,9 +91,9 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     }
 
     private void validateSubscriptionSupported(Album album) {
-        if (album.getPlan() == AlbumPlan.BASIC) {
+        if (album.getType() == AlbumType.BASIC) {
             throw new CustomException(
-                    SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN);
+                    SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE);
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.util.List;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.controller.AlbumController;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
@@ -49,18 +49,18 @@ class AlbumControllerTest {
     class 앨범_생성_요청_시 {
 
         @Nested
-        class BASIC_플랜인_경우 {
+        class BASIC_유형인_경우 {
 
             @Test
             void 결제ID_없이_요청하면_앨범_생성_정보를_반환한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, false);
+                                "testTitle", "testCoverUrl", AlbumType.BASIC, null, false);
 
                 AlbumCreateResponse response =
                         new AlbumCreateResponse(
-                                1L, "testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
+                                1L, "testTitle", "testCoverUrl", AlbumType.BASIC, false);
 
                 given(albumService.createAlbum(request)).willReturn(response);
 
@@ -77,7 +77,7 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.data.albumId").value(1))
                         .andExpect(jsonPath("$.data.title").value("testTitle"))
                         .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"))
-                        .andExpect(jsonPath("$.data.plan").value("BASIC"))
+                        .andExpect(jsonPath("$.data.type").value("BASIC"))
                         .andExpect(jsonPath("$.data.permissionControl").value("false"));
             }
 
@@ -86,12 +86,12 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumType.BASIC, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(
                                 new CustomException(
-                                        AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN));
+                                        AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_TYPE));
 
                 // when & then
                 ResultActions perform =
@@ -105,9 +105,9 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                         .andExpect(
                                 jsonPath("$.data.code")
-                                        .value("PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN"))
+                                        .value("PAYMENT_NOT_REQUIRED_FOR_BASIC_TYPE"))
                         .andExpect(
-                                jsonPath("$.data.message").value("BASIC 플랜에서는 결제 ID가 필요하지 않습니다."));
+                                jsonPath("$.data.message").value("BASIC 유형에서는 결제 ID가 필요하지 않습니다."));
             }
 
             @Test
@@ -115,13 +115,13 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, true);
+                                "testTitle", "testCoverUrl", AlbumType.BASIC, null, true);
 
                 given(albumService.createAlbum(request))
                         .willThrow(
                                 new CustomException(
                                         AlbumErrorCode
-                                                .PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN));
+                                                .PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE));
 
                 // when & then
                 ResultActions perform =
@@ -135,26 +135,26 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                         .andExpect(
                                 jsonPath("$.data.code")
-                                        .value("PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN"))
+                                        .value("PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE"))
                         .andExpect(
                                 jsonPath("$.data.message")
-                                        .value("BASIC 플랜에서는 권한 부여 활성화가 허용되지 않습니다."));
+                                        .value("BASIC 유형에서는 권한 부여 활성화가 허용되지 않습니다."));
             }
         }
 
         @Nested
-        class PRO_또는_PREMIUM_플랜인_경우 {
+        class PRO_또는_PREMIUM_유형인_경우 {
 
             @Test
             void 유효한_결제ID면_앨범_생성_정보를_반환한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, true);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, true);
 
                 AlbumCreateResponse response =
                         new AlbumCreateResponse(
-                                1L, "testTitle", "testCoverUrl", AlbumPlan.PRO, true);
+                                1L, "testTitle", "testCoverUrl", AlbumType.PRO, true);
 
                 given(albumService.createAlbum(request)).willReturn(response);
 
@@ -171,7 +171,7 @@ class AlbumControllerTest {
                         .andExpect(jsonPath("$.data.albumId").value(1))
                         .andExpect(jsonPath("$.data.title").value("testTitle"))
                         .andExpect(jsonPath("$.data.coverUrl").value("testCoverUrl"))
-                        .andExpect(jsonPath("$.data.plan").value("PRO"))
+                        .andExpect(jsonPath("$.data.type").value("PRO"))
                         .andExpect(jsonPath("$.data.permissionControl").value("true"));
             }
 
@@ -180,11 +180,11 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, null, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, null, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(
-                                new CustomException(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_PLAN));
+                                new CustomException(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_TYPE));
 
                 // when & then
                 ResultActions perform =
@@ -196,8 +196,8 @@ class AlbumControllerTest {
                 perform.andExpect(status().isBadRequest())
                         .andExpect(jsonPath("$.success").value(false))
                         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                        .andExpect(jsonPath("$.data.code").value("PAYMENT_REQUIRED_FOR_PAID_PLAN"))
-                        .andExpect(jsonPath("$.data.message").value("유료 플랜은 결제 ID가 필요합니다."));
+                        .andExpect(jsonPath("$.data.code").value("PAYMENT_REQUIRED_FOR_PAID_TYPE"))
+                        .andExpect(jsonPath("$.data.message").value("유료 앨범 유형은 결제 ID가 필요합니다."));
             }
 
             @Test
@@ -205,7 +205,7 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 999L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 999L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
@@ -229,7 +229,7 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(new CustomException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH));
@@ -253,7 +253,7 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(new CustomException(PaymentDomainErrorCode.NOT_PAID));
@@ -277,7 +277,7 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(
@@ -302,7 +302,7 @@ class AlbumControllerTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, false);
 
                 given(albumService.createAlbum(request))
                         .willThrow(
@@ -331,7 +331,7 @@ class AlbumControllerTest {
         void 앨범_이름이_null_또는_공백이면_예외가_발생한다(String title) throws Exception {
             // given
             AlbumCreateRequest request =
-                    new AlbumCreateRequest(title, "testCoverUrl", AlbumPlan.BASIC, null, false);
+                    new AlbumCreateRequest(title, "testCoverUrl", AlbumType.BASIC, null, false);
 
             // when & then
             ResultActions perform =
@@ -352,7 +352,7 @@ class AlbumControllerTest {
             // given
             AlbumCreateRequest request =
                     new AlbumCreateRequest(
-                            "t".repeat(21), "testCoverUrl", AlbumPlan.BASIC, null, false);
+                            "t".repeat(21), "testCoverUrl", AlbumType.BASIC, null, false);
 
             // when & then
             ResultActions perform =
@@ -372,11 +372,11 @@ class AlbumControllerTest {
         @NullSource
         @EmptySource
         @ValueSource(strings = {" ", "PROO", "PREMIUMM"})
-        void 앨범_플랜이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String plan) throws Exception {
+        void 앨범_유형이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String type) throws Exception {
             // given
             AlbumCreateRequest request =
                     new AlbumCreateRequest(
-                            "testTitle", "testCoverUrl", AlbumPlan.from(plan), 1L, false);
+                            "testTitle", "testCoverUrl", AlbumType.from(type), 1L, false);
 
             // when & then
             ResultActions perform =
@@ -391,7 +391,7 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(
                             jsonPath("$.data.message")
-                                    .value("앨범 플랜은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다."));
+                                    .value("앨범 유형은 비워둘 수 없으며, BASIC, PRO, PREMIUM만 지원됩니다."));
         }
 
         @ParameterizedTest
@@ -400,7 +400,7 @@ class AlbumControllerTest {
             // given
             AlbumCreateRequest request =
                     new AlbumCreateRequest(
-                            "testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L, permissionControl);
+                            "testTitle", "testCoverUrl", AlbumType.BASIC, 1L, permissionControl);
 
             // when & then
             ResultActions perform =
@@ -428,7 +428,7 @@ class AlbumControllerTest {
 
             AlbumUpdateResponse response =
                     new AlbumUpdateResponse(
-                            1L, "testUpdatedTitle", "testUpdatedCoverUrl", AlbumPlan.BASIC);
+                            1L, "testUpdatedTitle", "testUpdatedCoverUrl", AlbumType.BASIC);
 
             given(albumService.updateAlbum(1L, request)).willReturn(response);
 
@@ -623,12 +623,12 @@ class AlbumControllerTest {
         }
 
         @Test
-        void BASIC_플랜인_경우_예외가_발생한다() throws Exception {
+        void BASIC_유형인_경우_예외가_발생한다() throws Exception {
             // given
             given(albumService.togglePermission(1L))
                     .willThrow(
                             new CustomException(
-                                    AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN));
+                                    AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE));
 
             // when & then
             ResultActions perform = mockMvc.perform(patch("/albums/1/permission"));
@@ -638,9 +638,9 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(
                             jsonPath("$.data.code")
-                                    .value("PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN"))
+                                    .value("PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE"))
                     .andExpect(
-                            jsonPath("$.data.message").value("BASIC 플랜에서는 권한 부여 활성화가 허용되지 않습니다."));
+                            jsonPath("$.data.message").value("BASIC 유형에서는 권한 부여 활성화가 허용되지 않습니다."));
         }
     }
 
@@ -853,7 +853,7 @@ class AlbumControllerTest {
                     new AlbumInfoResponse(
                             "testAlbum",
                             "testUrl",
-                            AlbumPlan.BASIC,
+                            AlbumType.BASIC,
                             new BigDecimal("0.00"),
                             new BigDecimal("3"),
                             "testNickname",
@@ -868,7 +868,7 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
                     .andExpect(jsonPath("$.data.title").value("testAlbum"))
                     .andExpect(jsonPath("$.data.coverUrl").value("testUrl"))
-                    .andExpect(jsonPath("$.data.albumPlan").value("BASIC"))
+                    .andExpect(jsonPath("$.data.type").value("BASIC"))
                     .andExpect(jsonPath("$.data.capacityUsed").value("0.00"))
                     .andExpect(jsonPath("$.data.totalCapacity").value("3"))
                     .andExpect(jsonPath("$.data.hostName").value("testNickname"))
@@ -931,29 +931,29 @@ class AlbumControllerTest {
     class 앨범_목록_조회_요청_시 {
 
         @Test
-        void PRO_플랜으로_필터링하면_PRO_앨범만_응답한다() throws Exception {
+        void PRO_유형으로_필터링하면_PRO_앨범만_응답한다() throws Exception {
             // given
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.PRO, false));
+                                    1L, "testTitle1", "testCoverUrl1", AlbumType.PRO, false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    AlbumPlan.PRO, null, null, 2, SortDirection.DESC))
+                                    AlbumType.PRO, null, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(get("/albums").param("plan", "PRO").param("size", "2"));
+                    mockMvc.perform(get("/albums").param("type", "PRO").param("size", "2"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                    .andExpect(jsonPath("$.data.content[0].plan").value("PRO"))
-                    .andExpect(jsonPath("$.data.content[1].plan").value("PRO"))
+                    .andExpect(jsonPath("$.data.content[0].type").value("PRO"))
+                    .andExpect(jsonPath("$.data.content[1].type").value("PRO"))
                     .andExpect(jsonPath("$.data.isLast").value(true));
         }
 
@@ -963,9 +963,9 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.BASIC, true),
+                                    2L, "testTitle2", "testCoverUrl2", AlbumType.BASIC, true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
+                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -986,25 +986,25 @@ class AlbumControllerTest {
         }
 
         @Test
-        void PRO_플랜과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_응답한다() throws Exception {
+        void PRO_유형과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_응답한다() throws Exception {
             // given
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.PRO, false));
+                                    1L, "testTitle1", "testCoverUrl1", AlbumType.PRO, false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    AlbumPlan.PRO, "testTitle", null, 2, SortDirection.DESC))
+                                    AlbumType.PRO, "testTitle", null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
                             get("/albums")
-                                    .param("plan", "PRO")
+                                    .param("type", "PRO")
                                     .param("keyword", "testTitle")
                                     .param("size", "2"));
 
@@ -1022,9 +1022,9 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false),
+                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false),
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true));
+                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -1049,9 +1049,9 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
+                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -1076,7 +1076,7 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
+                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -1100,9 +1100,9 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumPlan.PRO, true),
+                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false));
+                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -14,7 +14,7 @@ import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.entity.InvitationCode;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.request.AlbumCreateRequest;
 import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.AlbumInfoResponse;
@@ -84,7 +84,7 @@ class AlbumServiceTest extends IntegrationTest {
     class 앨범을_생성할_때 {
 
         @Nested
-        class BASIC_플랜인_경우 {
+        class BASIC_유형인_경우 {
 
             @BeforeEach
             void setUp() {
@@ -103,7 +103,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, false);
+                                "testTitle", "testCoverUrl", AlbumType.BASIC, null, false);
 
                 // when
                 albumService.createAlbum(request);
@@ -125,13 +125,13 @@ class AlbumServiceTest extends IntegrationTest {
                                                 "id",
                                                 "title",
                                                 "coverUrl",
-                                                "plan",
+                                                "type",
                                                 "permissionControl")
                                         .containsExactly(
                                                 1L,
                                                 "testTitle",
                                                 "testCoverUrl",
-                                                AlbumPlan.BASIC,
+                                                AlbumType.BASIC,
                                                 false),
                         () ->
                                 assertThat(participant)
@@ -144,13 +144,13 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumType.BASIC, 1L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
                         .isInstanceOf(CustomException.class)
                         .hasMessage(
-                                AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_PLAN.getMessage());
+                                AlbumErrorCode.PAYMENT_NOT_REQUIRED_FOR_BASIC_TYPE.getMessage());
             }
 
             @Test
@@ -158,19 +158,19 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.BASIC, null, true);
+                                "testTitle", "testCoverUrl", AlbumType.BASIC, null, true);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
                         .isInstanceOf(CustomException.class)
                         .hasMessage(
-                                AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN
+                                AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE
                                         .getMessage());
             }
         }
 
         @Nested
-        class PRO_또는_PREMIUM_플랜인_경우 {
+        class PRO_또는_PREMIUM_유형인_경우 {
 
             @BeforeEach
             void setUp() {
@@ -190,7 +190,7 @@ class AlbumServiceTest extends IntegrationTest {
 
                 Album album =
                         Album.createAlbum(
-                                "testPaidTitle", "testPaidCoverUrl", AlbumPlan.PRO, false);
+                                "testPaidTitle", "testPaidCoverUrl", AlbumType.PRO, false);
                 albumRepository.save(album);
 
                 // 검증 완료된 결제
@@ -224,7 +224,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, true);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, true);
 
                 LocalDateTime startAt = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
 
@@ -252,13 +252,13 @@ class AlbumServiceTest extends IntegrationTest {
                                                 "id",
                                                 "title",
                                                 "coverUrl",
-                                                "plan",
+                                                "type",
                                                 "permissionControl")
                                         .containsExactly(
                                                 2L,
                                                 "testTitle",
                                                 "testCoverUrl",
-                                                AlbumPlan.PRO,
+                                                AlbumType.PRO,
                                                 true),
                         () ->
                                 assertThat(participant)
@@ -294,12 +294,12 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, null, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, null, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
                         .isInstanceOf(CustomException.class)
-                        .hasMessage(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_PLAN.getMessage());
+                        .hasMessage(AlbumErrorCode.PAYMENT_REQUIRED_FOR_PAID_TYPE.getMessage());
             }
 
             @Test
@@ -307,7 +307,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 999L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 999L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -323,7 +323,7 @@ class AlbumServiceTest extends IntegrationTest {
 
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 1L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -336,7 +336,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 2L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 2L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -349,7 +349,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 3L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 3L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -362,7 +362,7 @@ class AlbumServiceTest extends IntegrationTest {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
-                                "testTitle", "testCoverUrl", AlbumPlan.PRO, 4L, false);
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 4L, false);
 
                 // when & then
                 assertThatThrownBy(() -> albumService.createAlbum(request))
@@ -385,9 +385,9 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -411,12 +411,12 @@ class AlbumServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () ->
                             assertThat(album)
-                                    .extracting("id", "title", "coverUrl", "plan")
+                                    .extracting("id", "title", "coverUrl", "type")
                                     .containsExactly(
                                             1L,
                                             "testUpdatedTitle",
                                             "testUpdatedCoverUrl",
-                                            AlbumPlan.BASIC));
+                                            AlbumType.BASIC));
         }
 
         @Test
@@ -496,10 +496,10 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2, member3, member4));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.PRO, true);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
-            Album album4 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.PRO, true);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
+            Album album4 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3, album4));
 
             Participant participant1 =
@@ -576,12 +576,12 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void BASIC_플랜인_경우_예외가_발생한다() {
+        void BASIC_유형인_경우_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> albumService.togglePermission(3L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(
-                            AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_PLAN
+                            AlbumErrorCode.PERMISSION_CONTROL_NOT_ALLOWED_FOR_BASIC_TYPE
                                     .getMessage());
         }
     }
@@ -604,8 +604,8 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -710,9 +710,9 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant =
@@ -789,7 +789,7 @@ class AlbumServiceTest extends IntegrationTest {
         void 최대_참가자_수를_초과하면_예외가_발생한다() {
             // given
             Album album = albumRepository.findById(1L).orElseThrow();
-            int maxParticipants = album.getPlan().getMaxParticipants();
+            int maxParticipants = album.getType().getMaxParticipants();
 
             for (int i = 0; i < maxParticipants; i++) {
                 Member member =
@@ -824,9 +824,9 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -846,7 +846,7 @@ class AlbumServiceTest extends IntegrationTest {
                     .extracting(
                             "title",
                             "coverUrl",
-                            "albumPlan",
+                            "type",
                             "capacityUsed",
                             "totalCapacity",
                             "hostName",
@@ -854,7 +854,7 @@ class AlbumServiceTest extends IntegrationTest {
                     .containsExactly(
                             "testAlbum1",
                             "testURL1",
-                            AlbumPlan.BASIC,
+                            AlbumType.BASIC,
                             new BigDecimal("0.00"),
                             new BigDecimal("3"),
                             "testNickname",
@@ -899,9 +899,9 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.PRO, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.PRO, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -919,16 +919,16 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void PRO_플랜으로_필터링하면_PRO_앨범만_조회한다() {
+        void PRO_유형으로_필터링하면_PRO_앨범만_조회한다() {
             // given
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            AlbumPlan.PRO, null, null, 1, SortDirection.DESC);
+                            AlbumType.PRO, null, null, 1, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(
                     () -> assertThat(response.content().get(0).albumId()).isEqualTo(3),
-                    () -> assertThat(response.content().get(0).plan()).isEqualTo(AlbumPlan.PRO),
+                    () -> assertThat(response.content().get(0).type()).isEqualTo(AlbumType.PRO),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -947,17 +947,17 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
-        void PRO_플랜과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_조회한다() {
+        void PRO_유형과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_조회한다() {
             // given
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            AlbumPlan.PRO, "title3", null, 1, SortDirection.DESC);
+                            AlbumType.PRO, "title3", null, 1, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(
                     () -> assertThat(response.content().get(0).albumId()).isEqualTo(3),
                     () -> assertThat(response.content().get(0).title()).isEqualTo("testTitle3"),
-                    () -> assertThat(response.content().get(0).plan()).isEqualTo(AlbumPlan.PRO),
+                    () -> assertThat(response.content().get(0).type()).isEqualTo(AlbumType.PRO),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -1054,11 +1054,11 @@ class AlbumServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
-            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.BASIC, false);
-            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.PRO, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.BASIC, false);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PRO, false);
             albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
 
             Image image = Image.createImage(album1, 1L, "testUrl", LocalDateTime.now());

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
@@ -87,8 +87,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -162,8 +162,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2, member3));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -268,8 +268,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURl2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURl2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -345,8 +345,8 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =
@@ -463,9 +463,9 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -698,9 +698,9 @@ public class EventServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/favorites/service/FavoritesServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/favorites/service/FavoritesServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.favorites.repository.FavoritesRepository;
@@ -48,8 +48,8 @@ class FavoritesServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -137,9 +137,9 @@ class ImageServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -201,9 +201,9 @@ class ImageServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -270,10 +270,10 @@ class ImageServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
             album1.increaseCapacity(BigDecimal.ONE);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -478,9 +478,9 @@ class ImageServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -585,8 +585,8 @@ class ImageServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant =
@@ -696,7 +696,7 @@ class ImageServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
+            Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumType.BASIC, false);
             albumRepository.save(album);
 
             Image image1 = Image.createImage(album, 1L, "testUrl1", LocalDateTime.now());
@@ -744,9 +744,9 @@ class ImageServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/notification/service/NotificationServiceTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.RedisCleaner;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.notification.repository.NotificationRepository;
@@ -66,7 +66,7 @@ class NotificationServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2, member3));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album = Album.createAlbum("testAlbum", "testURL", AlbumPlan.BASIC, false);
+            Album album = Album.createAlbum("testAlbum", "testURL", AlbumType.BASIC, false);
             albumRepository.save(album);
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
@@ -66,9 +66,9 @@ class ParticipantServiceTest extends IntegrationTest {
             memberRepository.save(member2);
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -177,9 +177,9 @@ class ParticipantServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -307,11 +307,11 @@ class ParticipantServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.PRO, true);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.PRO, true);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, true);
-            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.PRO, true);
-            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.PRO, true);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.PRO, true);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, true);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.PRO, true);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
 
             Participant participant1 =
@@ -523,8 +523,8 @@ class ParticipantServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2, member3, member4));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.BASIC, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             albumRepository.saveAll(List.of(album1, album2));
 
             Participant participant1 =

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -385,7 +385,7 @@ class PaymentControllerTest {
     }
 
     @Nested
-    class 앨범_유료_플랜_결제_검증_요청_시 {
+    class 결제_검증_요청_시 {
 
         @Test
         void 유효한_요청이면_결제_ID를_반환한다() throws Exception {

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.payment.controller.PaymentController;
 import org.cherrypic.domain.payment.dto.request.PaymentReadyRequest;
@@ -44,16 +44,16 @@ class PaymentControllerTest {
     class 결제_준비_요청_시 {
 
         @Nested
-        class 유료_앨범_최초_생성의_경우 {
+        class 유료_앨범_생성의_경우 {
 
             @Test
             void CREATION_목적의_결제_준비_정보를_반환한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, null);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, null);
 
                 PaymentReadyResponse response =
                         new PaymentReadyResponse(
-                                AlbumPlan.PRO,
+                                AlbumType.PRO,
                                 3900,
                                 "album_20250723_pro_1_a5c5dd8beaa6",
                                 "상냥한 너구리",
@@ -71,7 +71,7 @@ class PaymentControllerTest {
                 perform.andExpect(status().isOk())
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                        .andExpect(jsonPath("$.data.plan").value("PRO"))
+                        .andExpect(jsonPath("$.data.type").value("PRO"))
                         .andExpect(jsonPath("$.data.price").value("3900"))
                         .andExpect(
                                 jsonPath("$.data.merchantUid")
@@ -87,11 +87,11 @@ class PaymentControllerTest {
             @Test
             void RENEWAL_목적의_결제_준비_정보를_반환한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 PaymentReadyResponse response =
                         new PaymentReadyResponse(
-                                AlbumPlan.PRO,
+                                AlbumType.PRO,
                                 5900,
                                 "album_20250723_pro_1_a5c5dd8beaa6",
                                 "상냥한 너구리",
@@ -109,7 +109,7 @@ class PaymentControllerTest {
                 perform.andExpect(status().isOk())
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                        .andExpect(jsonPath("$.data.plan").value("PRO"))
+                        .andExpect(jsonPath("$.data.type").value("PRO"))
                         .andExpect(jsonPath("$.data.price").value("5900"))
                         .andExpect(
                                 jsonPath("$.data.merchantUid")
@@ -119,9 +119,9 @@ class PaymentControllerTest {
             }
 
             @Test
-            void 하위_플랜으로_결제_준비를_요청하면_예외가_발생한다() throws Exception {
+            void 하위_앨범_유형으로_결제_준비를_요청하면_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(PaymentErrorCode.DOWNGRADE_NOT_ALLOWED));
@@ -139,13 +139,13 @@ class PaymentControllerTest {
                         .andExpect(jsonPath("$.data.code").value("DOWNGRADE_NOT_ALLOWED"))
                         .andExpect(
                                 jsonPath("$.data.message")
-                                        .value("현재 구독 플랜보다 낮은 플랜으로는 결제를 진행할 수 없습니다."));
+                                        .value("현재 앨범 유형보다 낮은 유형으로 결제를 진행할 수 없습니다."));
             }
 
             @Test
             void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
@@ -167,7 +167,7 @@ class PaymentControllerTest {
             @Test
             void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
@@ -189,7 +189,7 @@ class PaymentControllerTest {
             @Test
             void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
@@ -215,11 +215,11 @@ class PaymentControllerTest {
             @Test
             void UPGRADE_목적의_결제_준비_정보를_반환한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PREMIUM, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PREMIUM, 1L);
 
                 PaymentReadyResponse response =
                         new PaymentReadyResponse(
-                                AlbumPlan.PREMIUM,
+                                AlbumType.PREMIUM,
                                 12900,
                                 "album_20250723_pro_1_a5c5dd8beaa6",
                                 "상냥한 너구리",
@@ -237,7 +237,7 @@ class PaymentControllerTest {
                 perform.andExpect(status().isOk())
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                        .andExpect(jsonPath("$.data.plan").value("PREMIUM"))
+                        .andExpect(jsonPath("$.data.type").value("PREMIUM"))
                         .andExpect(jsonPath("$.data.price").value("12900"))
                         .andExpect(
                                 jsonPath("$.data.merchantUid")
@@ -247,9 +247,9 @@ class PaymentControllerTest {
             }
 
             @Test
-            void 하위_플랜으로_결제_준비를_요청하면_예외가_발생한다() throws Exception {
+            void 하위_앨범_유형으로_결제_준비를_요청하면_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(PaymentErrorCode.DOWNGRADE_NOT_ALLOWED));
@@ -267,13 +267,13 @@ class PaymentControllerTest {
                         .andExpect(jsonPath("$.data.code").value("DOWNGRADE_NOT_ALLOWED"))
                         .andExpect(
                                 jsonPath("$.data.message")
-                                        .value("현재 구독 플랜보다 낮은 플랜으로는 결제를 진행할 수 없습니다."));
+                                        .value("현재 앨범 유형보다 낮은 유형으로 결제를 진행할 수 없습니다."));
             }
 
             @Test
             void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
@@ -295,7 +295,7 @@ class PaymentControllerTest {
             @Test
             void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
@@ -317,7 +317,7 @@ class PaymentControllerTest {
             @Test
             void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 given(paymentService.preparePayment(request))
                         .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
@@ -338,12 +338,12 @@ class PaymentControllerTest {
         }
 
         @Test
-        void BASIC_플랜으로_결제_준비를_요청하면_예외가_발생한다() throws Exception {
+        void BASIC_유형으로_결제_준비를_요청하면_예외가_발생한다() throws Exception {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.BASIC, null);
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.BASIC, null);
 
             given(paymentService.preparePayment(request))
-                    .willThrow(new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT_PLAN));
+                    .willThrow(new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT));
 
             // when & then
             ResultActions perform =
@@ -355,20 +355,17 @@ class PaymentControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("UNSUPPORTED_PAYMENT_PLAN"))
-                    .andExpect(
-                            jsonPath("$.data.message")
-                                    .value(
-                                            "해당 플랜은 유료 결제가 필요하지 않습니다. PRO 또는 PREMIUM 플랜만 결제가 가능합니다."));
+                    .andExpect(jsonPath("$.data.code").value("UNSUPPORTED_PAYMENT"))
+                    .andExpect(jsonPath("$.data.message").value("BASIC 유형은 결제를 지원하지 않습니다."));
         }
 
         @ParameterizedTest
         @NullSource
         @EmptySource
         @ValueSource(strings = {" ", "PROO", "PREMIUMM"})
-        void 앨범_플랜이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String plan) throws Exception {
+        void 앨범_유형이_null_또는_지원하지_않는_형식이면_예외가_발생한다(String type) throws Exception {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.from(plan), null);
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.from(type), null);
 
             // when & then
             ResultActions perform =
@@ -383,7 +380,7 @@ class PaymentControllerTest {
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(
                             jsonPath("$.data.message")
-                                    .value("앨범 구독 플랜은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다."));
+                                    .value("유료 앨범 유형은 비워둘 수 없으며, PRO, PREMIUM만 지원됩니다."));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
@@ -19,7 +18,7 @@ import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
@@ -62,47 +61,44 @@ public class PaymentServiceTest extends IntegrationTest {
     @Mock private IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse;
     @Mock private com.siot.IamportRestClient.response.Payment iamportPayment;
 
-    private Member member;
-
-    @BeforeEach
-    void setUp() {
-        member =
-                Member.createMember(
-                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
-                        "testNickname",
-                        "testProfileImageUrl");
-        memberRepository.save(member);
-
-        given(memberUtil.getCurrentMember()).willReturn(member);
-
-        Album proAlbum = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumPlan.PRO, false);
-        Album premiumAlbum =
-                Album.createAlbum("testTitle2", "testCoverUrl2", AlbumPlan.PREMIUM, false);
-        Album basicAlbum1 =
-                Album.createAlbum("testTitle3", "testCoverUrl3", AlbumPlan.BASIC, false);
-        Album basicAlbum2 =
-                Album.createAlbum("testTitle4", "testCoverUrl4", AlbumPlan.BASIC, false);
-        albumRepository.saveAll(List.of(proAlbum, premiumAlbum, basicAlbum1, basicAlbum2));
-
-        Participant participant1 =
-                Participant.createParticipant(member, proAlbum, ParticipantRole.HOST);
-        Participant participant2 =
-                Participant.createParticipant(member, premiumAlbum, ParticipantRole.HOST);
-        Participant participant3 =
-                Participant.createParticipant(member, basicAlbum2, ParticipantRole.STANDARD);
-        participantRepository.saveAll(List.of(participant1, participant2, participant3));
-    }
-
     @Nested
     class 결제를_준비할_때 {
 
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            Album proAlbum = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.PRO, false);
+            Album premiumAlbum =
+                    Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.PREMIUM, false);
+            Album basicAlbum1 =
+                    Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
+            Album basicAlbum2 =
+                    Album.createAlbum("testTitle4", "testCoverUrl4", AlbumType.BASIC, false);
+            albumRepository.saveAll(List.of(proAlbum, premiumAlbum, basicAlbum1, basicAlbum2));
+
+            Participant participant1 =
+                    Participant.createParticipant(member, proAlbum, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member, premiumAlbum, ParticipantRole.HOST);
+            Participant participant3 =
+                    Participant.createParticipant(member, basicAlbum2, ParticipantRole.STANDARD);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+        }
+
         @Nested
-        class 유료_앨범_최초_생성의_경우 {
+        class 유료_앨범_생성의_경우 {
 
             @Test
             void CREATION_목적의_결제_준비_정보를_생성한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, null);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, null);
 
                 // when
                 paymentService.preparePayment(request);
@@ -126,7 +122,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void RENEWAL_목적의_결제_준비_정보를_생성한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
 
                 // when
                 paymentService.preparePayment(request);
@@ -144,9 +140,9 @@ public class PaymentServiceTest extends IntegrationTest {
             }
 
             @Test
-            void 하위_플랜으로_결제_준비를_요청하면_예외가_발생한다() {
+            void 하위_앨범_유형으로_결제_준비를_요청하면_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 2L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 2L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -157,7 +153,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void 앨범이_존재하지_않는_경우_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 999L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 999L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -168,7 +164,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void 앨범_참가자가_아닌_경우_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 3L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 3L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -179,7 +175,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void 앨범_방장이_아닌_경우_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 4L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 4L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -194,7 +190,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void UPGRADE_목적의_결제_준비_정보를_생성한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PREMIUM, 1L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PREMIUM, 1L);
 
                 // when
                 paymentService.preparePayment(request);
@@ -212,9 +208,9 @@ public class PaymentServiceTest extends IntegrationTest {
             }
 
             @Test
-            void 하위_플랜으로_결제_준비를_요청하면_예외가_발생한다() {
+            void 하위_앨범_유형으로_결제_준비를_요청하면_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PRO, 2L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 2L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -225,7 +221,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void 앨범이_존재하지_않는_경우_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PREMIUM, 999L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PREMIUM, 999L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -236,7 +232,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void 앨범_참가자가_아닌_경우_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PREMIUM, 3L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PREMIUM, 3L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -247,7 +243,7 @@ public class PaymentServiceTest extends IntegrationTest {
             @Test
             void 앨범_방장이_아닌_경우_예외가_발생한다() {
                 // given
-                PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.PREMIUM, 4L);
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PREMIUM, 4L);
 
                 // when & then
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
@@ -257,19 +253,19 @@ public class PaymentServiceTest extends IntegrationTest {
         }
 
         @Test
-        void BASIC_플랜으로_결제_준비를_요청하면_예외가_발생한다() {
+        void BASIC_유형으로_결제_준비를_요청하면_예외가_발생한다() {
             // given
-            PaymentReadyRequest request = new PaymentReadyRequest(AlbumPlan.BASIC, null);
+            PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.BASIC, null);
 
             // when & then
             assertThatThrownBy(() -> paymentService.preparePayment(request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(PaymentErrorCode.UNSUPPORTED_PAYMENT_PLAN.getMessage());
+                    .hasMessage(PaymentErrorCode.UNSUPPORTED_PAYMENT.getMessage());
         }
     }
 
     @Nested
-    class 앨범_유료_플랜_결제를_검증할_때 {
+    class 결제를_검증할_때 {
 
         private static final String MERCHANT_UID_EXISTING = "album_20250724_pro_1_a5c5dd8beaa6";
         private static final String MERCHANT_UID_NON_EXISTING =
@@ -277,6 +273,14 @@ public class PaymentServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
             paymentRepository.save(
                     Payment.createPayment(
                             member, MERCHANT_UID_EXISTING, 3900, PaymentPurpose.CREATION));

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -106,12 +106,12 @@ class SubscriptionControllerTest {
         }
 
         @Test
-        void BASIC_플랜인_경우_예외가_발생한다() throws Exception {
+        void BASIC_유형인_경우_예외가_발생한다() throws Exception {
             // given
             willThrow(
                             new CustomException(
                                     SubscriptionErrorCode
-                                            .SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN))
+                                            .SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE))
                     .given(subscriptionService)
                     .cancelSubscription(1L);
 
@@ -123,8 +123,8 @@ class SubscriptionControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(
                             jsonPath("$.data.code")
-                                    .value("SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN"))
-                    .andExpect(jsonPath("$.data.message").value("BASIC 플랜은 구독 기능을 지원하지 않습니다."));
+                                    .value("SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE"))
+                    .andExpect(jsonPath("$.data.message").value("BASIC 유형은 구독 기능을 지원하지 않습니다."));
         }
 
         @Test
@@ -162,7 +162,7 @@ class SubscriptionControllerTest {
         }
 
         @Test
-        void 종료된_구독이면_예외가_발생한다() throws Exception {
+        void 만료된_구독이면_예외가_발생한다() throws Exception {
             // given
             willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_EXPIRED))
                     .given(subscriptionService)
@@ -278,7 +278,7 @@ class SubscriptionControllerTest {
         }
 
         @Test
-        void BASIC_플랜인_경우_예외가_발생한다() throws Exception {
+        void BASIC_유형인_경우_예외가_발생한다() throws Exception {
             // given
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 
@@ -286,7 +286,7 @@ class SubscriptionControllerTest {
                     .willThrow(
                             new CustomException(
                                     SubscriptionErrorCode
-                                            .SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN));
+                                            .SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE));
 
             // when & then
             ResultActions perform =
@@ -300,8 +300,8 @@ class SubscriptionControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(
                             jsonPath("$.data.code")
-                                    .value("SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN"))
-                    .andExpect(jsonPath("$.data.message").value("BASIC 플랜은 구독 기능을 지원하지 않습니다."));
+                                    .value("SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE"))
+                    .andExpect(jsonPath("$.data.message").value("BASIC 유형은 구독 기능을 지원하지 않습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -9,7 +9,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.album.entity.Album;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
@@ -64,12 +64,12 @@ class SubscriptionServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.BASIC, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.PRO, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, false);
-            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.PREMIUM, false);
-            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.PREMIUM, false);
-            Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumPlan.PREMIUM, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.PRO, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, false);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.PREMIUM, false);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PREMIUM, false);
+            Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumType.PREMIUM, false);
             albumRepository.saveAll(List.of(album1, album2, album3, album4, album5, album6));
 
             Participant participant1 =
@@ -132,12 +132,12 @@ class SubscriptionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void BASIC_플랜인_경우_예외가_발생한다() {
+        void BASIC_유형인_경우_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> subscriptionService.cancelSubscription(1L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(
-                            SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN
+                            SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE
                                     .getMessage());
         }
 
@@ -161,7 +161,7 @@ class SubscriptionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 종료된_구독이면_예외가_발생한다() {
+        void 만료된_구독이면_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> subscriptionService.cancelSubscription(3L))
                     .isInstanceOf(CustomException.class)
@@ -187,13 +187,13 @@ class SubscriptionServiceTest extends IntegrationTest {
             memberRepository.saveAll(List.of(member1, member2));
             given(memberUtil.getCurrentMember()).willReturn(member1);
 
-            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumPlan.PRO, false);
-            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumPlan.PRO, false);
-            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumPlan.PRO, false);
-            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumPlan.BASIC, false);
-            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumPlan.PREMIUM, false);
-            Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumPlan.PREMIUM, false);
-            Album album7 = Album.createAlbum("testAlbum7", "testURL7", AlbumPlan.PREMIUM, false);
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.PRO, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.PRO, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, false);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.BASIC, false);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PREMIUM, false);
+            Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumType.PREMIUM, false);
+            Album album7 = Album.createAlbum("testAlbum7", "testURL7", AlbumType.PREMIUM, false);
             albumRepository.saveAll(
                     List.of(album1, album2, album3, album4, album5, album6, album7));
 
@@ -347,7 +347,7 @@ class SubscriptionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void BASIC_플랜인_경우_예외가_발생한다() {
+        void BASIC_유형인_경우_예외가_발생한다() {
             // given
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 
@@ -355,7 +355,7 @@ class SubscriptionServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> subscriptionService.renewSubscription(4L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(
-                            SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_PLAN
+                            SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE
                                     .getMessage());
         }
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -9,7 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.event.entity.Event;
@@ -34,7 +34,7 @@ public class Album extends BaseTimeEntity {
     private String coverUrl;
 
     @Enumerated(EnumType.STRING)
-    private AlbumPlan plan;
+    private AlbumType type;
 
     @NotNull private Boolean permissionControl;
 
@@ -62,22 +62,22 @@ public class Album extends BaseTimeEntity {
     private Album(
             String title,
             String coverUrl,
-            AlbumPlan plan,
+            AlbumType type,
             boolean permissionControl,
             BigDecimal capacityGb) {
         this.title = title;
         this.coverUrl = coverUrl;
-        this.plan = plan;
+        this.type = type;
         this.permissionControl = permissionControl;
         this.capacityGb = capacityGb;
     }
 
     public static Album createAlbum(
-            String title, String coverUrl, AlbumPlan plan, boolean permissionControl) {
+            String title, String coverUrl, AlbumType type, boolean permissionControl) {
         return Album.builder()
                 .title(title)
                 .coverUrl(coverUrl)
-                .plan(plan)
+                .type(type)
                 .permissionControl(permissionControl)
                 .capacityGb(BigDecimal.ZERO)
                 .build();

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumType.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumType.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum AlbumPlan {
+public enum AlbumType {
     BASIC(0, new BigDecimal("3"), 10),
     PRO(5900, new BigDecimal("200"), 50),
     PREMIUM(12900, new BigDecimal("2048"), Integer.MAX_VALUE);
@@ -18,9 +18,9 @@ public enum AlbumPlan {
     private final int maxParticipants;
 
     @JsonCreator
-    public static AlbumPlan from(String plan) {
+    public static AlbumType from(String type) {
         return Stream.of(values())
-                .filter(p -> p.name().equalsIgnoreCase(plan))
+                .filter(p -> p.name().equalsIgnoreCase(type))
                 .findFirst()
                 .orElse(null);
     }

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -16,7 +16,7 @@ CREATE TABLE album (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
                        title VARCHAR(20) NOT NULL,
                        cover_url VARCHAR(255),
-                       plan VARCHAR(255) CHECK (plan IN ('BASIC','PRO','PREMIUM')),
+                       type VARCHAR(255) CHECK (type IN ('BASIC','PRO','PREMIUM')),
                        permission_control BOOLEAN NOT NULL,
                        capacity_gb DECIMAL(6,2) NOT NULL,
                        created_at DATETIME(6) NOT NULL,

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/AlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/AlbumTest.java
@@ -3,7 +3,7 @@ package org.cherrypic.album.entity;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
-import org.cherrypic.album.enums.AlbumPlan;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.exception.CustomException;
 import org.junit.jupiter.api.Test;
@@ -13,7 +13,7 @@ class AlbumTest {
     @Test
     void 용량을_4자리_GB_이상으로_늘릴_경우_예외가_발생한다() {
         // given
-        Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
+        Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumType.BASIC, false);
 
         // when & then
         assertThatThrownBy(() -> album.increaseCapacity(BigDecimal.valueOf(10000)))
@@ -24,7 +24,7 @@ class AlbumTest {
     @Test
     void 용량을_0GB_미만으로_줄일_경우_예외가_발생한다() {
         // given
-        Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumPlan.BASIC, false);
+        Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumType.BASIC, false);
 
         // when & then
         assertThatThrownBy(() -> album.decreaseCapacity(BigDecimal.valueOf(1)))


### PR DESCRIPTION
## 🌱 관련 이슈
- close #176 

---
## 📌 작업 내용 및 특이사항
* 앨범 플랜 / 구독 플랜 등 혼용되던 용어를 앨범 유형으로 통일해 표현을 명확하게 하고자 리팩토링을 진행하였습니다.
* 앨범 플랜 Enum 명칭 및 관련 필드명을 전반적으로 정리했습니다.
* 에러 메시지, 쿼리 파라미터, DTO, Swagger 문서 등 관련된 모든 영역에 변경 사항을 반영했습니다.