### PR TITLE
feat: 앨범 결제 내역 목록 조회 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
@@ -1,20 +1,27 @@
 package org.cherrypic.domain.payment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.payment.dto.request.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.response.PaymentListResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentReadyResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentVerificationResponse;
 import org.cherrypic.domain.payment.service.PaymentService;
+import org.cherrypic.global.annotation.PageSize;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/payments")
 @RequiredArgsConstructor
 @Tag(name = "5. 결제 API", description = "결제 관련 API입니다.")
+@Validated
 public class PaymentController {
 
     private final PaymentService paymentService;
@@ -41,5 +48,19 @@ public class PaymentController {
             description = "결제는 완료되었지만 아직 앨범 생성, 구독 갱신, 또는 구독 업그레이드에 사용되지 않은 결제 내역을 조회합니다.")
     public PaymentUnlinkedResponse getUnlinkedPayment() {
         return paymentService.getUnlinkedPayment();
+    }
+
+    @GetMapping
+    @Operation(summary = "앨범의 결제 내역 조회", description = "특정 앨범에 대한 결제 내역을 조회합니다.")
+    public SliceResponse<PaymentListResponse> paymentsGet(
+            @Parameter(description = "앨범 ID") @RequestParam Long albumId,
+            @Parameter(description = "이전 페이지의 마지막 결제 ID (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    Long lastPaymentId,
+            @Parameter(description = "페이지당 조회할 결제 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
+                    @RequestParam(defaultValue = "DESC")
+                    SortDirection direction) {
+        return paymentService.getAlbumPayments(albumId, lastPaymentId, size, direction);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentListResponse.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.payment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record PaymentListResponse(
+        @Schema(description = "결제 ID", example = "1") Long paymentId,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "결제 완료일", example = "2024-08-21")
+                LocalDate paidAt,
+        @Schema(description = "결제 금액", example = "5900") Integer amount) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentListResponse.java
@@ -2,7 +2,7 @@ package org.cherrypic.domain.payment.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record PaymentListResponse(
         @Schema(description = "결제 ID", example = "1") Long paymentId,
@@ -11,5 +11,5 @@ public record PaymentListResponse(
                         pattern = "yyyy-MM-dd",
                         timezone = "Asia/Seoul")
                 @Schema(description = "결제 완료일", example = "2024-08-21")
-                LocalDate paidAt,
+                LocalDateTime paidAt,
         @Schema(description = "결제 금액", example = "5900") Integer amount) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/exception/PaymentErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum PaymentErrorCode implements BaseErrorCode {
-    UNSUPPORTED_PAYMENT(400, "BASIC 유형은 결제를 지원하지 않습니다."),
+    UNSUPPORTED_PAYMENT(400, "BASIC 유형은 결제 기능을 지원하지 않습니다."),
 
     PAYMENT_NOT_FOUND(404, "결제 정보가 존재하지 않습니다."),
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryCustom.java
@@ -10,5 +10,5 @@ public interface PaymentRepositoryCustom {
     Optional<PaymentUnlinkedResponse> findLatestPaidUnlinkedPayment(Long memberId);
 
     Slice<PaymentListResponse> findAllByAlbumId(
-            Long albumId, Long lastPaymentId, int size, SortDirection direction);
+            Long memberId, Long albumId, Long lastPaymentId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryCustom.java
@@ -1,8 +1,14 @@
 package org.cherrypic.domain.payment.repository;
 
 import java.util.Optional;
+import org.cherrypic.domain.payment.dto.response.PaymentListResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
+import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.data.domain.Slice;
 
 public interface PaymentRepositoryCustom {
     Optional<PaymentUnlinkedResponse> findLatestPaidUnlinkedPayment(Long memberId);
+
+    Slice<PaymentListResponse> findAllByAlbumId(
+            Long albumId, Long lastPaymentId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryImpl.java
@@ -3,11 +3,18 @@ package org.cherrypic.domain.payment.repository;
 import static org.cherrypic.payment.entity.QPayment.payment;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.payment.dto.response.PaymentListResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -35,5 +42,53 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                                 payment.album.isNull())
                         .orderBy(payment.paidAt.desc())
                         .fetchFirst());
+    }
+
+    @Override
+    public Slice<PaymentListResponse> findAllByAlbumId(
+            Long albumId, Long lastPaymentId, int size, SortDirection direction) {
+        List<PaymentListResponse> results =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        PaymentListResponse.class,
+                                        payment.id,
+                                        payment.paidAt,
+                                        payment.amount))
+                        .from(payment)
+                        .where(
+                                payment.album.id.eq(albumId),
+                                payment.status.eq(PaymentStatus.PAID),
+                                lastPaymentIdCondition(lastPaymentId, direction))
+                        .orderBy(
+                                direction == SortDirection.DESC
+                                        ? payment.id.desc()
+                                        : payment.id.asc())
+                        .limit(size + 1)
+                        .fetch();
+
+        return checkLastPage(size, results);
+    }
+
+    private BooleanExpression lastPaymentIdCondition(Long paymentId, SortDirection direction) {
+        if (paymentId == null) {
+            return null;
+        }
+
+        return direction == SortDirection.DESC
+                ? payment.id.lt(paymentId)
+                : payment.id.gt(paymentId);
+    }
+
+    private Slice<PaymentListResponse> checkLastPage(
+            int pageSize, List<PaymentListResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepositoryImpl.java
@@ -46,7 +46,7 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
 
     @Override
     public Slice<PaymentListResponse> findAllByAlbumId(
-            Long albumId, Long lastPaymentId, int size, SortDirection direction) {
+            Long memberId, Long albumId, Long lastPaymentId, int size, SortDirection direction) {
         List<PaymentListResponse> results =
                 queryFactory
                         .select(
@@ -59,6 +59,7 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                         .where(
                                 payment.album.id.eq(albumId),
                                 payment.status.eq(PaymentStatus.PAID),
+                                payment.member.id.eq(memberId),
                                 lastPaymentIdCondition(lastPaymentId, direction))
                         .orderBy(
                                 direction == SortDirection.DESC

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentService.java
@@ -1,9 +1,12 @@
 package org.cherrypic.domain.payment.service;
 
 import org.cherrypic.domain.payment.dto.request.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.response.PaymentListResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentReadyResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentVerificationResponse;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 
 public interface PaymentService {
     PaymentReadyResponse preparePayment(PaymentReadyRequest request);
@@ -11,4 +14,7 @@ public interface PaymentService {
     PaymentVerificationResponse verifyPayment(String impUid);
 
     PaymentUnlinkedResponse getUnlinkedPayment();
+
+    SliceResponse<PaymentListResponse> getAlbumPayments(
+            Long albumId, Long lastPaymentId, int size, SortDirection direction);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -129,7 +129,8 @@ public class PaymentServiceImpl implements PaymentService {
         validatePaidAlbumType(album.getType());
 
         Slice<PaymentListResponse> results =
-                paymentRepository.findAllByAlbumId(albumId, lastPaymentId, size, direction);
+                paymentRepository.findAllByAlbumId(
+                        currentMember.getId(), albumId, lastPaymentId, size, direction);
 
         return SliceResponse.from(results);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -54,9 +54,7 @@ public class PaymentServiceImpl implements PaymentService {
         final Member currentMember = memberUtil.getCurrentMember();
 
         AlbumType type = request.type();
-        if (type.equals(AlbumType.BASIC)) {
-            throw new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT);
-        }
+        validatePaidAlbumType(type);
 
         paymentRepository
                 .findLatestPaidUnlinkedPayment(currentMember.getId())
@@ -128,6 +126,7 @@ public class PaymentServiceImpl implements PaymentService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+        validatePaidAlbumType(album.getType());
 
         Slice<PaymentListResponse> results =
                 paymentRepository.findAllByAlbumId(albumId, lastPaymentId, size, direction);
@@ -188,6 +187,12 @@ public class PaymentServiceImpl implements PaymentService {
 
         if (!participant.getRole().equals(ParticipantRole.HOST)) {
             throw new CustomException(AlbumErrorCode.NOT_ALBUM_HOST);
+        }
+    }
+
+    private void validatePaidAlbumType(AlbumType type) {
+        if (type == AlbumType.BASIC) {
+            throw new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -16,12 +16,15 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.dto.request.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.response.PaymentListResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentReadyResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentVerificationResponse;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
@@ -29,6 +32,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -114,6 +118,21 @@ public class PaymentServiceImpl implements PaymentService {
         } catch (IOException e) {
             throw new CustomException(PaymentErrorCode.IAMPORT_API_UNAVAILABLE);
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SliceResponse<PaymentListResponse> getAlbumPayments(
+            Long albumId, Long lastPaymentId, int size, SortDirection direction) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateAlbumHost(currentMember.getId(), album.getId());
+
+        Slice<PaymentListResponse> results =
+                paymentRepository.findAllByAlbumId(albumId, lastPaymentId, size, direction);
+
+        return SliceResponse.from(results);
     }
 
     @Override

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -8,17 +8,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.payment.controller.PaymentController;
 import org.cherrypic.domain.payment.dto.request.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.response.PaymentListResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentReadyResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentVerificationResponse;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.service.PaymentService;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -360,7 +365,7 @@ class PaymentControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("UNSUPPORTED_PAYMENT"))
-                    .andExpect(jsonPath("$.data.message").value("BASIC 앨범 유형은 결제 기능을 지원하지 않습니다."));
+                    .andExpect(jsonPath("$.data.message").value("BASIC 유형은 결제 기능을 지원하지 않습니다."));
         }
 
         @Test
@@ -556,6 +561,206 @@ class PaymentControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
                     .andExpect(jsonPath("$.data").value(nullValue()));
+        }
+    }
+
+    @Nested
+    class 앨범의_결제_내역_목록_조회_요청_시 {
+
+        @Test
+        void 정렬_조건이_ASC이면_paymentId를_오름차순으로_응답한다() throws Exception {
+            // given
+            List<PaymentListResponse> payments =
+                    List.of(
+                            new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900),
+                            new PaymentListResponse(2L, LocalDate.of(2025, 10, 2), 5900));
+
+            given(paymentService.getAlbumPayments(1L, null, 2, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(payments, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/payments")
+                                    .param("albumId", "1")
+                                    .param("size", "2")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].paymentId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].paymentId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_paymentId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<PaymentListResponse> payments =
+                    List.of(
+                            new PaymentListResponse(2L, LocalDate.of(2025, 10, 2), 5900),
+                            new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900));
+
+            given(paymentService.getAlbumPayments(1L, null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(payments, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/payments").param("albumId", "1").param("size", "2"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].paymentId").value(2))
+                    .andExpect(jsonPath("$.data.content[1].paymentId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
+            // given
+            List<PaymentListResponse> payments =
+                    List.of(new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900));
+
+            given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(payments, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/payments").param("albumId", "1").param("size", "1"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].paymentId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_응답한다() throws Exception {
+            // given
+            List<PaymentListResponse> payments =
+                    List.of(
+                            new PaymentListResponse(2L, LocalDate.of(2025, 10, 2), 5900),
+                            new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900));
+
+            given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(payments, false));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/payments")
+                                    .param("albumId", "1")
+                                    .param("size", "1")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].paymentId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(false));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/payments").param("albumId", "1").param("size", "1"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/payments").param("albumId", "1").param("size", "1"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/payments").param("albumId", "1").param("size", "1"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void BASIC_유형인_경우_예외가_발생한다() throws Exception {
+            // given
+            given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
+                    .willThrow(new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/payments").param("albumId", "1").param("size", "1"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("UNSUPPORTED_PAYMENT"))
+                    .andExpect(jsonPath("$.data.message").value("BASIC 유형은 결제 기능을 지원하지 않습니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "-999", "0"})
+        void 페이지_크기를_0_이하로_설정하면_예외가_발생한다(String pageSize) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/payments").param("albumId", "1").param("size", pageSize));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ConstraintViolationException"))
+                    .andExpect(jsonPath("$.data.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
+        void 존재하지_않는_정렬_기준을_입력한_경우_예외가_발생한다(String sort) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/payments")
+                                    .param("albumId", "1")
+                                    .param("size", "2")
+                                    .param("direction", sort));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("METHOD_ARGUMENT_TYPE_MISMATCH"))
+                    .andExpect(jsonPath("$.data.message").value("요청한 값의 타입이 잘못되어 처리할 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.album.enums.AlbumType;
@@ -572,8 +571,8 @@ class PaymentControllerTest {
             // given
             List<PaymentListResponse> payments =
                     List.of(
-                            new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900),
-                            new PaymentListResponse(2L, LocalDate.of(2025, 10, 2), 5900));
+                            new PaymentListResponse(1L, LocalDateTime.of(2025, 9, 2, 0, 0), 5900),
+                            new PaymentListResponse(2L, LocalDateTime.of(2025, 10, 2, 0, 0), 5900));
 
             given(paymentService.getAlbumPayments(1L, null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(payments, true));
@@ -599,8 +598,8 @@ class PaymentControllerTest {
             // given
             List<PaymentListResponse> payments =
                     List.of(
-                            new PaymentListResponse(2L, LocalDate.of(2025, 10, 2), 5900),
-                            new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900));
+                            new PaymentListResponse(2L, LocalDateTime.of(2025, 10, 2, 0, 0), 5900),
+                            new PaymentListResponse(1L, LocalDateTime.of(2025, 9, 2, 0, 0), 5900));
 
             given(paymentService.getAlbumPayments(1L, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(payments, true));
@@ -621,7 +620,7 @@ class PaymentControllerTest {
         void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
             // given
             List<PaymentListResponse> payments =
-                    List.of(new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900));
+                    List.of(new PaymentListResponse(1L, LocalDateTime.of(2025, 9, 2, 0, 0), 5900));
 
             given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(payments, true));
@@ -642,8 +641,8 @@ class PaymentControllerTest {
             // given
             List<PaymentListResponse> payments =
                     List.of(
-                            new PaymentListResponse(2L, LocalDate.of(2025, 10, 2), 5900),
-                            new PaymentListResponse(1L, LocalDate.of(2025, 9, 2), 5900));
+                            new PaymentListResponse(2L, LocalDateTime.of(2025, 10, 2, 0, 0), 5900),
+                            new PaymentListResponse(1L, LocalDateTime.of(2025, 9, 2, 0, 0), 5900));
 
             given(paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(payments, false));

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -360,7 +360,7 @@ class PaymentControllerTest {
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("UNSUPPORTED_PAYMENT"))
-                    .andExpect(jsonPath("$.data.message").value("BASIC 유형은 결제를 지원하지 않습니다."));
+                    .andExpect(jsonPath("$.data.message").value("BASIC 앨범 유형은 결제 기능을 지원하지 않습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -1,10 +1,9 @@
 package org.cherrypic.payment.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
@@ -25,11 +24,14 @@ import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.dto.request.PaymentReadyRequest;
+import org.cherrypic.domain.payment.dto.response.PaymentListResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.payment.service.PaymentService;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.global.pagination.SliceResponse;
+import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
@@ -468,6 +470,163 @@ public class PaymentServiceTest extends IntegrationTest {
 
             // when & then
             assertThat(response).isNull();
+        }
+    }
+
+    @Nested
+    class 앨범의_결제_내역_목록을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.PRO, false);
+            Album album2 =
+                    Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.PREMIUM, false);
+            Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.PRO, false);
+            Album album4 = Album.createAlbum("testTitle4", "testCoverUrl4", AlbumType.PRO, false);
+            Album album5 = Album.createAlbum("testTitle5", "testCoverUrl5", AlbumType.BASIC, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member1, album2, ParticipantRole.HOST);
+            Participant participant3 =
+                    Participant.createParticipant(member1, album4, ParticipantRole.STANDARD);
+            Participant participant4 =
+                    Participant.createParticipant(member1, album5, ParticipantRole.HOST);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4));
+
+            Payment payment1 =
+                    Payment.createPayment(
+                            member1,
+                            "testMerchantUid1",
+                            5900,
+                            PaymentPurpose.CREATION,
+                            AlbumType.PRO);
+            payment1.updatePayment(
+                    "testImpUid1",
+                    "kakaopay",
+                    PaymentStatus.PAID,
+                    LocalDateTime.of(2025, 8, 1, 20, 0));
+            payment1.updatePayment(PaymentPurpose.CREATION, album1);
+            Payment payment2 =
+                    Payment.createPayment(
+                            member1,
+                            "testMerchantUid2",
+                            12900,
+                            PaymentPurpose.RENEWAL,
+                            AlbumType.PRO);
+            payment2.updatePayment(
+                    "testImpUid2",
+                    "kakaopay",
+                    PaymentStatus.PAID,
+                    LocalDateTime.of(2025, 9, 1, 20, 0));
+            payment2.updatePayment(PaymentPurpose.RENEWAL, album1);
+            paymentRepository.saveAll(List.of(payment1, payment2));
+        }
+
+        @Test
+        void 정렬_조건이_ASC이면_paymentId를_오름차순으로_조회한다() {
+            // when
+            SliceResponse<PaymentListResponse> response =
+                    paymentService.getAlbumPayments(1L, null, 2, SortDirection.ASC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content())
+                                    .extracting("paymentId")
+                                    .containsExactly(1L, 2L),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_paymentId를_내림차순으로_조회한다() {
+            // when
+            SliceResponse<PaymentListResponse> response =
+                    paymentService.getAlbumPayments(1L, null, 2, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(response.content())
+                                    .extracting("paymentId")
+                                    .containsExactly(2L, 1L),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_반환한다() {
+            SliceResponse<PaymentListResponse> response =
+                    paymentService.getAlbumPayments(1L, null, 2, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(2),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
+            SliceResponse<PaymentListResponse> response =
+                    paymentService.getAlbumPayments(1L, null, 1, SortDirection.DESC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(1),
+                    () -> assertThat(response.isLast()).isFalse());
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    paymentService.getAlbumPayments(
+                                            999L, null, 2, SortDirection.DESC))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () -> paymentService.getAlbumPayments(3L, null, 2, SortDirection.DESC))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () -> paymentService.getAlbumPayments(4L, null, 2, SortDirection.DESC))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void BASIC_유형인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () -> paymentService.getAlbumPayments(5L, null, 2, SortDirection.DESC))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.UNSUPPORTED_PAYMENT.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #151 

---
## 📌 작업 내용 및 특이사항
* 앨범 결제 내역 목록 조회 기능을 구현했습니다.
  * 유료 앨범(PRO, PREMIUM)에 한해 결제 내역 조회가 가능합니다.
  * BASIC 앨범이거나 방장이 아닌 경우에는 결제 내역 조회 권한이 없어 예외 처리하였습니다.