### PR TITLE
feat: 로컬 이미지 삭제 토글 기능 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -16,6 +16,7 @@ import org.cherrypic.domain.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.image.event.ImagesDeleteEvent;
+import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
@@ -51,6 +52,7 @@ public class AlbumServiceImpl implements AlbumService {
     private final SubscriptionRepository subscriptionRepository;
     private final InvitationCodeRepository invitationCodeRepository;
     private final EventRepository eventRepository;
+    private final ImageRepository imageRepository;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -222,7 +224,10 @@ public class AlbumServiceImpl implements AlbumService {
         eventPublisher.publishEvent(
                 ImagesDeleteEvent.of(events.stream().map(Event::getCoverUrl).toList()));
 
-        eventPublisher.publishEvent(AlbumImagesDeleteEvent.of(album.getId()));
+        if (imageRepository.existsByAlbumId(album.getId())) {
+            eventPublisher.publishEvent(AlbumImagesDeleteEvent.of(album.getId()));
+        }
+
         if (album.getCoverUrl() != null) {
             eventPublisher.publishEvent(ImageDeleteEvent.of(album.getCoverUrl()));
         }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/ImageUploadListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/ImageUploadListResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record ImageUploadListResponse(
-        @Schema(description = "로컬 사진 삭제 여부") Boolean localImageDeletion,
+        @Schema(description = "로컬 사진 삭제 허용 여부") Boolean localImageDeletion,
         @Schema(description = "업로드된 이미지들의 정보 리스트") List<Payload> payloads) {
     public static ImageUploadListResponse of(List<Payload> payloads, Boolean localImageDeletion) {
         return new ImageUploadListResponse(localImageDeletion, payloads);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/ImageUploadListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/ImageUploadListResponse.java
@@ -4,9 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record ImageUploadListResponse(
+        @Schema(description = "로컬 사진 삭제 여부") Boolean localImageDeletion,
         @Schema(description = "업로드된 이미지들의 정보 리스트") List<Payload> payloads) {
-    public static ImageUploadListResponse of(List<Payload> payloads) {
-        return new ImageUploadListResponse(payloads);
+    public static ImageUploadListResponse of(List<Payload> payloads, Boolean localImageDeletion) {
+        return new ImageUploadListResponse(localImageDeletion, payloads);
     }
 
     public record Payload(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -9,5 +9,7 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
 
     long countByIdIn(List<Long> ids);
 
+    boolean existsByAlbumId(Long albumId);
+
     long countByIdInAndAlbumId(List<Long> imageIds, Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -171,7 +171,7 @@ public class ImageServiceImpl implements ImageService {
                                                 imageIds.get(i), presignedUrls.get(i)))
                         .toList();
 
-        return ImageUploadListResponse.of(payloads);
+        return ImageUploadListResponse.of(payloads, currentMember.getLocalImageDeletion());
     }
 
     @Override

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController {
     }
 
     @PatchMapping("/me/local-image-deletion")
-    @Operation(summary = "로컬 이미지 삭제 토글 상태 변경", description = "로컬 이미지 삭제 토글 상태를 변경합니다.")
+    @Operation(summary = "로컬 이미지 삭제 권한 변경", description = "로컬 이미지 삭제 권한 허용 여부 상태를 변경합니다.")
     public LocalImageDeletionToggleResponse localImageDeletionToggle() {
         return memberService.toggleLocalImageDeletion();
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
+import org.cherrypic.domain.member.dto.response.LocalImageDeletionToggleResponse;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.dto.response.MemberProfileUpdateResponse;
 import org.cherrypic.domain.member.service.MemberService;
@@ -31,6 +32,12 @@ public class MemberController {
     public MemberProfileUpdateResponse memberProfileUpdate(
             @Valid @RequestBody MemberProfileUpdateRequest request) {
         return memberService.updateProfile(request);
+    }
+
+    @PatchMapping("/me/local-image-deletion")
+    @Operation(summary = "로컬 이미지 삭제 토글 상태 변경", description = "로컬 이미지 삭제 토글 상태를 변경합니다.")
+    public LocalImageDeletionToggleResponse localImageDeletionToggle() {
+        return memberService.toggleLocalImageDeletion();
     }
 
     @PostMapping("/fcm-tokens")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController {
     }
 
     @PatchMapping("/me/local-image-deletion")
-    @Operation(summary = "로컬 이미지 삭제 권한 변경", description = "로컬 이미지 삭제 권한 허용 여부 상태를 변경합니다.")
+    @Operation(summary = "로컬 이미지 삭제 허용 변경", description = "로컬 이미지 삭제 허용 여부를 변경합니다.")
     public LocalImageDeletionToggleResponse localImageDeletionToggle() {
         return memberService.toggleLocalImageDeletion();
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
@@ -1,0 +1,11 @@
+package org.cherrypic.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.cherrypic.member.entity.Member;
+
+public record LocalImageDeletionToggleResponse(
+        @Schema(description = "로컬 이미지 삭제 관련 토글 상태", example = "true") Boolean removeLocalImage) {
+    public static LocalImageDeletionToggleResponse from(Member member) {
+        return new LocalImageDeletionToggleResponse(member.getLocalImageDeletion());
+    }
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.member.entity.Member;
 
 public record LocalImageDeletionToggleResponse(
-        @Schema(description = "로컬 이미지 삭제 관련 토글 상태", example = "true") Boolean removeLocalImage) {
+        @Schema(description = "로컬 이미지 삭제 관련 토글 상태", example = "true") Boolean localImageDeletion) {
     public static LocalImageDeletionToggleResponse from(Member member) {
         return new LocalImageDeletionToggleResponse(member.getLocalImageDeletion());
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.member.entity.Member;
 
 public record LocalImageDeletionToggleResponse(
-        @Schema(description = "로컬 이미지 삭제 권한 허용 여부", example = "true") Boolean localImageDeletion) {
+        @Schema(description = "로컬 이미지 삭제 허용 여부", example = "true") Boolean localImageDeletion) {
     public static LocalImageDeletionToggleResponse from(Member member) {
         return new LocalImageDeletionToggleResponse(member.getLocalImageDeletion());
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/LocalImageDeletionToggleResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.cherrypic.member.entity.Member;
 
 public record LocalImageDeletionToggleResponse(
-        @Schema(description = "로컬 이미지 삭제 관련 토글 상태", example = "true") Boolean localImageDeletion) {
+        @Schema(description = "로컬 이미지 삭제 권한 허용 여부", example = "true") Boolean localImageDeletion) {
     public static LocalImageDeletionToggleResponse from(Member member) {
         return new LocalImageDeletionToggleResponse(member.getLocalImageDeletion());
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/MemberInfoResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/dto/response/MemberInfoResponse.java
@@ -16,7 +16,8 @@ public record MemberInfoResponse(
                                 "http://k.kakaocdn.net/dn/ceTrU6/btsL0V0mhKO/DGqAZKAK/img_110x110.jpg")
                 String profileImageUrl,
         @Schema(description = "회원 상태", example = "NORMAL") MemberStatus status,
-        @Schema(description = "회원 역할", example = "ROLE_USER") MemberRole role) {
+        @Schema(description = "회원 역할", example = "ROLE_USER") MemberRole role,
+        @Schema(description = "회원 로컬 사진 삭제 동의", example = "true") Boolean localImageDeletion) {
     public static MemberInfoResponse from(Member member) {
         return new MemberInfoResponse(
                 member.getId(),
@@ -24,6 +25,7 @@ public record MemberInfoResponse(
                 member.getNickname(),
                 member.getProfileImageUrl(),
                 member.getStatus(),
-                member.getRole());
+                member.getRole(),
+                member.getLocalImageDeletion());
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package org.cherrypic.domain.member.service;
 
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
+import org.cherrypic.domain.member.dto.response.LocalImageDeletionToggleResponse;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.dto.response.MemberProfileUpdateResponse;
 
@@ -11,4 +12,6 @@ public interface MemberService {
     MemberProfileUpdateResponse updateProfile(MemberProfileUpdateRequest request);
 
     void saveFcmToken(FcmTokenSaveRequest request);
+
+    LocalImageDeletionToggleResponse toggleLocalImageDeletion();
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -53,7 +53,6 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public LocalImageDeletionToggleResponse toggleLocalImageDeletion() {
         final Member currentMember = memberUtil.getCurrentMember();
         currentMember.toggleLocalImageDeletion();

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/member/service/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
+import org.cherrypic.domain.member.dto.response.LocalImageDeletionToggleResponse;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.dto.response.MemberProfileUpdateResponse;
 import org.cherrypic.domain.notification.service.FcmTokenService;
@@ -49,5 +50,13 @@ public class MemberServiceImpl implements MemberService {
     public void saveFcmToken(FcmTokenSaveRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         fcmTokenService.saveFcmToken(currentMember.getId(), request.fcmToken());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LocalImageDeletionToggleResponse toggleLocalImageDeletion() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        currentMember.toggleLocalImageDeletion();
+        return LocalImageDeletionToggleResponse.from(currentMember);
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -355,6 +355,7 @@ class ImageControllerTest {
 
             ImageUploadListResponse response =
                     new ImageUploadListResponse(
+                            false,
                             List.of(
                                     new ImageUploadListResponse.Payload(1L, "testPresignedUrl1"),
                                     new ImageUploadListResponse.Payload(2L, "testPresignedUrl2")));

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -372,7 +372,8 @@ class ImageControllerTest {
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                    .andExpect(jsonPath("$.data.payloads").isNotEmpty());
+                    .andExpect(jsonPath("$.data.payloads").isNotEmpty())
+                    .andExpect(jsonPath("$.data.localImageDeletion").value(false));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -359,6 +359,7 @@ class ImageServiceTest extends IntegrationTest {
                                         .containsPattern(
                                                 ".*/local/album-image/1/[\\w\\-]+\\.(jpg|jpeg)\\?.+");
                             });
+            assertThat(response.localImageDeletion()).isFalse();
 
             List<Image> images = imageRepository.findAll();
             assertThat(images)

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -51,7 +51,8 @@ class MemberControllerTest {
                             "testNickname",
                             "testProfileImageUrl",
                             MemberStatus.NORMAL,
-                            MemberRole.USER);
+                            MemberRole.USER,
+                            false);
 
             given(memberService.getMemberInfo()).willReturn(response);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cherrypic.domain.member.controller.MemberController;
 import org.cherrypic.domain.member.dto.request.FcmTokenSaveRequest;
 import org.cherrypic.domain.member.dto.request.MemberProfileUpdateRequest;
+import org.cherrypic.domain.member.dto.response.LocalImageDeletionToggleResponse;
 import org.cherrypic.domain.member.dto.response.MemberInfoResponse;
 import org.cherrypic.domain.member.dto.response.MemberProfileUpdateResponse;
 import org.cherrypic.domain.member.service.MemberService;
@@ -67,7 +68,8 @@ class MemberControllerTest {
                     .andExpect(jsonPath("$.data.nickname").value("testNickname"))
                     .andExpect(jsonPath("$.data.profileImageUrl").value("testProfileImageUrl"))
                     .andExpect(jsonPath("$.data.status").value("NORMAL"))
-                    .andExpect(jsonPath("$.data.role").value("USER"));
+                    .andExpect(jsonPath("$.data.role").value("USER"))
+                    .andExpect(jsonPath("$.data.localImageDeletion").value(false));
         }
     }
 
@@ -201,6 +203,29 @@ class MemberControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
                     .andExpect(jsonPath("$.data.message").value("FCM Token은 비워둘 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 로컬_사진_삭제_토글을_변경_요청_시 {
+
+        @Test
+        void 유요한_요청이면_토글_상태를_변경한다() throws Exception {
+            // given
+            LocalImageDeletionToggleResponse response = new LocalImageDeletionToggleResponse(true);
+
+            given(memberService.toggleLocalImageDeletion()).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/members/me/local-image-deletion")
+                                    .contentType(MediaType.APPLICATION_JSON));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.localImageDeletion").value(true));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -207,10 +207,10 @@ class MemberControllerTest {
     }
 
     @Nested
-    class 로컬_사진_삭제_권한_변경_요청_시 {
+    class 로컬_사진_삭제_허용_여부_변경_요청_시 {
 
         @Test
-        void 유효한_요청이면_로컬_이미지_삭제_권한을_변경한다() throws Exception {
+        void 유효한_요청이면_로컬_이미지_삭제_허용_여부를_변경한다() throws Exception {
             // given
             LocalImageDeletionToggleResponse response = new LocalImageDeletionToggleResponse(true);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -207,7 +207,7 @@ class MemberControllerTest {
     }
 
     @Nested
-    class 로컬_사진_삭제_허용_여부_변경_요청_시 {
+    class 로컬_이미지_삭제_허용_여부_변경_요청_시 {
 
         @Test
         void 유효한_요청이면_로컬_이미지_삭제_허용_여부를_변경한다() throws Exception {

--- a/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/controller/MemberControllerTest.java
@@ -207,10 +207,10 @@ class MemberControllerTest {
     }
 
     @Nested
-    class 로컬_사진_삭제_토글을_변경_요청_시 {
+    class 로컬_사진_삭제_권한_변경_요청_시 {
 
         @Test
-        void 유요한_요청이면_토글_상태를_변경한다() throws Exception {
+        void 유효한_요청이면_로컬_이미지_삭제_권한을_변경한다() throws Exception {
             // given
             LocalImageDeletionToggleResponse response = new LocalImageDeletionToggleResponse(true);
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -159,10 +159,10 @@ class MemberServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 로컬_사진_삭제_토글을_변경할_때 {
+    class 로컬_사진_삭제_권한_변경을_요청할_때 {
 
         @Test
-        void 유효한_요청이면_토글을_변경한다() {
+        void 유효한_요청이면_로컬_이미지_삭제_권한을_변경한다() {
             // when
             memberService.toggleLocalImageDeletion();
 

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -159,7 +159,7 @@ class MemberServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 로컬_사진_삭제_허용_여부_변경을_요청할_때 {
+    class 로컬_이미지_삭제_허용_여부를_변경할_때 {
 
         @Test
         void 유효한_요청이면_로컬_이미지_삭제_허용_여부를_변경한다() {

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -73,14 +73,16 @@ class MemberServiceTest extends IntegrationTest {
                             "nickname",
                             "profileImageUrl",
                             "role",
-                            "status")
+                            "status",
+                            "localImageDeletion")
                     .containsExactly(
                             1L,
                             "testOauthProvider",
                             "testNickname",
                             "testProfileImageUrl",
                             MemberRole.USER,
-                            MemberStatus.NORMAL);
+                            MemberStatus.NORMAL,
+                            false);
         }
     }
 
@@ -153,6 +155,20 @@ class MemberServiceTest extends IntegrationTest {
             assertThat(redisTemplate.opsForSet().members("fcmToken:1"))
                     .contains("testFcmToken1", "testFcmToken2");
             assertThat(redisTemplate.opsForSet().size(("fcmToken:1"))).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class 로컬_사진_삭제_토글을_변경할_때 {
+
+        @Test
+        void 유효한_요청이면_토글을_변경한다() {
+            // when
+            memberService.toggleLocalImageDeletion();
+
+            // then
+            Member member = memberRepository.findById(1L).orElseThrow();
+            assertThat(member.getLocalImageDeletion()).isTrue();
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/member/service/MemberServiceTest.java
@@ -159,10 +159,10 @@ class MemberServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 로컬_사진_삭제_권한_변경을_요청할_때 {
+    class 로컬_사진_삭제_허용_여부_변경을_요청할_때 {
 
         @Test
-        void 유효한_요청이면_로컬_이미지_삭제_권한을_변경한다() {
+        void 유효한_요청이면_로컬_이미지_삭제_허용_여부를_변경한다() {
             // when
             memberService.toggleLocalImageDeletion();
 

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -38,6 +38,8 @@ public class Member extends BaseTimeEntity {
 
     @NotNull private Boolean appAlarm = Boolean.FALSE;
 
+    @NotNull private Boolean localImageDeletion = Boolean.FALSE;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
 
@@ -78,5 +80,9 @@ public class Member extends BaseTimeEntity {
     public void updateMember(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void toggleLocalImageDeletion() {
+        this.localImageDeletion = !this.localImageDeletion;
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/member/entity/Member.java
@@ -38,7 +38,7 @@ public class Member extends BaseTimeEntity {
 
     @NotNull private Boolean appAlarm = Boolean.FALSE;
 
-    @NotNull private Boolean localImageDeletion = Boolean.FALSE;
+    @NotNull private Boolean localImageDeletion;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
@@ -58,12 +58,14 @@ public class Member extends BaseTimeEntity {
             String nickname,
             String profileImageUrl,
             MemberRole role,
-            MemberStatus status) {
+            MemberStatus status,
+            Boolean localImageDeletion) {
         this.oauthInfo = oauthInfo;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
         this.role = role;
         this.status = status;
+        this.localImageDeletion = localImageDeletion;
     }
 
     public static Member createMember(
@@ -74,6 +76,7 @@ public class Member extends BaseTimeEntity {
                 .profileImageUrl(profileImageUrl)
                 .role(MemberRole.USER)
                 .status(MemberStatus.NORMAL)
+                .localImageDeletion(Boolean.FALSE)
                 .build();
     }
 
@@ -83,6 +86,6 @@ public class Member extends BaseTimeEntity {
     }
 
     public void toggleLocalImageDeletion() {
-        this.localImageDeletion = !this.localImageDeletion;
+        localImageDeletion = !localImageDeletion;
     }
 }

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -7,6 +7,7 @@ CREATE TABLE member (
                         role VARCHAR(255)  NOT NULL CHECK(role IN ('ADMIN','USER')),
                         status VARCHAR(255) NOT NULL CHECK(status IN ('NORMAL','DELETED','FORBIDDEN')),
                         app_alarm BOOLEAN NOT NULL,
+                        local_image_deletion BOOLEAN NOT NULL,
                         created_at DATETIME(6) NOT NULL,
                         updated_at DATETIME(6) NOT NULL
 );


### PR DESCRIPTION
## 🌱 관련 이슈
- close #214 

---
## 📌 작업 내용 및 특이사항
- 로컬 이미지 삭제 토글 기능을 구현했습니다.
- 회원 정보에서 보여지며, 앨범에 파일을 업로드 하는 경우에만 해당 정보를 반환하도록 했습니다.