### PR TITLE
feat: 구독 종료일 기준 자동 만료 처리 배치 스케줄러 추가

### DIFF
--- a/cherrypic-batch/build.gradle
+++ b/cherrypic-batch/build.gradle
@@ -5,9 +5,12 @@ jar {
 dependencies {
     implementation project(':cherrypic-domain')
     implementation project(':cherrypic-common')
-//    implementation 'org.springframework.boot:spring-boot-starter-batch'
-//    testImplementation 'org.springframework.batch:spring-batch-test'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
+
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    testImplementation 'org.springframework.batch:spring-batch-test'
 }

--- a/cherrypic-batch/build.gradle
+++ b/cherrypic-batch/build.gradle
@@ -7,5 +7,7 @@ dependencies {
     implementation project(':cherrypic-common')
 //    implementation 'org.springframework.boot:spring-boot-starter-batch'
 //    testImplementation 'org.springframework.batch:spring-batch-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
 }

--- a/cherrypic-batch/src/main/java/org/cherrypic/config/SchedulerConfig.java
+++ b/cherrypic-batch/src/main/java/org/cherrypic/config/SchedulerConfig.java
@@ -1,0 +1,8 @@
+package org.cherrypic.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {}

--- a/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/job/SubscriptionExpireJob.java
+++ b/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/job/SubscriptionExpireJob.java
@@ -1,0 +1,16 @@
+package org.cherrypic.domain.subscription.job;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.subscription.service.SubscriptionService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionExpireJob {
+
+    private final SubscriptionService subscriptionService;
+
+    public void run() {
+        subscriptionService.expireOverdueSubscriptions();
+    }
+}

--- a/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/repository/SubscriptionRepository.java
+++ b/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,17 @@
+package org.cherrypic.domain.subscription.repository;
+
+import java.time.LocalDateTime;
+import org.cherrypic.subscription.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+    @Modifying(clearAutomatically = true)
+    @Query(
+            value =
+                    "update subscription set status = 'EXPIRED', next_billing_at = null where status IN ('ACTIVE', 'CANCELED') and end_at < :now",
+            nativeQuery = true)
+    void bulkExpire(@Param("now") LocalDateTime now);
+}

--- a/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/scheduler/SubscriptionExpireScheduler.java
+++ b/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/scheduler/SubscriptionExpireScheduler.java
@@ -1,0 +1,18 @@
+package org.cherrypic.domain.subscription.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.subscription.job.SubscriptionExpireJob;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionExpireScheduler {
+
+    private final SubscriptionExpireJob subscriptionExpireJob;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runSubscriptionExpireJob() {
+        subscriptionExpireJob.run();
+    }
+}

--- a/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
+++ b/cherrypic-batch/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionService.java
@@ -1,0 +1,19 @@
+package org.cherrypic.domain.subscription.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SubscriptionService {
+
+    private final SubscriptionRepository subscriptionRepository;
+
+    public void expireOverdueSubscriptions() {
+        subscriptionRepository.bulkExpire(LocalDateTime.now());
+    }
+}

--- a/cherrypic-batch/src/main/resources/application-dev.yml
+++ b/cherrypic-batch/src/main/resources/application-dev.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      minimum-idle: 10
+      maximum-pool-size: 20
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true

--- a/cherrypic-batch/src/main/resources/application-prod.yml
+++ b/cherrypic-batch/src/main/resources/application-prod.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      minimum-idle: 10
+      maximum-pool-size: 20
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true

--- a/cherrypic-batch/src/main/resources/application.yml
+++ b/cherrypic-batch/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+management:
+  endpoints:
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health
+      base-path: /cherrypic-actuator
+    access:
+      default: none
+  endpoint:
+    health:
+      access: unrestricted


### PR DESCRIPTION
## 🌱 관련 이슈
- close #198 

---
## 📌 작업 내용 및 특이사항
* 배치 모듈에서 구독 만료 상태 전환 스케줄러를 추가했습니다.
* 매일 자정 실행되며, 종료일이 지난 ACTIVE, CANCELED 상태의 구독을 EXPIRED로 일괄 갱신합니다.
* 성능을 고려해 Native bulk update 쿼리를 사용하였고, nextBillingAt은 null로 초기화됩니다.
* Scheduler, Job, Service는 역할 분리를 위해 계층적으로 구성했습니다.
* 스케줄링 활성화를 위해 @EnableScheduling 설정과 배치용 환경 설정 파일을 추가했습니다.

---
## 📚 참고사항
* 구독 종료 후 유예 기간(14일) 경과 시 앨범 삭제 처리는 추후 구현 예정입니다.
* Spring Batch 또는 Quartz와 같은 Job 관리 도구는 대규모 데이터 처리에 적합하지만 현재 구독 건수는 많지 않을 것으로 예상하여 간단한 스케줄러(```@Scheduled```) 기반으로 처리했습니다.
* 배치 모듈 배포는 추후에 진행할 예정입니다.