### PR TITLE
feat: 앨범 구독 정보 조회 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/controller/SubscriptionController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionInfoResponse;
 import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
 import org.cherrypic.domain.subscription.service.SubscriptionService;
 import org.springframework.http.ResponseEntity;
@@ -30,5 +31,11 @@ public class SubscriptionController {
     public SubscriptionRenewResponse subscriptionRenew(
             @PathVariable Long albumId, @Valid @RequestBody SubscriptionRenewRequest request) {
         return subscriptionService.renewSubscription(albumId, request);
+    }
+
+    @GetMapping
+    @Operation(summary = "구독 정보 조회", description = "앨범의 구독 정보를 조회합니다.")
+    public SubscriptionInfoResponse SubscriptionInfoGet(@PathVariable Long albumId) {
+        return subscriptionService.getSubscriptionInfo(albumId);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/dto/response/SubscriptionInfoResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/dto/response/SubscriptionInfoResponse.java
@@ -1,0 +1,36 @@
+package org.cherrypic.domain.subscription.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
+
+public record SubscriptionInfoResponse(
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "구독 시작일", example = "2024-08-21")
+                LocalDateTime subscriptionStartAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "구독 종료일", example = "2024-09-20")
+                LocalDateTime subscriptionEndAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "다음 결제일", example = "2024-09-21")
+                LocalDateTime subscriptionNextBillingAt,
+        @Schema(description = "구독 상태", example = "ACTIVE") SubscriptionStatus status) {
+    public static SubscriptionInfoResponse from(Subscription subscription) {
+        return new SubscriptionInfoResponse(
+                subscription.getStartAt(),
+                subscription.getEndAt(),
+                subscription.getNextBillingAt(),
+                subscription.getStatus());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
@@ -1,10 +1,13 @@
 package org.cherrypic.domain.subscription.service;
 
 import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionInfoResponse;
 import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
 
 public interface SubscriptionService {
     void cancelSubscription(Long albumId);
 
     SubscriptionRenewResponse renewSubscription(Long albumId, SubscriptionRenewRequest request);
+
+    SubscriptionInfoResponse getSubscriptionInfo(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -9,6 +9,7 @@ import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionInfoResponse;
 import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
 import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
@@ -68,6 +69,20 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         subscription.renew();
 
         return SubscriptionRenewResponse.from(subscription);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SubscriptionInfoResponse getSubscriptionInfo(Long albumId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Album album = getAlbumById(albumId);
+
+        validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionSupported(album);
+
+        final Subscription subscription = getSubscriptionByAlbumId(albumId);
+
+        return SubscriptionInfoResponse.from(subscription);
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -11,6 +11,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.subscription.controller.SubscriptionController;
 import org.cherrypic.domain.subscription.dto.request.SubscriptionRenewRequest;
+import org.cherrypic.domain.subscription.dto.response.SubscriptionInfoResponse;
 import org.cherrypic.domain.subscription.dto.response.SubscriptionRenewResponse;
 import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
 import org.cherrypic.domain.subscription.service.SubscriptionService;
@@ -479,6 +480,119 @@ class SubscriptionControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("ALREADY_EXPIRED"))
                     .andExpect(jsonPath("$.data.message").value("이미 만료된 구독입니다. 해지 또는 갱신할 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 구독_정보_조회_요청_시 {
+
+        @Test
+        void 유효한_요청이면_구독_정보를_반환한다() throws Exception {
+            // given
+            SubscriptionInfoResponse response =
+                    new SubscriptionInfoResponse(
+                            LocalDateTime.of(2025, 7, 1, 0, 0),
+                            LocalDateTime.of(2025, 8, 1, 0, 0),
+                            LocalDateTime.of(2025, 7, 29, 0, 0),
+                            SubscriptionStatus.ACTIVE);
+
+            given(subscriptionService.getSubscriptionInfo(1L)).willReturn(response);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.subscriptionStartAt").value("2025-07-01"))
+                    .andExpect(jsonPath("$.data.subscriptionEndAt").value("2025-08-01"))
+                    .andExpect(jsonPath("$.data.subscriptionNextBillingAt").value("2025-07-29"))
+                    .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(subscriptionService.getSubscriptionInfo(1L))
+                    .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALBUM_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("앨범이 존재하지 않습니다."));
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            given(subscriptionService.getSubscriptionInfo(1L))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            given(subscriptionService.getSubscriptionInfo(1L))
+                    .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
+                    .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void BASIC_유형인_경우_예외가_발생한다() throws Exception {
+            // given
+            given(subscriptionService.getSubscriptionInfo(1L))
+                    .willThrow(
+                            new CustomException(
+                                    SubscriptionErrorCode
+                                            .SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.data.code")
+                                    .value("SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE"))
+                    .andExpect(jsonPath("$.data.message").value("BASIC 유형은 구독 기능을 지원하지 않습니다."));
+        }
+
+        @Test
+        void 구독이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            given(subscriptionService.getSubscriptionInfo(1L))
+                    .willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(get("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("구독 정보가 존재하지 않습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -470,4 +470,125 @@ class SubscriptionServiceTest extends IntegrationTest {
                     .hasMessage(SubscriptionDomainErrorCode.ALREADY_EXPIRED.getMessage());
         }
     }
+
+    @Nested
+    class 구독_정보를_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId1", "testOauthProvider1"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId2", "testOauthProvider2"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.PRO, false);
+            Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.PRO, false);
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, false);
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.BASIC, false);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PREMIUM, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
+
+            Participant participant1 =
+                    Participant.createParticipant(member1, album1, ParticipantRole.HOST);
+            Participant participant2 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.STANDARD);
+            Participant participant3 =
+                    Participant.createParticipant(member1, album4, ParticipantRole.HOST);
+            Participant participant4 =
+                    Participant.createParticipant(member1, album5, ParticipantRole.HOST);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4));
+
+            Subscription subscription =
+                    Subscription.createSubscription(
+                            member1, album1, LocalDateTime.of(2025, 8, 4, 0, 0));
+            subscriptionRepository.save(subscription);
+        }
+
+        @Test
+        void 유효한_요청이면_구독_정보를_조회한다() {
+            // when
+            subscriptionService.getSubscriptionInfo(1L);
+
+            // then
+            Album album =
+                    transactionUtil.getResult(
+                            () -> {
+                                Album loadedAlbum = albumRepository.findById(1L).get();
+                                loadedAlbum.getSubscription();
+                                return loadedAlbum;
+                            });
+            Subscription subscription = album.getSubscription();
+
+            Assertions.assertAll(
+                    () ->
+                            assertThat(subscription)
+                                    .extracting(
+                                            "id",
+                                            "member.id",
+                                            "album.id",
+                                            "status",
+                                            "startAt",
+                                            "endAt",
+                                            "nextBillingAt")
+                                    .containsExactly(
+                                            1L,
+                                            1L,
+                                            1L,
+                                            SubscriptionStatus.ACTIVE,
+                                            LocalDateTime.of(2025, 8, 4, 0, 0),
+                                            LocalDateTime.of(2025, 9, 4, 0, 0),
+                                            LocalDateTime.of(2025, 9, 1, 0, 0)));
+        }
+
+        @Test
+        void 앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.getSubscriptionInfo(999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 앨범_참가자가_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.getSubscriptionInfo(2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        void 앨범_방장이_아닌_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.getSubscriptionInfo(3L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void BASIC_유형인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.getSubscriptionInfo(4L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(
+                            SubscriptionErrorCode.SUBSCRIPTION_NOT_SUPPORTED_FOR_BASIC_TYPE
+                                    .getMessage());
+        }
+
+        @Test
+        void 구독이_존재하지_않는_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.getSubscriptionInfo(5L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #189 

---
## 📌 작업 내용 및 특이사항
* 앨범의 구독 상태 및 기간 정보를 조회하는 API를 추가했습니다.
* 결제 내역은 앨범의 방장만 볼 수 있으므로 구독 정보 또한 방장만 조회 가능하도록 하였습니다.