### PR TITLE
fix: 첫 결제일 또는 갱신 기준 종료일이 28일 이상일 경우, 구독 종료일을 말일로 보정하도록 수정

### DIFF
--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -202,7 +202,10 @@ class AlbumServiceTest extends IntegrationTest {
                                 PaymentPurpose.CREATION,
                                 AlbumType.PRO);
                 payment1.updatePayment(
-                        "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+                        "testImpUid",
+                        "testPgProvider",
+                        PaymentStatus.PAID,
+                        LocalDateTime.of(2025, 8, 1, 13, 0));
                 // 검증되지 않은 결제
                 Payment payment2 =
                         Payment.createPayment(
@@ -241,8 +244,6 @@ class AlbumServiceTest extends IntegrationTest {
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(
                                 "testTitle", "testCoverUrl", AlbumType.PRO, 1L, true);
-
-                LocalDateTime startAt = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
 
                 // when
                 albumService.createAlbum(request);
@@ -286,23 +287,22 @@ class AlbumServiceTest extends IntegrationTest {
                                         .containsExactly(2L, PaymentStatus.PAID),
                         () ->
                                 assertThat(subscription)
-                                        .extracting("id", "member.id", "album.id", "status")
-                                        .containsExactly(1L, 1L, 2L, SubscriptionStatus.ACTIVE),
-                        () ->
-                                assertThat(
-                                                subscription
-                                                        .getStartAt()
-                                                        .truncatedTo(ChronoUnit.MINUTES))
-                                        .isEqualTo(startAt),
-                        () ->
-                                assertThat(subscription.getEndAt().truncatedTo(ChronoUnit.MINUTES))
-                                        .isEqualTo(startAt.plusMonths(1)),
-                        () ->
-                                assertThat(
-                                                subscription
-                                                        .getNextBillingAt()
-                                                        .truncatedTo(ChronoUnit.MINUTES))
-                                        .isEqualTo(startAt.plusMonths(1).minusDays(3)));
+                                        .extracting(
+                                                "id",
+                                                "member.id",
+                                                "album.id",
+                                                "status",
+                                                "startAt",
+                                                "endAt",
+                                                "nextBillingAt")
+                                        .containsExactly(
+                                                1L,
+                                                1L,
+                                                2L,
+                                                SubscriptionStatus.ACTIVE,
+                                                LocalDateTime.of(2025, 8, 1, 13, 0),
+                                                LocalDateTime.of(2025, 9, 1, 13, 0),
+                                                LocalDateTime.of(2025, 8, 29, 13, 0)));
             }
 
             @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -98,11 +98,9 @@ class MemberServiceTest extends IntegrationTest {
 
             // then
             Member member = memberRepository.findById(1L).orElseThrow();
-            Assertions.assertAll(
-                    () -> assertThat(member.getNickname()).isEqualTo("updateNickname"),
-                    () ->
-                            assertThat(member.getProfileImageUrl())
-                                    .isEqualTo("updateProfileImageUrl"));
+            assertThat(member)
+                    .extracting("nickname", "profileImageUrl")
+                    .containsExactly("updateNickname", "updateProfileImageUrl");
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -110,13 +110,18 @@ public class PaymentServiceTest extends IntegrationTest {
                 // then
                 Payment payment = paymentRepository.findById(1L).orElseThrow();
                 Assertions.assertAll(
-                        () -> assertThat(payment.getId()).isEqualTo(1L),
-                        () -> assertThat(payment.getMember().getId()).isEqualTo(1L),
+                        () ->
+                                assertThat(payment)
+                                        .extracting(
+                                                "id", "member.id", "amount", "status", "purpose")
+                                        .containsExactly(
+                                                1L,
+                                                1L,
+                                                5900,
+                                                PaymentStatus.READY,
+                                                PaymentPurpose.CREATION),
                         () -> assertThat(payment.getMerchantUid()).startsWith("album_"),
-                        () -> assertThat(payment.getMerchantUid()).contains("pro"),
-                        () -> assertThat(payment.getAmount()).isEqualTo(5900),
-                        () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY),
-                        () -> assertThat(payment.getPurpose()).isEqualTo(PaymentPurpose.CREATION));
+                        () -> assertThat(payment.getMerchantUid()).contains("pro"));
             }
         }
 
@@ -134,13 +139,18 @@ public class PaymentServiceTest extends IntegrationTest {
                 // then
                 Payment payment = paymentRepository.findById(1L).orElseThrow();
                 Assertions.assertAll(
-                        () -> assertThat(payment.getId()).isEqualTo(1L),
-                        () -> assertThat(payment.getMember().getId()).isEqualTo(1L),
+                        () ->
+                                assertThat(payment)
+                                        .extracting(
+                                                "id", "member.id", "amount", "status", "purpose")
+                                        .containsExactly(
+                                                1L,
+                                                1L,
+                                                5900,
+                                                PaymentStatus.READY,
+                                                PaymentPurpose.RENEWAL),
                         () -> assertThat(payment.getMerchantUid()).startsWith("album_"),
-                        () -> assertThat(payment.getMerchantUid()).contains("pro"),
-                        () -> assertThat(payment.getAmount()).isEqualTo(5900),
-                        () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY),
-                        () -> assertThat(payment.getPurpose()).isEqualTo(PaymentPurpose.RENEWAL));
+                        () -> assertThat(payment.getMerchantUid()).contains("pro"));
             }
 
             @Test
@@ -202,13 +212,18 @@ public class PaymentServiceTest extends IntegrationTest {
                 // then
                 Payment payment = paymentRepository.findById(1L).orElseThrow();
                 Assertions.assertAll(
-                        () -> assertThat(payment.getId()).isEqualTo(1L),
-                        () -> assertThat(payment.getMember().getId()).isEqualTo(1L),
+                        () ->
+                                assertThat(payment)
+                                        .extracting(
+                                                "id", "member.id", "amount", "status", "purpose")
+                                        .containsExactly(
+                                                1L,
+                                                1L,
+                                                12900,
+                                                PaymentStatus.READY,
+                                                PaymentPurpose.UPGRADE),
                         () -> assertThat(payment.getMerchantUid()).startsWith("album_"),
-                        () -> assertThat(payment.getMerchantUid()).contains("premium"),
-                        () -> assertThat(payment.getAmount()).isEqualTo(12900),
-                        () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY),
-                        () -> assertThat(payment.getPurpose()).isEqualTo(PaymentPurpose.UPGRADE));
+                        () -> assertThat(payment.getMerchantUid()).contains("premium"));
             }
 
             @Test
@@ -324,14 +339,14 @@ public class PaymentServiceTest extends IntegrationTest {
 
             // then
             Payment payment = paymentRepository.findById(1L).orElseThrow();
-            Assertions.assertAll(
-                    () -> assertThat(payment.getId()).isEqualTo(1L),
-                    () -> assertThat(payment.getImpUid()).isEqualTo("imp_1234"),
-                    () -> assertThat(payment.getAmount()).isEqualTo(5900),
-                    () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID),
-                    () ->
-                            assertThat(payment.getPaidAt())
-                                    .isEqualTo(LocalDateTime.of(2025, 8, 1, 13, 0)));
+            assertThat(payment)
+                    .extracting("id", "impUid", "amount", "status", "paidAt")
+                    .containsExactly(
+                            1L,
+                            "imp_1234",
+                            5900,
+                            PaymentStatus.PAID,
+                            LocalDateTime.of(2025, 8, 1, 13, 0));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -11,7 +11,7 @@ import com.siot.IamportRestClient.response.IamportResponse;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import okhttp3.MediaType;
@@ -309,7 +309,7 @@ public class PaymentServiceTest extends IntegrationTest {
                     Payment.createPayment(
                             member,
                             MERCHANT_UID_EXISTING,
-                            3900,
+                            5900,
                             PaymentPurpose.CREATION,
                             AlbumType.PRO));
         }
@@ -317,7 +317,7 @@ public class PaymentServiceTest extends IntegrationTest {
         @Test
         void 유효한_요청이면_결제_정보를_검증한_후_갱신한다() throws IamportResponseException, IOException {
             // given
-            stubIamportPayment(MERCHANT_UID_EXISTING, BigDecimal.valueOf(3900), "PAID");
+            stubIamportPayment(MERCHANT_UID_EXISTING, BigDecimal.valueOf(5900), "PAID");
 
             // when
             paymentService.verifyPayment("imp_1234");
@@ -327,12 +327,11 @@ public class PaymentServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(payment.getId()).isEqualTo(1L),
                     () -> assertThat(payment.getImpUid()).isEqualTo("imp_1234"),
-                    () -> assertThat(payment.getAmount()).isEqualTo(3900),
+                    () -> assertThat(payment.getAmount()).isEqualTo(5900),
                     () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID),
                     () ->
-                            assertThat(payment.getPaidAt().truncatedTo(ChronoUnit.MINUTES))
-                                    .isEqualTo(
-                                            LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)));
+                            assertThat(payment.getPaidAt())
+                                    .isEqualTo(LocalDateTime.of(2025, 8, 1, 13, 0)));
         }
 
         @Test
@@ -380,7 +379,7 @@ public class PaymentServiceTest extends IntegrationTest {
         @Test
         void 결제_상태가_PAID가_아니면_예외가_발생한다() throws IamportResponseException, IOException {
             // given
-            stubIamportPayment(MERCHANT_UID_EXISTING, BigDecimal.valueOf(3900), "READY");
+            stubIamportPayment(MERCHANT_UID_EXISTING, BigDecimal.valueOf(5900), "READY");
 
             // when & then
             assertThatThrownBy(() -> paymentService.verifyPayment("imp_1234"))
@@ -409,7 +408,12 @@ public class PaymentServiceTest extends IntegrationTest {
             given(iamportPayment.getPgProvider()).willReturn("kakaopay");
             given(iamportPayment.getAmount()).willReturn(amount);
             given(iamportPayment.getStatus()).willReturn(status);
-            given(iamportPayment.getPaidAt()).willReturn(new Date());
+            given(iamportPayment.getPaidAt())
+                    .willReturn(
+                            Date.from(
+                                    LocalDateTime.of(2025, 8, 1, 13, 0)
+                                            .atZone(ZoneId.systemDefault())
+                                            .toInstant()));
         }
     }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -244,7 +244,10 @@ class SubscriptionServiceTest extends IntegrationTest {
                             PaymentPurpose.RENEWAL,
                             AlbumType.PRO);
             payment1.updatePayment(
-                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+                    "testImpUid",
+                    "testPgProvider",
+                    PaymentStatus.PAID,
+                    LocalDateTime.now().minusDays(15));
 
             // 완료된 다른 회원의 결제
             Payment payment2 =

--- a/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/subscription/entity/Subscription.java
@@ -3,6 +3,7 @@ package org.cherrypic.subscription.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,8 +65,8 @@ public class Subscription extends BaseTimeEntity {
                 .album(album)
                 .status(SubscriptionStatus.ACTIVE)
                 .startAt(paidAt)
-                .endAt(paidAt.plusMonths(1))
-                .nextBillingAt(paidAt.plusMonths(1).minusDays(3))
+                .endAt(adjustEndDate(paidAt))
+                .nextBillingAt(adjustEndDate(paidAt).minusDays(3))
                 .build();
     }
 
@@ -89,7 +90,18 @@ public class Subscription extends BaseTimeEntity {
         }
 
         this.status = SubscriptionStatus.ACTIVE;
-        this.endAt = this.endAt.plusMonths(1);
+        this.endAt = adjustEndDate(this.endAt);
         this.nextBillingAt = this.endAt.minusDays(3);
+    }
+
+    public static LocalDateTime adjustEndDate(LocalDateTime baseDate) {
+        boolean isAtEndOfMonth = baseDate.getDayOfMonth() >= 28;
+
+        if (isAtEndOfMonth) {
+            YearMonth nextMonth = YearMonth.from(baseDate.plusMonths(1));
+            return nextMonth.atEndOfMonth().atTime(baseDate.toLocalTime());
+        }
+
+        return baseDate.plusMonths(1);
     }
 }

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/album/AlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/album/AlbumTest.java
@@ -1,8 +1,9 @@
-package org.cherrypic.album.entity;
+package org.cherrypic.album.entity.album;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
+import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.exception.CustomException;

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/subscription/SubscriptionTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/subscription/SubscriptionTest.java
@@ -1,0 +1,34 @@
+package org.cherrypic.album.entity.subscription;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.LocalDateTime;
+import org.cherrypic.subscription.entity.Subscription;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionTest {
+
+    @Test
+    void 결제일이_28일_이상이면_첫_종료일은_다음_달의_말일로_보정된다() {
+        // given
+        LocalDateTime paidAt = LocalDateTime.of(2025, 1, 31, 13, 0);
+
+        // when
+        LocalDateTime adjusted = Subscription.adjustEndDate(paidAt);
+
+        // then
+        assertThat(adjusted).isEqualTo(LocalDateTime.of(2025, 2, 28, 13, 0));
+    }
+
+    @Test
+    void 구독_종료일이_28일_이상이면_갱신된_종료일도_다음_달의_말일로_보정된다() {
+        // given
+        LocalDateTime endAt = LocalDateTime.of(2025, 2, 28, 13, 0);
+
+        // when
+        LocalDateTime adjusted = Subscription.adjustEndDate(endAt);
+
+        // then
+        assertThat(adjusted).isEqualTo(LocalDateTime.of(2025, 3, 31, 13, 0));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #192 

---
## 📌 작업 내용 및 특이사항
* 첫 결제일 또는 갱신 기준 종료일이 28일 이상인 경우, 다음 달의 말일로 구독 종료일을 보정하도록 수정했습니다.
* 종료일 보정 로직을 Subscription.adjustEndDate()로 분리하고, createSubscription() 및 renew()에서 이를 적용했습니다.
* 말일 보정 테스트를 통해 1월 31일, 2월 28일 등의 흐름을 검증했습니다.

---
## 📚 참고사항
* 결제 시간 검증 테스트에서 truncatedTo(ChronoUnit.MINUTES) 사용을 제거하고, 고정된 시간 값을 사용하도록 변경하여 테스트의 안정성과 명확성을 높였습니다.
* 회원 프로필 수정 및 결제 정보 검증 테스트에서는 필드 개별 비교 방식 대신 extracting()을 사용하여 가독성과 유지보수성을 개선했습니다.
