### PR TITLE
chore: Docker 실행 환경 JVM 타임존 Asia/Seoul 설정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -68,5 +68,5 @@ jobs:
             aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
             docker rm -f cherrypic-api || true
             docker pull ${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
-            docker run -d --name cherrypic-api --env-file .env -p 8080:8080 ${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+            docker run -d --name cherrypic-api --env-file .env -e TZ=Asia/Seoul -p 8080:8080 ${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
             docker image prune -a -f


### PR DESCRIPTION
## 🌱 관련 이슈
- close #207 

---
## 📌 작업 내용 및 특이사항
* 개발 서버(EC2)에서 실행되는 Spring Boot 컨테이너의 JVM 타임존을 기본값인 UTC에서 KST(Asia/Seoul)로 변경했습니다.
  * docker run 명령어에 -e TZ=Asia/Seoul 옵션을 추가하여 적용했습니다.
* 운영 환경은 AWS ECS를 사용하고 있어, 추후 task-definition.json 추가 시 환경변수를 추가할 예정입니다.