### PR TITLE
refactor: 중복된 에러 코드 통일

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -197,7 +197,7 @@ public class EventServiceImpl implements EventService {
 
     private void validateAllImageAlbum(List<Long> imageIds, Long albumId) {
         if (imageRepository.countByIdInAndAlbumId(imageIds, albumId) != imageIds.size()) {
-            throw new CustomException(ImageErrorCode.IMAGES_IN_OTHER_ALBUM);
+            throw new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM);
         }
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/exception/ImageErrorCode.java
@@ -8,7 +8,6 @@ import org.cherrypic.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum ImageErrorCode implements BaseErrorCode {
     IMAGES_NOT_FOUND(404, "존재하지 않는 이미지를 포함하고 있습니다."),
-    IMAGES_IN_OTHER_ALBUM(400, "앨범 소속이 아닌 이미지를 포함하고 있습니다."),
     IMAGE_DELETED(409, "이미지 관련 작업 중 이미지가 삭제되었습니다."),
     IMAGE_CONFLICT(409, "예상치 못한 이미지 무결성 오류"),
     NOT_IMAGE_EXTENSION(400, "프로필과 커버에는 이미지 파일만 업로드 가능합니다."),

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -675,7 +675,7 @@ public class EventControllerTest {
         void 다른_앨범에_속한_이미지를_추가하면_예외가_발생한다() throws Exception {
             // given
             EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
-            willThrow(new CustomException(ImageErrorCode.IMAGES_IN_OTHER_ALBUM))
+            willThrow(new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM))
                     .given(eventService)
                     .addImages(1L, request);
 
@@ -689,8 +689,8 @@ public class EventControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("IMAGES_IN_OTHER_ALBUM"))
-                    .andExpect(jsonPath("$.data.message").value("앨범 소속이 아닌 이미지를 포함하고 있습니다."));
+                    .andExpect(jsonPath("$.data.code").value("IMAGES_NOT_IN_ALBUM"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속해 있지 않은 이미지가 포함되어 있습니다."));
         }
 
         @ParameterizedTest

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -569,7 +569,7 @@ public class EventServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventService.addImages(1L, request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(ImageErrorCode.IMAGES_IN_OTHER_ALBUM.getMessage());
+                    .hasMessage(AlbumErrorCode.IMAGES_NOT_IN_ALBUM.getMessage());
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #182 

---
## 📌 작업 내용 및 특이사항
- 이미지가 앨범에 포함되어 있지 않는 내용의 에러코드가 2개가 존재했습니다.
- 이를 앨범 에러 코드로 통일해서 관리합니다.