### PR TITLE
feat: 앨범 목록 조회 응답에 앨범 생성일 및 구독 가격 필드 추가

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
@@ -1,6 +1,8 @@
 package org.cherrypic.domain.album.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import org.cherrypic.album.enums.AlbumType;
 
 public record AlbumListResponse(
@@ -8,4 +10,22 @@ public record AlbumListResponse(
         @Schema(description = "앨범 이름", example = "연인 앨범") String title,
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
         @Schema(description = "앨범 유형", example = "BASIC") AlbumType type,
-        @Schema(description = "즐겨찾기 상태", example = "true") Boolean marked) {}
+        @Schema(description = "앨범 구독 가격", example = "5900") Integer price,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "앨범 생성일", example = "2025-08-01")
+                LocalDateTime createdAt,
+        @Schema(description = "즐겨찾기 상태", example = "true") Boolean marked) {
+    public static AlbumListResponse of(
+            Long albumId,
+            String title,
+            String coverUrl,
+            AlbumType type,
+            LocalDateTime createdAt,
+            Boolean marked) {
+        return new AlbumListResponse(
+                albumId, title, coverUrl, type, type.getPrice(), createdAt, marked);
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -1,12 +1,14 @@
 package org.cherrypic.domain.album.repository;
 
 import static org.cherrypic.album.entity.QAlbum.album;
+import static org.cherrypic.favorites.entity.QFavorites.favorites;
 import static org.cherrypic.participant.entity.QParticipant.participant;
 
-import com.querydsl.core.types.Projections;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
@@ -30,16 +32,15 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
             Long lastAlbumId,
             int size,
             SortDirection direction) {
-        List<AlbumListResponse> results =
+        List<Tuple> tuples =
                 queryFactory
                         .select(
-                                Projections.constructor(
-                                        AlbumListResponse.class,
-                                        album.id,
-                                        album.title,
-                                        album.coverUrl,
-                                        album.type,
-                                        participant.favorites.marked))
+                                album.id,
+                                album.title,
+                                album.coverUrl,
+                                album.type,
+                                album.createdAt,
+                                participant.favorites.marked)
                         .from(participant)
                         .join(participant.album, album)
                         .where(
@@ -50,6 +51,19 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                         .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())
                         .limit(size + 1)
                         .fetch();
+
+        List<AlbumListResponse> results =
+                tuples.stream()
+                        .map(
+                                tuple ->
+                                        AlbumListResponse.of(
+                                                tuple.get(album.id),
+                                                tuple.get(album.title),
+                                                tuple.get(album.coverUrl),
+                                                tuple.get(album.type),
+                                                tuple.get(album.createdAt),
+                                                tuple.get(favorites.marked)))
+                        .collect(Collectors.toList());
 
         return checkLastPage(size, results);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
@@ -6,14 +6,14 @@ import org.cherrypic.payment.enums.PaymentPurpose;
 
 public record PaymentReadyResponse(
         @Schema(description = "유료 앨범 유형", defaultValue = "PRO") AlbumType type,
-        @Schema(description = "유료 앨범 가격", example = "3900") int price,
+        @Schema(description = "앨범 구독 가격", example = "3900") Integer price,
         @Schema(description = "결제 요청 고유 ID", example = "album_20250723_pro_1_c4f1a2b3d5e6")
                 String merchantUid,
         @Schema(description = "구매자 이름", example = "최현태") String buyerName,
         @Schema(description = "결제 목적", example = "RENEWAL") PaymentPurpose purpose) {
     public static PaymentReadyResponse of(
             AlbumType type,
-            int price,
+            Integer price,
             String merchantUid,
             String buyerName,
             PaymentPurpose purpose) {

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.controller.AlbumController;
@@ -844,7 +845,7 @@ class AlbumControllerTest {
     }
 
     @Nested
-    class 개별_앨범을_조회_요청_시 {
+    class 개별_앨범_조회_요청_시 {
 
         @Test
         void 유효한_요청인_경우_앨범_정보를_반환한다() throws Exception {
@@ -936,9 +937,21 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
+                                    2L,
+                                    "testTitle2",
+                                    "testCoverUrl2",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    LocalDateTime.now(),
+                                    true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumType.PRO, false));
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    LocalDateTime.now(),
+                                    false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -963,9 +976,21 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumType.BASIC, true),
+                                    2L,
+                                    "testTitle2",
+                                    "testCoverUrl2",
+                                    AlbumType.BASIC,
+                                    AlbumType.BASIC.getPrice(),
+                                    LocalDateTime.now(),
+                                    true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.BASIC,
+                                    AlbumType.BASIC.getPrice(),
+                                    LocalDateTime.now(),
+                                    false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -991,9 +1016,21 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
+                                    2L,
+                                    "testTitle2",
+                                    "testCoverUrl2",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    LocalDateTime.now(),
+                                    true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumType.PRO, false));
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    LocalDateTime.now(),
+                                    false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -1022,9 +1059,21 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false),
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.BASIC,
+                                    AlbumType.BASIC.getPrice(),
+                                    LocalDateTime.now(),
+                                    false),
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true));
+                                    2L,
+                                    "testTitle2",
+                                    "testCoverUrl2",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    LocalDateTime.now(),
+                                    true));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -1049,9 +1098,21 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
+                                    2L,
+                                    "testTitle2",
+                                    "testCoverUrl2",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    LocalDateTime.now(),
+                                    true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.BASIC,
+                                    AlbumType.BASIC.getPrice(),
+                                    LocalDateTime.now(),
+                                    false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -1076,7 +1137,13 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.BASIC,
+                                    AlbumType.BASIC.getPrice(),
+                                    LocalDateTime.now(),
+                                    false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
@@ -1100,9 +1167,21 @@ class AlbumControllerTest {
             List<AlbumListResponse> albums =
                     List.of(
                             new AlbumListResponse(
-                                    2L, "testTitle2", "testCoverUrl2", AlbumType.PRO, true),
+                                    2L,
+                                    "testTitle2",
+                                    "testCoverUrl2",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    LocalDateTime.now(),
+                                    true),
                             new AlbumListResponse(
-                                    1L, "testTitle1", "testCoverUrl1", AlbumType.BASIC, false));
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.BASIC,
+                                    AlbumType.BASIC.getPrice(),
+                                    LocalDateTime.now(),
+                                    false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -929,6 +929,16 @@ class AlbumServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(response.content().get(0).albumId()).isEqualTo(3),
                     () -> assertThat(response.content().get(0).type()).isEqualTo(AlbumType.PRO),
+                    () ->
+                            assertThat(response.content().get(0).price())
+                                    .isEqualTo(AlbumType.PRO.getPrice()),
+                    () ->
+                            assertThat(
+                                            response.content()
+                                                    .get(0)
+                                                    .createdAt()
+                                                    .truncatedTo(ChronoUnit.MINUTES))
+                                    .isEqualTo(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)),
                     () -> assertThat(response.isLast()).isTrue());
         }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #180 

---
## 📌 작업 내용 및 특이사항
* 앨범 목록 조회 응답에 앨범 생성일(createdAt)과 구독 가격(price) 필드를 추가했습니다.
  * 메인 페이지와 마이페이지(결제 정보 화면)에서 앨범 목록을 조회할 때 동일한 API 응답을 재사용할 수 있도록, 하나의 응답 구조로 통합했습니다.
* @QueryProjection 대신 Tuple과 정적 팩토리 메서드(AlbumListResponse.of)를 사용했습니다.
  * AlbumType enum 내부의 price 값은 QueryDSL에서 직접 매핑할 수 없어, Tuple로 받아 DTO 변환 과정에서 type.getPrice()로 처리하도록 구현했습니다.