### PR TITLE
feat: 결제 취소 및 환불 처리 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -80,7 +80,7 @@ public class AlbumServiceImpl implements AlbumService {
 
             validatePaymentMemberMismatch(payment, currentMember);
 
-            payment.updatePayment(PaymentPurpose.CREATION, album);
+            payment.assignToAlbum(PaymentPurpose.CREATION, album);
 
             subscriptionRepository.save(
                     Subscription.createSubscription(currentMember, album, payment.getPaidAt()));

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/controller/PaymentController.java
@@ -14,6 +14,7 @@ import org.cherrypic.domain.payment.service.PaymentService;
 import org.cherrypic.global.annotation.PageSize;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,6 +41,13 @@ public class PaymentController {
             description = "impUid에 해당하는 결제 정보를 아임포트에서 조회하고, 결제 금액과 상태를 검증합니다.")
     public PaymentVerificationResponse paymentVerify(@PathVariable String impUid) {
         return paymentService.verifyPayment(impUid);
+    }
+
+    @PostMapping("/cancel/{impUid}")
+    @Operation(summary = "impUid 기반 결제 취소", description = "impUid에 해당하는 결제를 전체 환불 처리합니다.")
+    public ResponseEntity<Void> paymentCancel(@PathVariable String impUid) {
+        paymentService.cancelPayment(impUid);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/unlinked")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long>, PaymentRepositoryCustom {
     Optional<Payment> findByMerchantUid(String merchantUid);
+
+    Optional<Payment> findByImpUid(String impUid);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentService.java
@@ -13,6 +13,8 @@ public interface PaymentService {
 
     PaymentVerificationResponse verifyPayment(String impUid);
 
+    void cancelPayment(String impUid);
+
     PaymentUnlinkedResponse getUnlinkedPayment();
 
     SliceResponse<PaymentListResponse> getAlbumPayments(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -108,7 +108,7 @@ public class PaymentServiceImpl implements PaymentService {
                 throw new CustomException(PaymentErrorCode.NOT_PAID);
             }
 
-            payment.updatePayment(impUid, pgProvider, PaymentStatus.PAID, paidAt);
+            payment.complete(impUid, pgProvider, paidAt);
 
             return PaymentVerificationResponse.from(payment);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -2,6 +2,7 @@ package org.cherrypic.domain.payment.service;
 
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.CancelData;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -111,6 +112,31 @@ public class PaymentServiceImpl implements PaymentService {
             payment.complete(impUid, pgProvider, paidAt);
 
             return PaymentVerificationResponse.from(payment);
+
+        } catch (IamportResponseException e) {
+            throw new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND);
+        } catch (IOException e) {
+            throw new CustomException(PaymentErrorCode.IAMPORT_API_UNAVAILABLE);
+        }
+    }
+
+    @Override
+    public void cancelPayment(String impUid) {
+        try {
+            var iamportPayment = iamportClient.paymentByImpUid(impUid).getResponse();
+
+            Payment payment =
+                    paymentRepository
+                            .findByImpUid(impUid)
+                            .orElseThrow(
+                                    () -> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+            payment.cancel(LocalDateTime.now());
+
+            CancelData cancelData =
+                    new CancelData(iamportPayment.getImpUid(), true, iamportPayment.getAmount());
+
+            iamportClient.cancelPaymentByImpUid(cancelData);
 
         } catch (IamportResponseException e) {
             throw new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -65,7 +65,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
         validatePaymentMemberMismatch(payment, currentMember);
 
-        payment.updatePayment(PaymentPurpose.RENEWAL, album);
+        payment.assignToAlbum(PaymentPurpose.RENEWAL, album);
 
         final Subscription subscription = getSubscriptionByAlbumId(album.getId());
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -250,7 +250,31 @@ class AlbumControllerTest {
             }
 
             @Test
-            void 결제상태가_PAID가_아니면_예외가_발생한다() throws Exception {
+            void 이미_취소된_결제라면_예외가_발생한다() throws Exception {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 1L, false);
+
+                given(albumService.createAlbum(request))
+                        .willThrow(new CustomException(PaymentDomainErrorCode.ALREADY_CANCELED));
+
+                // when & then
+                ResultActions perform =
+                        mockMvc.perform(
+                                post("/albums")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request)));
+
+                perform.andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.success").value(false))
+                        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                        .andExpect(jsonPath("$.data.code").value("ALREADY_CANCELED"))
+                        .andExpect(jsonPath("$.data.message").value("해당 결제는 이미 취소되었습니다."));
+            }
+
+            @Test
+            void 완료되지_않은_결제라면_예외가_발생한다() throws Exception {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -231,7 +231,18 @@ class AlbumServiceTest extends IntegrationTest {
                                 PaymentPurpose.RENEWAL,
                                 AlbumType.PRO);
                 payment4.complete("testImpUid", "testPgProvider", LocalDateTime.now());
-                paymentRepository.saveAll(List.of(payment1, payment2, payment3, payment4));
+                // 취소된 결제
+                Payment payment5 =
+                        Payment.createPayment(
+                                member1,
+                                "testMerchantUid",
+                                5900,
+                                PaymentPurpose.CREATION,
+                                AlbumType.PRO);
+                payment5.complete("testImpUid", "testPgProvider", LocalDateTime.now());
+                payment5.cancel(LocalDateTime.now());
+                paymentRepository.saveAll(
+                        List.of(payment1, payment2, payment3, payment4, payment5));
             }
 
             @Test
@@ -344,7 +355,20 @@ class AlbumServiceTest extends IntegrationTest {
             }
 
             @Test
-            void 결제상태가_PAID가_아니면_예외가_발생한다() {
+            void 이미_취소된_결제라면_예외가_발생한다() {
+                // given
+                AlbumCreateRequest request =
+                        new AlbumCreateRequest(
+                                "testTitle", "testCoverUrl", AlbumType.PRO, 5L, false);
+
+                // when & then
+                assertThatThrownBy(() -> albumService.createAlbum(request))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(PaymentDomainErrorCode.ALREADY_CANCELED.getMessage());
+            }
+
+            @Test
+            void 완료되지_않은_결제라면_예외가_발생한다() {
                 // given
                 AlbumCreateRequest request =
                         new AlbumCreateRequest(

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -202,11 +202,8 @@ class AlbumServiceTest extends IntegrationTest {
                                 5900,
                                 PaymentPurpose.CREATION,
                                 AlbumType.PRO);
-                payment1.updatePayment(
-                        "testImpUid",
-                        "testPgProvider",
-                        PaymentStatus.PAID,
-                        LocalDateTime.of(2025, 8, 1, 13, 0));
+                payment1.complete(
+                        "testImpUid", "testPgProvider", LocalDateTime.of(2025, 8, 1, 13, 0));
                 // 검증되지 않은 결제
                 Payment payment2 =
                         Payment.createPayment(
@@ -223,8 +220,7 @@ class AlbumServiceTest extends IntegrationTest {
                                 5900,
                                 PaymentPurpose.CREATION,
                                 AlbumType.PRO);
-                payment3.updatePayment(
-                        "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+                payment3.complete("testImpUid", "testPgProvider", LocalDateTime.now());
                 payment3.updatePayment(PaymentPurpose.CREATION, album);
                 // 구독 갱신 목적으로 쓰인 결제
                 Payment payment4 =
@@ -234,8 +230,7 @@ class AlbumServiceTest extends IntegrationTest {
                                 5900,
                                 PaymentPurpose.RENEWAL,
                                 AlbumType.PRO);
-                payment4.updatePayment(
-                        "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+                payment4.complete("testImpUid", "testPgProvider", LocalDateTime.now());
                 paymentRepository.saveAll(List.of(payment1, payment2, payment3, payment4));
             }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -221,7 +221,7 @@ class AlbumServiceTest extends IntegrationTest {
                                 PaymentPurpose.CREATION,
                                 AlbumType.PRO);
                 payment3.complete("testImpUid", "testPgProvider", LocalDateTime.now());
-                payment3.updatePayment(PaymentPurpose.CREATION, album);
+                payment3.assignToAlbum(PaymentPurpose.CREATION, album);
                 // 구독 갱신 목적으로 쓰인 결제
                 Payment payment4 =
                         Payment.createPayment(

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -1,7 +1,7 @@
 package org.cherrypic.payment.controller;
 
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -24,6 +24,7 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.payment.enums.PaymentPurpose;
+import org.cherrypic.payment.exception.PaymentDomainErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -552,6 +553,110 @@ class PaymentControllerTest {
 
             // when & then
             ResultActions perform = mockMvc.perform(post("/payments/verify/imp_1234"));
+
+            perform.andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.SERVICE_UNAVAILABLE.value()))
+                    .andExpect(jsonPath("$.data.code").value("IAMPORT_API_UNAVAILABLE"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value("결제 대행 시스템(Iamport)과의 통신에 실패했습니다. 잠시 후 다시 시도해주세요."));
+        }
+    }
+
+    @Nested
+    class 결제_취소_요청_시 {
+
+        @Test
+        void 유효한_요청이면_결제를_취소하고_NO_CONTENT_로_반환한다() throws Exception {
+            // given
+            willDoNothing().given(paymentService).cancelPayment("imp_1234");
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/payments/cancel/imp_9999"));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void impUid가_아임포트에_존재하지_않으면_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND))
+                    .given(paymentService)
+                    .cancelPayment("imp_9999");
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/payments/cancel/imp_9999"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("PAYMENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("결제 정보가 존재하지 않습니다."));
+        }
+
+        @Test
+        void impUid에_해당하는_결제가_DB에_없으면_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND))
+                    .given(paymentService)
+                    .cancelPayment("imp_9999");
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/payments/cancel/imp_9999"));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.data.code").value("PAYMENT_NOT_FOUND"))
+                    .andExpect(jsonPath("$.data.message").value("결제 정보가 존재하지 않습니다."));
+        }
+
+        @Test
+        void 이미_취소된_결제라면_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(PaymentDomainErrorCode.ALREADY_CANCELED))
+                    .given(paymentService)
+                    .cancelPayment("imp_9999");
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/payments/cancel/imp_9999"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_CANCELED"))
+                    .andExpect(jsonPath("$.data.message").value("해당 결제는 이미 취소되었습니다."));
+        }
+
+        @Test
+        void 완료되지_않은_결제라면_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(PaymentDomainErrorCode.ONLY_PAID_PAYMENT_CANCELABLE))
+                    .given(paymentService)
+                    .cancelPayment("imp_9999");
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/payments/cancel/imp_9999"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ONLY_PAID_PAYMENT_CANCELABLE"))
+                    .andExpect(jsonPath("$.data.message").value("결제 취소는 완료된 결제만 가능합니다."));
+        }
+
+        @Test
+        void Iamport_API_통신_장애가_발생하면_예외가_발생한다() throws Exception {
+            // given
+            willThrow(new CustomException(PaymentErrorCode.IAMPORT_API_UNAVAILABLE))
+                    .given(paymentService)
+                    .cancelPayment("imp_9999");
+
+            // when & then
+            ResultActions perform = mockMvc.perform(post("/payments/cancel/imp_9999"));
 
             perform.andExpect(status().isServiceUnavailable())
                     .andExpect(jsonPath("$.success").value(false))

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -332,8 +332,7 @@ public class PaymentServiceTest extends IntegrationTest {
             Payment payment =
                     Payment.createPayment(
                             member, "testMerchantUid", 5900, PaymentPurpose.RENEWAL, AlbumType.PRO);
-            payment.updatePayment(
-                    "testImpUid", "kakaopay", PaymentStatus.PAID, LocalDateTime.now());
+            payment.complete("testImpUid", "kakaopay", LocalDateTime.now());
             paymentRepository.save(payment);
 
             PaymentReadyRequest request = new PaymentReadyRequest(AlbumType.PRO, null);
@@ -501,11 +500,7 @@ public class PaymentServiceTest extends IntegrationTest {
                             5900,
                             PaymentPurpose.CREATION,
                             AlbumType.PRO);
-            payment.updatePayment(
-                    "testImpUid",
-                    "kakaopay",
-                    PaymentStatus.PAID,
-                    LocalDateTime.of(2025, 8, 31, 20, 0));
+            payment.complete("testImpUid", "kakaopay", LocalDateTime.of(2025, 8, 31, 20, 0));
             paymentRepository.save(payment);
 
             PaymentUnlinkedResponse response = paymentService.getUnlinkedPayment();
@@ -578,11 +573,7 @@ public class PaymentServiceTest extends IntegrationTest {
                             5900,
                             PaymentPurpose.CREATION,
                             AlbumType.PRO);
-            payment1.updatePayment(
-                    "testImpUid1",
-                    "kakaopay",
-                    PaymentStatus.PAID,
-                    LocalDateTime.of(2025, 8, 1, 20, 0));
+            payment1.complete("testImpUid1", "kakaopay", LocalDateTime.of(2025, 8, 1, 20, 0));
             payment1.updatePayment(PaymentPurpose.CREATION, album1);
             Payment payment2 =
                     Payment.createPayment(
@@ -591,11 +582,7 @@ public class PaymentServiceTest extends IntegrationTest {
                             12900,
                             PaymentPurpose.RENEWAL,
                             AlbumType.PRO);
-            payment2.updatePayment(
-                    "testImpUid2",
-                    "kakaopay",
-                    PaymentStatus.PAID,
-                    LocalDateTime.of(2025, 9, 1, 20, 0));
+            payment2.complete("testImpUid2", "kakaopay", LocalDateTime.of(2025, 9, 1, 20, 0));
             payment2.updatePayment(PaymentPurpose.RENEWAL, album1);
             paymentRepository.saveAll(List.of(payment1, payment2));
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import okhttp3.MediaType;
@@ -41,6 +42,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.payment.exception.PaymentDomainErrorCode;
 import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.Assertions;
@@ -464,6 +466,160 @@ public class PaymentServiceTest extends IntegrationTest {
             given(iamportPayment.getPgProvider()).willReturn("kakaopay");
             given(iamportPayment.getAmount()).willReturn(amount);
             given(iamportPayment.getStatus()).willReturn(status);
+            given(iamportPayment.getPaidAt())
+                    .willReturn(
+                            Date.from(
+                                    LocalDateTime.of(2025, 8, 1, 13, 0)
+                                            .atZone(ZoneId.systemDefault())
+                                            .toInstant()));
+        }
+    }
+
+    @Nested
+    class 결제를_취소할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname",
+                            "testProfileImageUrl");
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+
+            // 완료된 결제
+            Payment payment1 =
+                    Payment.createPayment(
+                            member,
+                            "testMerchantUid",
+                            5900,
+                            PaymentPurpose.CREATION,
+                            AlbumType.PRO);
+            payment1.complete("imp_1234", "kakaopay", LocalDateTime.of(2025, 8, 1, 13, 0));
+            // 취소된 결제
+            Payment payment2 =
+                    Payment.createPayment(
+                            member,
+                            "testMerchantUid",
+                            5900,
+                            PaymentPurpose.CREATION,
+                            AlbumType.PRO);
+            payment2.complete("imp_4321", "kakaopay", LocalDateTime.of(2025, 8, 1, 13, 0));
+            payment2.cancel(LocalDateTime.now());
+            // 완료되지 않은 결제
+            Payment payment3 =
+                    Payment.createPayment(
+                            member,
+                            "testMerchantUid",
+                            5900,
+                            PaymentPurpose.CREATION,
+                            AlbumType.PRO);
+            ReflectionTestUtils.setField(payment3, "impUid", "imp_5555");
+            ReflectionTestUtils.setField(payment3, "status", PaymentStatus.READY);
+            paymentRepository.saveAll(List.of(payment1, payment2, payment3));
+        }
+
+        @Test
+        void 유효한_요청이면_결제를_취소한다() throws IamportResponseException, IOException {
+            // given
+            stubIamportPayment();
+
+            // when
+            paymentService.cancelPayment("imp_1234");
+
+            // then
+            Payment payment = paymentRepository.findById(1L).orElseThrow();
+            Assertions.assertAll(
+                    () ->
+                            assertThat(payment)
+                                    .extracting("id", "impUid", "amount", "status", "paidAt")
+                                    .containsExactly(
+                                            1L,
+                                            "imp_1234",
+                                            5900,
+                                            PaymentStatus.CANCELED,
+                                            LocalDateTime.of(2025, 8, 1, 13, 0)),
+                    () ->
+                            assertThat(payment.getCanceledAt().truncatedTo(ChronoUnit.MINUTES))
+                                    .isEqualTo(
+                                            LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)));
+        }
+
+        @Test
+        void impUid가_아임포트에_존재하지_않으면_예외가_발생한다() throws IamportResponseException, IOException {
+            // given
+            HttpException httpException =
+                    new HttpException(
+                            Response.error(
+                                    404,
+                                    ResponseBody.create(
+                                            MediaType.parse("application/json"),
+                                            "{\"message\":\"not found\"}")));
+
+            given(iamportClient.paymentByImpUid("imp_9999"))
+                    .willThrow(new IamportResponseException("not found", httpException));
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.cancelPayment("imp_9999"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.PAYMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void impUid에_해당하는_결제가_DB에_없으면_예외가_발생한다() throws IamportResponseException, IOException {
+            // given
+            stubIamportPayment();
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.cancelPayment("imp_9999"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.PAYMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 이미_취소된_결제라면_예외가_발생한다() throws IamportResponseException, IOException {
+            // given
+            stubIamportPayment();
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.cancelPayment("imp_4321"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentDomainErrorCode.ALREADY_CANCELED.getMessage());
+        }
+
+        @Test
+        void 완료되지_않은_결제라면_예외가_발생한다() throws IamportResponseException, IOException {
+            // given
+            stubIamportPayment();
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.cancelPayment("imp_5555"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentDomainErrorCode.ONLY_PAID_PAYMENT_CANCELABLE.getMessage());
+        }
+
+        @Test
+        void Iamport_API_통신_장애가_발생하면_예외가_발생한다() throws IamportResponseException, IOException {
+            // given
+            given(iamportClient.paymentByImpUid("imp_1234"))
+                    .willThrow(new IOException("network error"));
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.verifyPayment("imp_1234"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.IAMPORT_API_UNAVAILABLE.getMessage());
+        }
+
+        private void stubIamportPayment() throws IOException, IamportResponseException {
+            given(iamportClient.paymentByImpUid(anyString())).willReturn(iamportResponse);
+            given(iamportResponse.getResponse()).willReturn(iamportPayment);
+
+            given(iamportPayment.getImpUid()).willReturn("imp_1234");
+            given(iamportPayment.getMerchantUid()).willReturn("testMerchantUid");
+            given(iamportPayment.getPgProvider()).willReturn("kakaopay");
+            given(iamportPayment.getAmount()).willReturn(BigDecimal.valueOf(5900));
+            given(iamportPayment.getStatus()).willReturn("PAID");
             given(iamportPayment.getPaidAt())
                     .willReturn(
                             Date.from(

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/service/PaymentServiceTest.java
@@ -574,7 +574,7 @@ public class PaymentServiceTest extends IntegrationTest {
                             PaymentPurpose.CREATION,
                             AlbumType.PRO);
             payment1.complete("testImpUid1", "kakaopay", LocalDateTime.of(2025, 8, 1, 20, 0));
-            payment1.updatePayment(PaymentPurpose.CREATION, album1);
+            payment1.assignToAlbum(PaymentPurpose.CREATION, album1);
             Payment payment2 =
                     Payment.createPayment(
                             member1,
@@ -583,7 +583,7 @@ public class PaymentServiceTest extends IntegrationTest {
                             PaymentPurpose.RENEWAL,
                             AlbumType.PRO);
             payment2.complete("testImpUid2", "kakaopay", LocalDateTime.of(2025, 9, 1, 20, 0));
-            payment2.updatePayment(PaymentPurpose.RENEWAL, album1);
+            payment2.assignToAlbum(PaymentPurpose.RENEWAL, album1);
             paymentRepository.saveAll(List.of(payment1, payment2));
         }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/controller/SubscriptionControllerTest.java
@@ -372,7 +372,29 @@ class SubscriptionControllerTest {
         }
 
         @Test
-        void 결제상태가_PAID가_아니면_예외가_발생한다() throws Exception {
+        void 이미_취소된_결제라면_예외가_발생한다() throws Exception {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
+
+            given(subscriptionService.renewSubscription(1L, request))
+                    .willThrow(new CustomException(PaymentDomainErrorCode.ALREADY_CANCELED));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/albums/1/subscriptions/renew")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("ALREADY_CANCELED"))
+                    .andExpect(jsonPath("$.data.message").value("해당 결제는 이미 취소되었습니다."));
+        }
+
+        @Test
+        void 완료되지_않은_결제라면_예외가_발생한다() throws Exception {
             // given
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -305,7 +305,19 @@ class SubscriptionServiceTest extends IntegrationTest {
                             AlbumType.PREMIUM);
             payment5.complete("testImpUid", "testPgProvider", LocalDateTime.now());
 
-            paymentRepository.saveAll(List.of(payment1, payment2, payment3, payment4, payment5));
+            // 취소된 결제
+            Payment payment6 =
+                    Payment.createPayment(
+                            member1,
+                            "testMerchantUid",
+                            5900,
+                            PaymentPurpose.RENEWAL,
+                            AlbumType.PRO);
+            payment6.complete("testImpUid", "testPgProvider", LocalDateTime.now());
+            payment6.cancel(LocalDateTime.now());
+
+            paymentRepository.saveAll(
+                    List.of(payment1, payment2, payment3, payment4, payment5, payment6));
         }
 
         @Test
@@ -432,7 +444,18 @@ class SubscriptionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 결제상태가_PAID가_아니면_예외가_발생한다() {
+        void 이미_취소된_결제라면_예외가_발생한다() {
+            // given
+            SubscriptionRenewRequest request = new SubscriptionRenewRequest(6L);
+
+            // when & then
+            assertThatThrownBy(() -> subscriptionService.renewSubscription(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentDomainErrorCode.ALREADY_CANCELED.getMessage());
+        }
+
+        @Test
+        void 완료되지_않은_결제라면_예외가_발생한다() {
             // given
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(3L);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -293,7 +293,7 @@ class SubscriptionServiceTest extends IntegrationTest {
                             PaymentPurpose.CREATION,
                             AlbumType.PRO);
             payment4.complete("testImpUid", "testPgProvider", LocalDateTime.now());
-            payment4.updatePayment(PaymentPurpose.CREATION, album1);
+            payment4.assignToAlbum(PaymentPurpose.CREATION, album1);
 
             // 구독 업그레이드 목적으로 쓰인 결제
             Payment payment5 =

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -263,11 +263,7 @@ class SubscriptionServiceTest extends IntegrationTest {
                             5900,
                             PaymentPurpose.RENEWAL,
                             AlbumType.PRO);
-            payment1.updatePayment(
-                    "testImpUid",
-                    "testPgProvider",
-                    PaymentStatus.PAID,
-                    LocalDateTime.now().minusDays(15));
+            payment1.complete("testImpUid", "testPgProvider", LocalDateTime.now().minusDays(15));
 
             // 완료된 다른 회원의 결제
             Payment payment2 =
@@ -277,8 +273,7 @@ class SubscriptionServiceTest extends IntegrationTest {
                             5900,
                             PaymentPurpose.RENEWAL,
                             AlbumType.PRO);
-            payment2.updatePayment(
-                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+            payment2.complete("testImpUid", "testPgProvider", LocalDateTime.now());
 
             // 완료되지 않은 결제
             Payment payment3 =
@@ -297,8 +292,7 @@ class SubscriptionServiceTest extends IntegrationTest {
                             5900,
                             PaymentPurpose.CREATION,
                             AlbumType.PRO);
-            payment4.updatePayment(
-                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+            payment4.complete("testImpUid", "testPgProvider", LocalDateTime.now());
             payment4.updatePayment(PaymentPurpose.CREATION, album1);
 
             // 구독 업그레이드 목적으로 쓰인 결제
@@ -309,8 +303,7 @@ class SubscriptionServiceTest extends IntegrationTest {
                             12900,
                             PaymentPurpose.UPGRADE,
                             AlbumType.PREMIUM);
-            payment5.updatePayment(
-                    "testImpUid", "testPgProvider", PaymentStatus.PAID, LocalDateTime.now());
+            payment5.complete("testImpUid", "testPgProvider", LocalDateTime.now());
 
             paymentRepository.saveAll(List.of(payment1, payment2, payment3, payment4, payment5));
         }

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -89,11 +89,10 @@ public class Payment extends BaseTimeEntity {
                 .build();
     }
 
-    public void updatePayment(
-            String impUid, String pgProvider, PaymentStatus status, LocalDateTime paidAt) {
+    public void complete(String impUid, String pgProvider, LocalDateTime paidAt) {
         this.impUid = impUid;
         this.pgProvider = pgProvider;
-        this.status = status;
+        this.status = PaymentStatus.PAID;
         this.paidAt = paidAt;
     }
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -109,6 +109,9 @@ public class Payment extends BaseTimeEntity {
     }
 
     public void assignToAlbum(PaymentPurpose purpose, Album album) {
+        if (this.status == PaymentStatus.CANCELED) {
+            throw new CustomException(PaymentDomainErrorCode.ALREADY_CANCELED);
+        }
         if (this.status != PaymentStatus.PAID) {
             throw new CustomException(PaymentDomainErrorCode.NOT_PAID);
         }

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -96,7 +96,7 @@ public class Payment extends BaseTimeEntity {
         this.paidAt = paidAt;
     }
 
-    public void updatePayment(PaymentPurpose purpose, Album album) {
+    public void assignToAlbum(PaymentPurpose purpose, Album album) {
         if (this.status != PaymentStatus.PAID) {
             throw new CustomException(PaymentDomainErrorCode.NOT_PAID);
         }

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -96,6 +96,18 @@ public class Payment extends BaseTimeEntity {
         this.paidAt = paidAt;
     }
 
+    public void cancel(LocalDateTime canceledAt) {
+        if (this.status == PaymentStatus.CANCELED) {
+            throw new CustomException(PaymentDomainErrorCode.ALREADY_CANCELED);
+        }
+        if (this.status != PaymentStatus.PAID) {
+            throw new CustomException(PaymentDomainErrorCode.ONLY_PAID_PAYMENT_CANCELABLE);
+        }
+
+        this.status = PaymentStatus.CANCELED;
+        this.canceledAt = canceledAt;
+    }
+
     public void assignToAlbum(PaymentPurpose purpose, Album album) {
         if (this.status != PaymentStatus.PAID) {
             throw new CustomException(PaymentDomainErrorCode.NOT_PAID);

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/entity/Payment.java
@@ -55,6 +55,8 @@ public class Payment extends BaseTimeEntity {
 
     private LocalDateTime paidAt;
 
+    private LocalDateTime canceledAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Payment(
             Member member,

--- a/cherrypic-domain/src/main/java/org/cherrypic/payment/exception/PaymentDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/payment/exception/PaymentDomainErrorCode.java
@@ -9,6 +9,8 @@ import org.cherrypic.exception.BaseErrorCode;
 public enum PaymentDomainErrorCode implements BaseErrorCode {
     NOT_PAID(400, "아직 결제가 완료되지 않았습니다."),
     ALREADY_USED_PAYMENT(400, "해당 결제는 이미 사용되었습니다."),
+    ALREADY_CANCELED(400, "해당 결제는 이미 취소되었습니다."),
+    ONLY_PAID_PAYMENT_CANCELABLE(400, "결제 취소는 완료된 결제만 가능합니다."),
     PAYMENT_PURPOSE_MISMATCH(400, "결제 목적이 요청하려는 작업과 일치하지 않습니다."),
     ;
 

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -36,6 +36,7 @@ CREATE TABLE payment (
                          purpose VARCHAR(20) NOT NULL CHECK (purpose IN ('CREATION','RENEWAL','UPGRADE')),
                          album_type VARCHAR(20) CHECK (album_type IN ('BASIC','PRO','PREMIUM')),
                          paid_at DATETIME,
+                         canceled_at DATETIME,
                          created_at DATETIME(6) NOT NULL,
                          updated_at DATETIME(6) NOT NULL,
                          CONSTRAINT fk_payment_member FOREIGN KEY (member_id) REFERENCES member (id),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #211 

---
## 📌 작업 내용 및 특이사항
* 결제 취소 및 환불 처리를 위한 API를 구현했습니다.
* 결제 취소 시각을 저장하는 필드를 Payment 도메인에 추가했습니다.
* 유료 서비스 정책에 따라, 사용자가 콘텐츠를 이용하지 않은 경우 일정 기간 내 환불이 가능해야 하므로 해당 기능을 제공하게 되었습니다.
* 정확한 환불 정책 기준은 추후 PM으로부터 전달받는 대로 다음 작업에서 반영할 예정입니다.
* 또한, 유료 앨범 최초 생성 및 구독 갱신 시 취소된 결제를 사용할 수 없도록 예외 처리 로직을 추가했습니다.

---
## 📚 참고사항
* 기존 updatePayment() 도메인 메서드를 complete()와 assignToAlbum()으로 리네이밍하였습니다.
* 결제 후 10분 이내에 앨범이 생성되지 않으면 자동으로 결제를 취소하고 환불하는 로직은 별도 PR에서 구현할 예정입니다.
