### PR TITLE
feat: 구독 만료된 앨범에 대한 주요 쓰기 요청 제한 로직 적용

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/exception/AlbumErrorCode.java
@@ -26,6 +26,8 @@ public enum AlbumErrorCode implements BaseErrorCode {
     OTHER_PARTICIPANTS_EXIST(400, "다른 참가자가 남아 있어 앨범을 삭제할 수 없습니다."),
     SUBSCRIPTION_ACTIVE(400, "구독 중인 앨범은 삭제할 수 없습니다."),
 
+    EXPIRED_SUBSCRIPTION(403, "만료된 앨범에서는 요청을 처리할 수 없습니다."),
+
     HOST_LEAVE_NOT_ALLOWED(403, "방장은 앨범을 나갈 수 없습니다."),
     HOST_SELF_KICK_NOT_ALLOWED(400, "방장은 자기 자신을 강퇴할 수 없습니다."),
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -97,6 +97,7 @@ public class AlbumServiceImpl implements AlbumService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionNotExpired(album);
 
         if (album.getCoverUrl() != null && !album.getCoverUrl().equals(request.coverUrl())) {
             eventPublisher.publishEvent(ImageDeleteEvent.of(album.getCoverUrl()));
@@ -114,6 +115,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         validateAlbumHost(currentMember.getId(), album.getId());
         validatePermissionControl(album.getType(), true);
+        validateSubscriptionNotExpired(album);
 
         album.togglePermissionControl();
 
@@ -130,6 +132,7 @@ public class AlbumServiceImpl implements AlbumService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionNotExpired(album);
 
         InvitationCode invitationCode =
                 invitationCodeRepository
@@ -159,6 +162,7 @@ public class AlbumServiceImpl implements AlbumService {
                                         new CustomException(
                                                 AlbumErrorCode.INVITATION_CODE_NOT_FOUND));
 
+        validateSubscriptionNotExpired(album);
         validateAlbumRejoin(currentMember, album);
         validateInvitationCode(currentInvitationCode, code);
         validateMaxParticipantLimit(album);
@@ -329,6 +333,14 @@ public class AlbumServiceImpl implements AlbumService {
 
         if (album.getSubscription().getStatus() == SubscriptionStatus.ACTIVE) {
             throw new CustomException(AlbumErrorCode.SUBSCRIPTION_ACTIVE);
+        }
+    }
+
+    private void validateSubscriptionNotExpired(Album album) {
+        if (album.getType() == AlbumType.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.dto.request.EventCreateRequest;
@@ -30,6 +31,7 @@ import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Slice;
@@ -59,6 +61,7 @@ public class EventServiceImpl implements EventService {
         final Album album = getAlbumById(request.albumId());
 
         validateParticipantAuthority(currentMember, album);
+        validateSubscriptionNotExpired(album);
 
         Event event = Event.createEvent(album, request.title(), request.coverUrl());
         eventRepository.save(event);
@@ -72,6 +75,7 @@ public class EventServiceImpl implements EventService {
         final Event event = getEventById(eventId);
 
         validateParticipantAuthority(currentMember, event.getAlbum());
+        validateSubscriptionNotExpired(event.getAlbum());
 
         if (event.getCoverUrl() != null && !event.getCoverUrl().equals(request.coverUrl())) {
             eventPublisher.publishEvent(ImageDeleteEvent.of(event.getCoverUrl()));
@@ -123,6 +127,8 @@ public class EventServiceImpl implements EventService {
                 request.imageIds().stream().filter(Objects::nonNull).distinct().toList();
 
         validateParticipantAuthority(currentMember, event.getAlbum());
+        validateSubscriptionNotExpired(event.getAlbum());
+
         validateAllImageExistence(distinctImageIds);
         validateAllImageAlbum(distinctImageIds, eventId);
 
@@ -237,5 +243,13 @@ public class EventServiceImpl implements EventService {
             t = t.getCause();
         }
         return null;
+    }
+
+    private void validateSubscriptionNotExpired(Album album) {
+        if (album.getType() == AlbumType.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
+        }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.entity.Album;
+import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.event.exception.EventErrorCode;
@@ -33,6 +34,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.s3.S3Util;
 import org.cherrypic.s3.enums.FileExtension;
 import org.cherrypic.s3.enums.ImageType;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -108,6 +110,7 @@ public class ImageServiceImpl implements ImageService {
         final Album album = getAlbumByIdWithLock(albumId);
 
         validateParticipantAuthority(currentMember.getId(), album.getId());
+        validateSubscriptionNotExpired(album);
 
         BigDecimal uploadCapacity =
                 request.payloads().stream()
@@ -284,6 +287,14 @@ public class ImageServiceImpl implements ImageService {
 
         if (containsNotInAlbum) {
             throw new CustomException(AlbumErrorCode.IMAGES_NOT_IN_ALBUM);
+        }
+    }
+
+    private void validateSubscriptionNotExpired(Album album) {
+        if (album.getType() == AlbumType.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -82,7 +82,10 @@ public class ParticipantServiceImpl implements ParticipantService {
         final Participant target = getParticipantById(participantId);
 
         validateAlbumHost(requester);
+
+        validateSubscriptionNotExpired(album);
         validatePermissionControlAvailable(album);
+
         validateSelfRoleChange(requester, target);
         validateParticipantBelongsToAlbum(target, album);
 
@@ -204,6 +207,14 @@ public class ParticipantServiceImpl implements ParticipantService {
     private void validateNotSameRole(Participant target, ParticipantRole role) {
         if (target.getRole() == role) {
             throw new CustomException(ParticipantErrorCode.ROLE_ALREADY_ASSIGNED);
+        }
+    }
+
+    private void validateSubscriptionNotExpired(Album album) {
+        if (album.getType() == AlbumType.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -32,6 +32,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -156,7 +157,9 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         final Album album = getAlbumById(albumId);
+
         validateAlbumHost(memberId, album.getId());
+        validateSubscriptionNotExpired(album);
 
         AlbumType currentType = album.getType();
 
@@ -194,6 +197,14 @@ public class PaymentServiceImpl implements PaymentService {
     private void validatePaidAlbumType(AlbumType type) {
         if (type == AlbumType.BASIC) {
             throw new CustomException(PaymentErrorCode.UNSUPPORTED_PAYMENT);
+        }
+    }
+
+    private void validateSubscriptionNotExpired(Album album) {
+        if (album.getType() == AlbumType.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -21,6 +21,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +43,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionNotExpired(album);
         validateSubscriptionSupported(album);
 
         final Subscription subscription = getSubscriptionByAlbumId(album.getId());
@@ -56,6 +58,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         final Album album = getAlbumById(albumId);
 
         validateAlbumHost(currentMember.getId(), album.getId());
+        validateSubscriptionNotExpired(album);
         validateSubscriptionSupported(album);
 
         final Payment payment = getPaidPaymentById(request.paymentId());
@@ -128,6 +131,14 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     private void validatePaymentMemberMismatch(Payment payment, Member member) {
         if (!payment.getMember().getId().equals(member.getId())) {
             throw new CustomException(PaymentErrorCode.PAYMENT_MEMBER_MISMATCH);
+        }
+    }
+
+    private void validateSubscriptionNotExpired(Album album) {
+        if (album.getType() == AlbumType.BASIC) return;
+
+        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -514,6 +514,28 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
         }
 
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            given(albumService.updateAlbum(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+        }
+
         @ParameterizedTest
         @NullSource
         @EmptySource
@@ -624,6 +646,22 @@ class AlbumControllerTest {
         }
 
         @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.togglePermission(1L))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(patch("/albums/1/permission"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+        }
+
+        @Test
         void BASIC_유형인_경우_예외가_발생한다() throws Exception {
             // given
             given(albumService.togglePermission(1L))
@@ -720,16 +758,29 @@ class AlbumControllerTest {
                     .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_HOST));
 
             // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/albums/1/invitation-link")
-                                    .contentType(MediaType.APPLICATION_JSON));
+            ResultActions perform = mockMvc.perform(post("/albums/1/invitation-link"));
 
             perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                     .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
                     .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.createInvitationLink(1L))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/albums/1/invitation-link"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
         }
     }
 
@@ -806,6 +857,23 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("ALREADY_PARTICIPATED"))
                     .andExpect(jsonPath("$.data.message").value("이미 참가한 앨범입니다."));
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            given(albumService.joinAlbum(1L, "expiredInvitationCode"))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(post("/albums/1/join").param("code", "expiredInvitationCode"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -538,6 +538,9 @@ class AlbumServiceTest extends IntegrationTest {
                             participant4,
                             participant5,
                             participant6));
+
+            subscriptionRepository.save(
+                    Subscription.createSubscription(member1, album1, LocalDateTime.now()));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -732,7 +732,7 @@ class AlbumServiceTest extends IntegrationTest {
             given(memberUtil.getCurrentMember()).willReturn(memberRepository.findById(2L).get());
 
             // when & then
-            assertThatThrownBy(() -> albumService.createInvitationLink(3L))
+            assertThatThrownBy(() -> albumService.createInvitationLink(999L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -59,6 +59,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @RecordApplicationEvents
 class AlbumServiceTest extends IntegrationTest {
@@ -404,13 +405,21 @@ class AlbumServiceTest extends IntegrationTest {
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4));
 
             Participant participant1 =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
             Participant participant2 =
                     Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
-            participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant3 =
+                    Participant.createParticipant(member, album4, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Subscription subscription =
+                    Subscription.createSubscription(member, album4, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.save(subscription);
         }
 
         @Test
@@ -482,6 +491,17 @@ class AlbumServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // given
+            AlbumUpdateRequest request = new AlbumUpdateRequest("testTitle", "testCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> albumService.updateAlbum(4L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
+        }
     }
 
     @Nested
@@ -515,8 +535,9 @@ class AlbumServiceTest extends IntegrationTest {
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.PRO, true);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
-            Album album4 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3, album4));
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.BASIC, false);
+            Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PRO, true);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
@@ -530,6 +551,8 @@ class AlbumServiceTest extends IntegrationTest {
                     Participant.createParticipant(member3, album1, ParticipantRole.STANDARD);
             Participant participant6 =
                     Participant.createParticipant(member3, album1, ParticipantRole.LIMITED);
+            Participant participant7 =
+                    Participant.createParticipant(member1, album5, ParticipantRole.HOST);
             participantRepository.saveAll(
                     List.of(
                             participant1,
@@ -537,10 +560,15 @@ class AlbumServiceTest extends IntegrationTest {
                             participant3,
                             participant4,
                             participant5,
-                            participant6));
+                            participant6,
+                            participant7));
 
-            subscriptionRepository.save(
-                    Subscription.createSubscription(member1, album1, LocalDateTime.now()));
+            Subscription subscription1 =
+                    Subscription.createSubscription(member1, album1, LocalDateTime.now());
+            Subscription subscription2 =
+                    Subscription.createSubscription(member1, album5, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription2, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2));
         }
 
         @Test
@@ -595,6 +623,14 @@ class AlbumServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.togglePermission(5L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
+        }
+
+        @Test
         void BASIC_유형인_경우_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> albumService.togglePermission(3L))
@@ -625,13 +661,21 @@ class AlbumServiceTest extends IntegrationTest {
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2));
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
             Participant participant2 =
                     Participant.createParticipant(member2, album2, ParticipantRole.STANDARD);
-            participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant3 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Subscription subscription =
+                    Subscription.createSubscription(member1, album3, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.save(subscription);
         }
 
         @AfterEach
@@ -714,6 +758,14 @@ class AlbumServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
         }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.createInvitationLink(3L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
+        }
     }
 
     @Nested
@@ -732,11 +784,14 @@ class AlbumServiceTest extends IntegrationTest {
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
+            Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4));
 
-            Participant participant =
+            Participant participant1 =
                     Participant.createParticipant(member, album3, ParticipantRole.HOST);
-            participantRepository.save(participant);
+            Participant participant2 =
+                    Participant.createParticipant(member, album4, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2));
 
             InvitationCode invitationCode1 =
                     InvitationCode.builder()
@@ -750,7 +805,19 @@ class AlbumServiceTest extends IntegrationTest {
                             .code("testInvitationCode2")
                             .ttl(Duration.ofMinutes(30).getSeconds())
                             .build();
-            invitationCodeRepository.saveAll(List.of(invitationCode1, invitationCode2));
+            InvitationCode invitationCode3 =
+                    InvitationCode.builder()
+                            .albumId(4L)
+                            .code("testInvitationCode3")
+                            .ttl(Duration.ofMinutes(30).getSeconds())
+                            .build();
+            invitationCodeRepository.saveAll(
+                    List.of(invitationCode1, invitationCode2, invitationCode3));
+
+            Subscription subscription =
+                    Subscription.createSubscription(member, album4, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.save(subscription);
         }
 
         @AfterEach
@@ -794,6 +861,14 @@ class AlbumServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> albumService.joinAlbum(1L, "expiredInvitationCode"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.INVITATION_CODE_MISMATCH.getMessage());
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> albumService.joinAlbum(4L, "testInvitationCode3"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/controller/EventControllerTest.java
@@ -179,6 +179,28 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
                     .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
         }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+
+            given(eventService.createEvent(request))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+        }
     }
 
     @Nested
@@ -277,15 +299,16 @@ public class EventControllerTest {
         @Test
         void 요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+            EventUpdateRequest request =
+                    new EventUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
 
-            given(eventService.createEvent(request))
+            given(eventService.updateEvent(1L, request))
                     .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events")
+                            patch("/events/1")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -299,15 +322,16 @@ public class EventControllerTest {
         @Test
         void 요청자가_LIMITED_권한을_가지는_경우_예외가_발생한다() throws Exception {
             // given
-            EventCreateRequest request = new EventCreateRequest(1L, "testTitle", "testCoverUrl");
+            EventUpdateRequest request =
+                    new EventUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
 
-            given(eventService.createEvent(request))
+            given(eventService.updateEvent(1L, request))
                     .willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/events")
+                            patch("/events/1")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -318,80 +342,99 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
         }
 
-        @Nested
-        class 이벤트_삭제_요청_시 {
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("testUpdatedTitle", "testUpdatedCoverUrl");
 
-            @Test
-            void 유효한_요청이면_이벤트를_삭제하고_NO_CONTENT_로_반환한다() throws Exception {
-                // given
-                willDoNothing().given(eventService).deleteEvent(1L);
+            given(eventService.updateEvent(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
 
-                // when & then
-                ResultActions perform =
-                        mockMvc.perform(
-                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/events/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
 
-                perform.andExpect(status().isNoContent())
-                        .andExpect(jsonPath("$.success").value(true))
-                        .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
-            }
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+        }
+    }
 
-            @Test
-            void 이벤트가_존재하지_않는_경우_예외가_발생한다() throws Exception {
-                // given
-                willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND))
-                        .given(eventService)
-                        .deleteEvent(1L);
+    @Nested
+    class 이벤트_삭제_요청_시 {
 
-                // when & then
-                ResultActions perform =
-                        mockMvc.perform(
-                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+        @Test
+        void 유효한_요청이면_이벤트를_삭제하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            willDoNothing().given(eventService).deleteEvent(1L);
 
-                perform.andExpect(status().isNotFound())
-                        .andExpect(jsonPath("$.success").value(false))
-                        .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                        .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
-                        .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
-            }
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(delete("/events/1").contentType(MediaType.APPLICATION_JSON));
 
-            @Test
-            void 요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
-                // given
-                willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
-                        .given(eventService)
-                        .deleteEvent(1L);
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
 
-                // when & then
-                ResultActions perform =
-                        mockMvc.perform(
-                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+        @Test
+        void 이벤트가_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND))
+                    .given(eventService)
+                    .deleteEvent(1L);
 
-                perform.andExpect(status().isForbidden())
-                        .andExpect(jsonPath("$.success").value(false))
-                        .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                        .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
-                        .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
-            }
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(delete("/events/1").contentType(MediaType.APPLICATION_JSON));
 
-            @Test
-            void 요청자가_LIMITED_권한을_가지는_경우_예외가_발생한다() throws Exception {
-                // given
-                willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY))
-                        .given(eventService)
-                        .deleteEvent(1L);
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("EVENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("존재하지 않는 이벤트입니다."));
+        }
 
-                // when & then
-                ResultActions perform =
-                        mockMvc.perform(
-                                delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+        @Test
+        void 요청자가_앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT))
+                    .given(eventService)
+                    .deleteEvent(1L);
 
-                perform.andExpect(status().isForbidden())
-                        .andExpect(jsonPath("$.success").value(false))
-                        .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
-                        .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
-                        .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
-            }
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_PARTICIPANT"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 속하지 않은 사용자입니다."));
+        }
+
+        @Test
+        void 요청자가_LIMITED_권한을_가지는_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.LIMITED_AUTHORITY))
+                    .given(eventService)
+                    .deleteEvent(1L);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(delete("/events/1").contentType(MediaType.APPLICATION_JSON));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
+                    .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
         }
     }
 
@@ -669,6 +712,29 @@ public class EventControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                     .andExpect(jsonPath("$.data.code").value("LIMITED_AUTHORITY"))
                     .andExpect(jsonPath("$.data.message").value("앨범에 대한 생성/수정 권한이 없습니다."));
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(1L));
+
+            willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION))
+                    .given(eventService)
+                    .addImages(1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/events/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/event/service/EventServiceTest.java
@@ -30,6 +30,7 @@ import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
@@ -42,6 +43,8 @@ import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -52,6 +55,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @RecordApplicationEvents
 public class EventServiceTest extends IntegrationTest {
@@ -65,6 +69,7 @@ public class EventServiceTest extends IntegrationTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private ParticipantRepository participantRepository;
     @Autowired private ImageRepository imageRepository;
+    @Autowired private SubscriptionRepository subscriptionRepository;
     @MockitoSpyBean private EventImageRepository eventImageRepository;
     @Autowired private EntityManager em;
 
@@ -90,13 +95,21 @@ public class EventServiceTest extends IntegrationTest {
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2));
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
             Participant participant2 =
                     Participant.createParticipant(member2, album1, ParticipantRole.LIMITED);
-            participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant3 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Subscription subscription =
+                    Subscription.createSubscription(member1, album3, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.save(subscription);
         }
 
         @Test
@@ -138,6 +151,17 @@ public class EventServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
         }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // given
+            EventCreateRequest request = new EventCreateRequest(3L, "testEvent", "tesCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> eventService.createEvent(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
+        }
     }
 
     @Nested
@@ -165,7 +189,8 @@ public class EventServiceTest extends IntegrationTest {
 
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2));
+            Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
@@ -173,11 +198,20 @@ public class EventServiceTest extends IntegrationTest {
                     Participant.createParticipant(member2, album1, ParticipantRole.LIMITED);
             Participant participant3 =
                     Participant.createParticipant(member3, album2, ParticipantRole.HOST);
-            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+            Participant participant4 =
+                    Participant.createParticipant(member1, album3, ParticipantRole.HOST);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4));
+
+            Subscription subscription =
+                    Subscription.createSubscription(member1, album3, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.save(subscription);
 
             Event event1 = Event.createEvent(album1, "testEvent1", "testEventCoverUrl1");
-            Event event2 = Event.createEvent(album2, "testEvent1", "testEventCoverUrl1");
-            eventRepository.saveAll(List.of(event1, event2));
+            Event event2 = Event.createEvent(album2, "testEvent2", "testEventCoverUrl2");
+            Event event3 = Event.createEvent(album3, "testEvent3", "testEventCoverUrl3");
+            eventRepository.saveAll(List.of(event1, event2, event3));
         }
 
         @Test
@@ -248,6 +282,18 @@ public class EventServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> eventService.updateEvent(1L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // given
+            EventUpdateRequest request =
+                    new EventUpdateRequest("changedTestEventTitle", "changedTestEventCoverUrl");
+
+            // when & then
+            assertThatThrownBy(() -> eventService.updateEvent(3L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
         }
     }
 
@@ -469,18 +515,27 @@ public class EventServiceTest extends IntegrationTest {
             Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
             Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
+            Album album4 = Album.createAlbum("testTitle4", "testCoverUrl4", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4));
 
             Participant participant1 =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
             Participant participant2 =
                     Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
-            participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant3 =
+                    Participant.createParticipant(member, album4, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Subscription subscription =
+                    Subscription.createSubscription(member, album4, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.save(subscription);
 
             Event event1 = Event.createEvent(album1, "testTitle1", "testCoverUrl1");
             Event event2 = Event.createEvent(album2, "testTitle2", "testCoverUrl2");
             Event event3 = Event.createEvent(album3, "testTitle3", "testCoverUrl3");
-            eventRepository.saveAll(List.of(event1, event2, event3));
+            Event event4 = Event.createEvent(album4, "testTitle4", "testCoverUrl4");
+            eventRepository.saveAll(List.of(event1, event2, event3, event4));
 
             Image image1 =
                     Image.createImage(album1, 1L, "testUrl", LocalDateTime.now(), BigDecimal.ZERO);
@@ -555,6 +610,17 @@ public class EventServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> eventService.addImages(2L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // given
+            EventImageAddRequest request = new EventImageAddRequest(List.of(3L));
+
+            // when & then
+            assertThatThrownBy(() -> eventService.addImages(4L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -481,6 +481,41 @@ class ImageControllerTest {
         }
 
         @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(
+                            List.of(
+                                    new AlbumImageUploadRequest.Payload(
+                                            FileExtension.JPEG,
+                                            "testMd5Hash1",
+                                            LocalDateTime.now(),
+                                            BigDecimal.ONE),
+                                    new AlbumImageUploadRequest.Payload(
+                                            FileExtension.JPEG,
+                                            "testMd5Hash2",
+                                            LocalDateTime.now(),
+                                            BigDecimal.ONE)));
+
+            given(imageService.createAlbumImageUploadUrls(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+            // when & then
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/albums/1/images")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+        }
+
+        @Test
         void 앨범의_남은_용량을_초과해서_요청하면_예외가_발생한다() throws Exception {
             // given
             AlbumImageUploadRequest request =

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -28,6 +28,7 @@ import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
@@ -42,6 +43,8 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.s3.S3Util;
 import org.cherrypic.s3.enums.FileExtension;
 import org.cherrypic.s3.enums.ImageType;
+import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -50,6 +53,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @RecordApplicationEvents
 class ImageServiceTest extends IntegrationTest {
@@ -65,6 +69,7 @@ class ImageServiceTest extends IntegrationTest {
     @Autowired private AlbumRepository albumRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private EventImageRepository eventImageRepository;
+    @Autowired private SubscriptionRepository subscriptionRepository;
 
     @Nested
     class 프로필용_Presigned_URL을_생성할_때 {
@@ -273,13 +278,21 @@ class ImageServiceTest extends IntegrationTest {
             album1.increaseCapacity(BigDecimal.ONE);
             Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
             Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
+            Album album4 = Album.createAlbum("testTitle4", "testCoverUrl4", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4));
 
             Participant participant1 =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
             Participant participant2 =
                     Participant.createParticipant(member, album2, ParticipantRole.LIMITED);
-            participantRepository.saveAll(List.of(participant1, participant2));
+            Participant participant3 =
+                    Participant.createParticipant(member, album4, ParticipantRole.HOST);
+            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Subscription subscription =
+                    Subscription.createSubscription(member, album4, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.save(subscription);
         }
 
         @Test
@@ -426,6 +439,29 @@ class ImageServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(2L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // given
+            AlbumImageUploadRequest request =
+                    new AlbumImageUploadRequest(
+                            List.of(
+                                    new AlbumImageUploadRequest.Payload(
+                                            FileExtension.JPEG,
+                                            "testMd5Hash1",
+                                            LocalDateTime.now(),
+                                            BigDecimal.ZERO),
+                                    new AlbumImageUploadRequest.Payload(
+                                            FileExtension.JPEG,
+                                            "testMd5Hash2",
+                                            LocalDateTime.now(),
+                                            BigDecimal.ZERO)));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(4L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/controller/ParticipantControllerTest.java
@@ -324,6 +324,30 @@ class ParticipantControllerTest {
         }
 
         @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION))
+                    .given(participantService)
+                    .updateParticipantRole(1L, 1L, request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/participants/1/role")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+        }
+
+        @Test
         void 앨범_방장이_자기_자신의_권한을_변경하려는_경우_예외가_발생한다() throws Exception {
             // given
             ParticipantRoleUpdateRequest request =

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -30,9 +30,11 @@ import org.cherrypic.notification.enums.NotificationType;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class ParticipantServiceTest extends IntegrationTest {
 
@@ -312,7 +314,8 @@ class ParticipantServiceTest extends IntegrationTest {
             Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.PRO, true);
             Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.PRO, true);
             Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
+            Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumType.PRO, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5, album6));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
@@ -330,6 +333,8 @@ class ParticipantServiceTest extends IntegrationTest {
                     Participant.createParticipant(member1, album5, ParticipantRole.HOST);
             Participant participant8 =
                     Participant.createParticipant(member2, album5, ParticipantRole.STANDARD);
+            Participant participant9 =
+                    Participant.createParticipant(member1, album6, ParticipantRole.HOST);
             participantRepository.saveAll(
                     List.of(
                             participant1,
@@ -339,7 +344,8 @@ class ParticipantServiceTest extends IntegrationTest {
                             participant5,
                             participant6,
                             participant7,
-                            participant8));
+                            participant8,
+                            participant9));
 
             // 15일 전에 시작되어 현재는 해지된 구독
             Subscription subscription1 =
@@ -350,7 +356,11 @@ class ParticipantServiceTest extends IntegrationTest {
             Subscription subscription2 =
                     Subscription.createSubscription(
                             member1, album4, LocalDateTime.now().minusDays(15));
-            subscriptionRepository.saveAll(List.of(subscription1, subscription2));
+            // 만료된 구독
+            Subscription subscription3 =
+                    Subscription.createSubscription(member1, album6, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription3, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
         }
 
         @Test
@@ -418,6 +428,18 @@ class ParticipantServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> participantService.updateParticipantRole(3L, 3L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // given
+            ParticipantRoleUpdateRequest request =
+                    new ParticipantRoleUpdateRequest(ParticipantRole.LIMITED);
+
+            // when & then
+            assertThatThrownBy(() -> participantService.updateParticipantRole(6L, 4L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -215,6 +215,28 @@ class PaymentControllerTest {
                         .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
                         .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
             }
+
+            @Test
+            void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+                // given
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
+
+                given(paymentService.preparePayment(request))
+                        .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/payments/ready")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                        .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                        .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+            }
         }
 
         @Nested
@@ -342,6 +364,28 @@ class PaymentControllerTest {
                         .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                         .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
                         .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+            }
+
+            @Test
+            void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+                // given
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 1L);
+
+                given(paymentService.preparePayment(request))
+                        .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/payments/ready")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                        .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                        .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
             }
         }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -42,6 +42,7 @@ import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
 import org.cherrypic.subscription.entity.Subscription;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import retrofit2.HttpException;
 import retrofit2.Response;
 
@@ -88,7 +90,10 @@ public class PaymentServiceTest extends IntegrationTest {
                     Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.BASIC, false);
             Album basicAlbum2 =
                     Album.createAlbum("testTitle4", "testCoverUrl4", AlbumType.BASIC, false);
-            albumRepository.saveAll(List.of(proAlbum, premiumAlbum, basicAlbum1, basicAlbum2));
+            Album expiredAlbum =
+                    Album.createAlbum("testTitle5", "testCoverUrl5", AlbumType.PRO, false);
+            albumRepository.saveAll(
+                    List.of(proAlbum, premiumAlbum, basicAlbum1, basicAlbum2, expiredAlbum));
 
             Participant participant1 =
                     Participant.createParticipant(member, proAlbum, ParticipantRole.HOST);
@@ -96,13 +101,19 @@ public class PaymentServiceTest extends IntegrationTest {
                     Participant.createParticipant(member, premiumAlbum, ParticipantRole.HOST);
             Participant participant3 =
                     Participant.createParticipant(member, basicAlbum2, ParticipantRole.STANDARD);
-            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+            Participant participant4 =
+                    Participant.createParticipant(member, expiredAlbum, ParticipantRole.HOST);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4));
 
             Subscription subscription1 =
                     Subscription.createSubscription(member, proAlbum, LocalDateTime.now());
             Subscription subscription2 =
                     Subscription.createSubscription(member, premiumAlbum, LocalDateTime.now());
-            subscriptionRepository.saveAll(List.of(subscription1, subscription2));
+            Subscription subscription3 =
+                    Subscription.createSubscription(member, expiredAlbum, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription3, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
         }
 
         @Nested
@@ -205,6 +216,17 @@ public class PaymentServiceTest extends IntegrationTest {
                         .isInstanceOf(CustomException.class)
                         .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
             }
+
+            @Test
+            void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+                // given
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 5L);
+
+                // when & then
+                assertThatThrownBy(() -> paymentService.preparePayment(request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
+            }
         }
 
         @Nested
@@ -277,6 +299,17 @@ public class PaymentServiceTest extends IntegrationTest {
                 assertThatThrownBy(() -> paymentService.preparePayment(request))
                         .isInstanceOf(CustomException.class)
                         .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+            }
+
+            @Test
+            void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+                // given
+                PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, 5L);
+
+                // when & then
+                assertThatThrownBy(() -> paymentService.preparePayment(request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
             }
         }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -29,6 +29,7 @@ import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.payment.service.PaymentService;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -40,6 +41,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.subscription.entity.Subscription;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -58,6 +60,7 @@ public class PaymentServiceTest extends IntegrationTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private AlbumRepository albumRepository;
     @Autowired private ParticipantRepository participantRepository;
+    @Autowired private SubscriptionRepository subscriptionRepository;
 
     @MockitoBean private MemberUtil memberUtil;
 
@@ -94,6 +97,12 @@ public class PaymentServiceTest extends IntegrationTest {
             Participant participant3 =
                     Participant.createParticipant(member, basicAlbum2, ParticipantRole.STANDARD);
             participantRepository.saveAll(List.of(participant1, participant2, participant3));
+
+            Subscription subscription1 =
+                    Subscription.createSubscription(member, proAlbum, LocalDateTime.now());
+            Subscription subscription2 =
+                    Subscription.createSubscription(member, premiumAlbum, LocalDateTime.now());
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2));
         }
 
         @Nested

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -129,23 +129,6 @@ class SubscriptionControllerTest {
         }
 
         @Test
-        void 구독이_존재하지_않는_경우_예외가_발생한다() throws Exception {
-            // given
-            willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND))
-                    .given(subscriptionService)
-                    .cancelSubscription(1L);
-
-            // when & then
-            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("구독 정보가 존재하지 않습니다."));
-        }
-
-        @Test
         void 이미_해지된_구독이면_예외가_발생한다() throws Exception {
             // given
             willThrow(new CustomException(SubscriptionDomainErrorCode.ALREADY_CANCELED))
@@ -414,28 +397,6 @@ class SubscriptionControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("PAYMENT_PURPOSE_MISMATCH"))
                     .andExpect(jsonPath("$.data.message").value("결제 목적이 요청하려는 작업과 일치하지 않습니다."));
-        }
-
-        @Test
-        void 구독이_존재하지_않는_경우_예외가_발생한다() throws Exception {
-            // given
-            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
-
-            given(subscriptionService.renewSubscription(1L, request))
-                    .willThrow(new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            patch("/albums/1/subscriptions/renew")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                    .andExpect(jsonPath("$.data.code").value("SUBSCRIPTION_NOT_FOUND"))
-                    .andExpect(jsonPath("$.data.message").value("구독 정보가 존재하지 않습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -107,6 +107,23 @@ class SubscriptionControllerTest {
         }
 
         @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION))
+                    .given(subscriptionService)
+                    .cancelSubscription(1L);
+
+            // when & then
+            ResultActions perform = mockMvc.perform(delete("/albums/1/subscriptions"));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
+        }
+
+        @Test
         void BASIC_유형인_경우_예외가_발생한다() throws Exception {
             // given
             willThrow(
@@ -259,6 +276,28 @@ class SubscriptionControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
                     .andExpect(jsonPath("$.data.code").value("NOT_ALBUM_HOST"))
                     .andExpect(jsonPath("$.data.message").value("방장이 아닌 경우 권한이 없습니다."));
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()))
+                    .andExpect(jsonPath("$.data.code").value("EXPIRED_SUBSCRIPTION"))
+                    .andExpect(jsonPath("$.data.message").value("만료된 앨범에서는 요청을 처리할 수 없습니다."));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -210,10 +210,10 @@ class SubscriptionServiceTest extends IntegrationTest {
                             participant5,
                             participant6));
 
-            // 15일 전에 시작되어 현재는 해지된 구독
+            // 9월 1일에 시작되어 현재는 해지된 구독
             Subscription subscription1 =
                     Subscription.createSubscription(
-                            member1, album1, LocalDateTime.now().minusDays(15));
+                            member1, album1, LocalDateTime.of(2025, 9, 1, 0, 0));
             subscription1.cancel();
 
             // 구독 중

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -37,6 +37,7 @@ import org.cherrypic.subscription.exception.SubscriptionDomainErrorCode;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class SubscriptionServiceTest extends IntegrationTest {
 
@@ -70,7 +71,9 @@ class SubscriptionServiceTest extends IntegrationTest {
             Album album4 = Album.createAlbum("testAlbum4", "testURL4", AlbumType.PREMIUM, false);
             Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PREMIUM, false);
             Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumType.PREMIUM, false);
-            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5, album6));
+            Album album7 = Album.createAlbum("testAlbum7", "testURL7", AlbumType.PRO, false);
+            albumRepository.saveAll(
+                    List.of(album1, album2, album3, album4, album5, album6, album7));
 
             Participant participant1 =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
@@ -82,15 +85,26 @@ class SubscriptionServiceTest extends IntegrationTest {
                     Participant.createParticipant(member, album4, ParticipantRole.STANDARD);
             Participant participant5 =
                     Participant.createParticipant(member, album5, ParticipantRole.HOST);
+            Participant participant6 =
+                    Participant.createParticipant(member, album7, ParticipantRole.HOST);
             participantRepository.saveAll(
-                    List.of(participant1, participant2, participant3, participant4, participant5));
+                    List.of(
+                            participant1,
+                            participant2,
+                            participant3,
+                            participant4,
+                            participant5,
+                            participant6));
 
             Subscription subscription1 =
                     Subscription.createSubscription(member, album2, LocalDateTime.now());
             Subscription subscription2 =
                     Subscription.createSubscription(
                             member, album3, LocalDateTime.of(2025, 1, 1, 0, 0));
-            subscriptionRepository.saveAll(List.of(subscription1, subscription2));
+            Subscription subscription3 =
+                    Subscription.createSubscription(member, album7, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription3, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
         }
 
         @Test
@@ -129,6 +143,14 @@ class SubscriptionServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> subscriptionService.cancelSubscription(4L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.cancelSubscription(7L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
         }
 
         @Test
@@ -186,8 +208,9 @@ class SubscriptionServiceTest extends IntegrationTest {
             Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PREMIUM, false);
             Album album6 = Album.createAlbum("testAlbum6", "testURL6", AlbumType.PREMIUM, false);
             Album album7 = Album.createAlbum("testAlbum7", "testURL7", AlbumType.PREMIUM, false);
+            Album album8 = Album.createAlbum("testAlbum8", "testURL8", AlbumType.PRO, false);
             albumRepository.saveAll(
-                    List.of(album1, album2, album3, album4, album5, album6, album7));
+                    List.of(album1, album2, album3, album4, album5, album6, album7, album8));
 
             Participant participant1 =
                     Participant.createParticipant(member1, album1, ParticipantRole.HOST);
@@ -201,6 +224,8 @@ class SubscriptionServiceTest extends IntegrationTest {
                     Participant.createParticipant(member1, album6, ParticipantRole.HOST);
             Participant participant6 =
                     Participant.createParticipant(member1, album7, ParticipantRole.HOST);
+            Participant participant7 =
+                    Participant.createParticipant(member1, album8, ParticipantRole.HOST);
             participantRepository.saveAll(
                     List.of(
                             participant1,
@@ -208,24 +233,27 @@ class SubscriptionServiceTest extends IntegrationTest {
                             participant3,
                             participant4,
                             participant5,
-                            participant6));
+                            participant6,
+                            participant7));
 
             // 9월 1일에 시작되어 현재는 해지된 구독
             Subscription subscription1 =
                     Subscription.createSubscription(
                             member1, album1, LocalDateTime.of(2025, 9, 1, 0, 0));
             subscription1.cancel();
-
-            // 구독 중
-            Subscription subscription3 =
-                    Subscription.createSubscription(member1, album6, LocalDateTime.now());
-
             // 종료된 구독
             Subscription subscription2 =
                     Subscription.createSubscription(
                             member1, album7, LocalDateTime.of(2025, 7, 1, 0, 0));
-
-            subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
+            // 구독 중
+            Subscription subscription3 =
+                    Subscription.createSubscription(member1, album6, LocalDateTime.now());
+            // 만료된 구독
+            Subscription subscription4 =
+                    Subscription.createSubscription(member1, album8, LocalDateTime.now());
+            ReflectionTestUtils.setField(subscription4, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.saveAll(
+                    List.of(subscription1, subscription2, subscription3, subscription4));
 
             // 완료된 결제
             Payment payment1 =
@@ -362,6 +390,17 @@ class SubscriptionServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> subscriptionService.renewSubscription(3L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_HOST.getMessage());
+        }
+
+        @Test
+        void 구독이_만료된_앨범인_경우_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(8L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(AlbumErrorCode.EXPIRED_SUBSCRIPTION.getMessage());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -142,14 +142,6 @@ class SubscriptionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 구독이_존재하지_않는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> subscriptionService.cancelSubscription(5L))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
-        }
-
-        @Test
         void 이미_해지된_구독이면_예외가_발생한다() {
             // given
             subscriptionService.cancelSubscription(2L);
@@ -438,17 +430,6 @@ class SubscriptionServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> subscriptionService.renewSubscription(1L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PaymentDomainErrorCode.PAYMENT_PURPOSE_MISMATCH.getMessage());
-        }
-
-        @Test
-        void 구독이_존재하지_않는_경우_예외가_발생한다() {
-            // given
-            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
-
-            // when & then
-            assertThatThrownBy(() -> subscriptionService.renewSubscription(5L, request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #201 

---
## 📌 작업 내용 및 특이사항
* 구독 만료 상태(EXPIRED)의 앨범에 대해 주요 쓰기 요청을 제한하는 로직을 각 도메인 서비스에 적용했습니다.
  * 기존에는 별도 차단 없이 요청이 가능했으나, 유예 기간이 도입되면서 명시적인 차단이 필요해졌습니다.
  * 읽기 작업은 허용을 해줘야 볼 수 있기 때문에 앨범, 이벤트, 이미지 등의 조회는 허용합니다.
* 다음 API들에 대해, 앨범이 구독 만료 상태일 경우 요청을 차단하도록 로직을 추가했습니다.
  * 앨범 수정, 멤버별 권한 부여, 초대 코드 발급
  * 이벤트 생성 / 수정
  * 이미지 업로드
  * 앨범 참여, 참가자 권한 변경
  * 구독 갱신 / 해지
* 유예 기간 중에도 사용자 편의를 고려해 아래 API는 제한하지 않았습니다.
  * 앨범 삭제
  * 이벤트 삭제
  * 이미지 삭제
  * 참가자 강퇴, 앨범 떠나기
  * 앨범 좋아요

---
## 📚 참고사항
* AOP 기반 접근은 도입을 고려했으나, 도메인별 예외 케이스가 존재해 서비스 레이어에서 명시적으로 처리하는 방식으로 구현했습니다.
* 에러 코드는 AlbumErrorCode.EXPIRED_SUBSCRIPTION을 공통으로 사용하며, 메시지는 상황에 따라 달라지지 않습니다.
* 구독 상태 확인은 AlbumType이 BASIC이 아닌 경우에만 수행됩니다.