### PR TITLE
test: 테스트 환경을 H2에서 MySQL로 전환 및 Flyway 적용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           distribution: 'corretto'
           java-version: '21'
 
-      - name: Start Redis container for test
+      - name: Start Redis & MySQL containers for test
         run: docker compose -f ./docker-compose-test.yml up -d
 
       - name: Gradle Caching

--- a/cherrypic-api/src/test/java/org/cherrypic/DatabaseCleaner.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/DatabaseCleaner.java
@@ -36,18 +36,16 @@ public class DatabaseCleaner implements InitializingBean {
 
     private void cleanTables(Connection conn) throws SQLException {
         Statement statement = conn.createStatement();
-        statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
+        statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 0");
 
         for (String name : tableNames) {
             statement.executeUpdate(String.format("TRUNCATE TABLE %s", name));
             if (columnExists(conn, name, name)) {
-                statement.executeUpdate(
-                        String.format(
-                                "ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1", name, name));
+                statement.executeUpdate(String.format("ALTER TABLE %s AUTO_INCREMENT = 1", name));
             }
         }
 
-        statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+        statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
     }
 
     private boolean columnExists(Connection conn, String tableName, String columnName)

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -183,7 +183,7 @@ public class EventServiceTest extends IntegrationTest {
         void 유효한_요청이면_이벤트가_수정된다() {
             // given
             EventUpdateRequest request =
-                    new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
+                    new EventUpdateRequest("changedTestTitle", "changedTestEventCoverUrl");
 
             // when
             eventService.updateEvent(1L, request);
@@ -192,7 +192,7 @@ public class EventServiceTest extends IntegrationTest {
             Event event = eventRepository.findById(1L).orElseThrow();
             assertThat(event)
                     .extracting("id", "album.id", "title", "coverUrl")
-                    .containsExactly(1L, 1L, "changedTestEventTitle", "changedTestEventCoverUrl");
+                    .containsExactly(1L, 1L, "changedTestTitle", "changedTestEventCoverUrl");
         }
 
         @Test

--- a/cherrypic-api/src/test/resources/application-test.yml
+++ b/cherrypic-api/src/test/resources/application-test.yml
@@ -1,8 +1,15 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/cherrypic_test_db
+    username: root
+    password: root
+  jpa:
+    hibernate:
+      ddl-auto: validate
   flyway:
-    enabled: false
+    enabled: true
+    baseline-on-migrate: true
   data:
     redis:
       host: ${REDIS_HOST:localhost}

--- a/cherrypic-domain/src/main/resources/db/migration/V3__create_temp_album_and_temp_album_image_table.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V3__create_temp_album_and_temp_album_image_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE temp_album (
                             title VARCHAR(20) NOT NULL,
                             capacity_gb DECIMAL(6,2) NOT NULL,
                             type VARCHAR(20) NOT NULL CHECK (type IN ('DEFAULT')),
-                            expired_at DATETIME NOT NULL,
+                            expired_at DATE NOT NULL,
                             web_url VARCHAR(255),
                             created_at DATETIME(6) NOT NULL,
                             updated_at DATETIME(6) NOT NULL,

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,3 +3,11 @@ services:
     image: "redis:alpine"
     ports:
       - "6379:6379"
+
+  mysql:
+    image: "mysql:latest"
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: cherrypic_test_db


### PR DESCRIPTION
## 🌱 관련 이슈
- close #196 

---
## 📌 작업 내용 및 특이사항
* 기존에 H2 인메모리 DB를 사용하던 테스트 환경을 MySQL로 전환했습니다.
  * CI 환경에서도 Flyway가 정상 동작하게 되어, SQL 문법 오류를 사전에 확인할 수 있게 되었습니다.
* 로컬 환경에서 사용하는 MySQL과 포트(3306)는 같고, 스키마(DB 이름)로 테스트 DB를 분리했습니다.
* 테스트용 MySQL 컨테이너를 docker-compose-test.yml에 추가하고, CI에서 해당 컨테이너가 Redis 컨테이너와 함께 실행되도록 설정했습니다.
* DatabaseCleaner에서 H2 전용 쿼리를 제거하고, MySQL에 맞게 외래 키 제약 조건을 끄고(SET FOREIGN_KEY_CHECKS = 0), AUTO_INCREMENT 초기화 쿼리(ALTER TABLE ... AUTO_INCREMENT = 1)로 변경했습니다.
* CI 환경에서 Flyway가 작동하지 않아 발생했던 expired_at 컬럼의 SQL 타입 오류를 수정했습니다.

---
## 📚 참고사항
* 테스트 환경을 H2에서 MySQL로 전환하면서 컬럼 길이 제약이 실제로 적용되어, 기존에 감지되지 않았던 이벤트 이름의 데이터 길이 초과 문제를 발견할 수 있었습니다.
* 환경 전환을 통해 테스트 신뢰도를 높일 수 있었고, 관련 데이터를 컬럼 제약에 맞게 수정했습니다.