### PR TITLE
refactor: 불필요한 양방향 연관관계 제거 및 단방향 설계로의 구조 개선

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
@@ -6,10 +6,9 @@ import org.cherrypic.album.entity.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select a from Album a where a.id = :albumId")
-    Optional<Album> findByIdWithPessimisticLock(@Param("albumId") Long albumId);
+    Optional<Album> findByIdWithPessimisticLock(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepository.java
@@ -5,10 +5,15 @@ import java.util.Optional;
 import org.cherrypic.album.entity.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface AlbumRepository extends JpaRepository<Album, Long>, AlbumRepositoryCustom {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select a from Album a where a.id = :albumId")
     Optional<Album> findByIdWithPessimisticLock(Long albumId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Album a where a.id = :albumId")
+    void deleteByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -43,8 +43,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                                 favorites.marked)
                         .from(participant)
                         .join(participant.album, album)
-                        .leftJoin(favorites)
-                        .on(favorites.participant.id.eq(participant.id))
+                        .join(favorites.participant, participant)
                         .where(
                                 participant.member.id.eq(memberId),
                                 type != null ? album.type.eq(type) : null,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -40,9 +40,11 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                                 album.coverUrl,
                                 album.type,
                                 album.createdAt,
-                                participant.favorites.marked)
+                                favorites.marked)
                         .from(participant)
                         .join(participant.album, album)
+                        .leftJoin(favorites)
+                        .on(favorites.participant.id.eq(participant.id))
                         .where(
                                 participant.member.id.eq(memberId),
                                 type != null ? album.type.eq(type) : null,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -43,7 +43,8 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                                 favorites.marked)
                         .from(participant)
                         .join(participant.album, album)
-                        .join(favorites.participant, participant)
+                        .leftJoin(favorites)
+                        .on(favorites.participant.eq(participant))
                         .where(
                                 participant.member.id.eq(memberId),
                                 type != null ? album.type.eq(type) : null,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -18,6 +18,7 @@ import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.favorites.repository.FavoritesRepository;
 import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.image.event.ImagesDeleteEvent;
+import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
@@ -60,6 +61,7 @@ public class AlbumServiceImpl implements AlbumService {
     private final InvitationCodeRepository invitationCodeRepository;
     private final EventRepository eventRepository;
     private final ImageRepository imageRepository;
+    private final EventImageRepository eventImageRepository;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -245,7 +247,10 @@ public class AlbumServiceImpl implements AlbumService {
 
         final List<Participant> participants = album.getParticipants();
         favoritesRepository.deleteAllByParticipants(participants);
-        participantRepository.deleteAllByAlbumId(albumId);
+        participantRepository.deleteAllByAlbumId(album.getId());
+
+        eventImageRepository.deleteAllByEvents(events);
+        eventRepository.deleteAllByAlbumId(album.getId());
 
         albumRepository.delete(album);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -258,7 +258,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         notificationRepository.deleteAllByAlbumId(album.getId());
 
-        albumRepository.deleteById(album.getId());
+        albumRepository.deleteByAlbumId(album.getId());
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -258,7 +258,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         notificationRepository.deleteAllByAlbumId(album.getId());
 
-        albumRepository.delete(album);
+        albumRepository.deleteById(album.getId());
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -23,6 +23,7 @@ import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.refundtask.repository.RefundTaskRepository;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
@@ -266,6 +267,13 @@ public class AlbumServiceImpl implements AlbumService {
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
     }
 
+    private Subscription getSubscriptionByAlbumId(Long albumId) {
+        return subscriptionRepository
+                .findByAlbumId(albumId)
+                .orElseThrow(
+                        () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
     private Participant getAlbumHostByAlbumId(Long albumId) {
         return participantRepository
                 .findHostByAlbumId(albumId)
@@ -349,7 +357,8 @@ public class AlbumServiceImpl implements AlbumService {
     private void validateSubscriptionInactive(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.ACTIVE) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.ACTIVE) {
             throw new CustomException(AlbumErrorCode.SUBSCRIPTION_ACTIVE);
         }
     }
@@ -357,7 +366,8 @@ public class AlbumServiceImpl implements AlbumService {
     private void validateSubscriptionNotExpired(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
             throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -243,8 +243,8 @@ public class AlbumServiceImpl implements AlbumService {
             eventPublisher.publishEvent(ImageDeleteEvent.of(album.getCoverUrl()));
         }
 
-        List<Long> participantIds = participantRepository.findIdsByAlbumId(albumId);
-        favoritesRepository.deleteByParticipantIdIn(participantIds);
+        final List<Participant> participants = album.getParticipants();
+        favoritesRepository.deleteAllByParticipants(participants);
 
         albumRepository.delete(album);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -20,6 +20,7 @@ import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.image.event.ImagesDeleteEvent;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
+import org.cherrypic.domain.notification.repository.NotificationRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
@@ -62,6 +63,7 @@ public class AlbumServiceImpl implements AlbumService {
     private final EventRepository eventRepository;
     private final ImageRepository imageRepository;
     private final EventImageRepository eventImageRepository;
+    private final NotificationRepository notificationRepository;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -253,6 +255,8 @@ public class AlbumServiceImpl implements AlbumService {
         eventRepository.deleteAllByAlbumId(album.getId());
 
         imageRepository.deleteAllByAlbumId(album.getId());
+
+        notificationRepository.deleteAllByAlbumId(album.getId());
 
         albumRepository.delete(album);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -242,6 +242,9 @@ public class AlbumServiceImpl implements AlbumService {
             eventPublisher.publishEvent(ImageDeleteEvent.of(album.getCoverUrl()));
         }
 
+        List<Long> participantIds = participantRepository.findIdsByAlbumId(albumId);
+        favoritesRepository.deleteByParticipantIdIn(participantIds);
+
         albumRepository.delete(album);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -249,10 +249,10 @@ public class AlbumServiceImpl implements AlbumService {
 
         final List<Participant> participants = album.getParticipants();
         favoritesRepository.deleteAllByParticipants(participants);
-        participantRepository.deleteAllByAlbumId(album.getId());
+        participantRepository.deleteAllInBatch(participants);
 
         eventImageRepository.deleteAllByEvents(events);
-        eventRepository.deleteAllByAlbumId(album.getId());
+        eventRepository.deleteAllInBatch(events);
 
         imageRepository.deleteAllByAlbumId(album.getId());
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -252,6 +252,8 @@ public class AlbumServiceImpl implements AlbumService {
         eventImageRepository.deleteAllByEvents(events);
         eventRepository.deleteAllByAlbumId(album.getId());
 
+        imageRepository.deleteAllByAlbumId(album.getId());
+
         albumRepository.delete(album);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -245,6 +245,7 @@ public class AlbumServiceImpl implements AlbumService {
 
         final List<Participant> participants = album.getParticipants();
         favoritesRepository.deleteAllByParticipants(participants);
+        participantRepository.deleteAllByAlbumId(albumId);
 
         albumRepository.delete(album);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -15,6 +15,7 @@ import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.album.repository.InvitationCodeRepository;
 import org.cherrypic.domain.event.repository.EventRepository;
+import org.cherrypic.domain.favorites.repository.FavoritesRepository;
 import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.image.event.ImagesDeleteEvent;
 import org.cherrypic.domain.image.repository.ImageRepository;
@@ -25,6 +26,7 @@ import org.cherrypic.domain.refundtask.repository.RefundTaskRepository;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
+import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.global.util.MemberUtil;
@@ -52,6 +54,7 @@ public class AlbumServiceImpl implements AlbumService {
     private final PaymentRepository paymentRepository;
     private final RefundTaskRepository refundTaskRepository;
     private final ParticipantRepository participantRepository;
+    private final FavoritesRepository favoritesRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final InvitationCodeRepository invitationCodeRepository;
     private final EventRepository eventRepository;
@@ -76,10 +79,10 @@ public class AlbumServiceImpl implements AlbumService {
 
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.HOST);
-        participant.assignFavorites();
         album.addParticipant(participant);
-
         albumRepository.save(album);
+
+        favoritesRepository.save(Favorites.createFavorites(participant));
 
         if (request.type() != AlbumType.BASIC) {
             final Payment payment = getPaymentByIdWithLock(request.paymentId());
@@ -177,8 +180,9 @@ public class AlbumServiceImpl implements AlbumService {
 
         Participant participant =
                 Participant.createParticipant(currentMember, album, ParticipantRole.STANDARD);
-        participant.assignFavorites();
         participantRepository.save(participant);
+
+        favoritesRepository.save(Favorites.createFavorites(participant));
 
         return AlbumJoinResponse.from(participant);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
@@ -3,10 +3,15 @@ package org.cherrypic.domain.event.repository;
 import java.util.List;
 import org.cherrypic.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
     @Query("select e from Event e where e.album.id = :albumId")
     List<Event> findAllByAlbumId(@Param("albumId") Long albumId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Event e where e.album.id = :albumId")
+    void deleteAllByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
@@ -4,9 +4,8 @@ import java.util.List;
 import org.cherrypic.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
     @Query("select e from Event e where e.album.id = :albumId")
-    List<Event> findAllByAlbumId(@Param("albumId") Long albumId);
+    List<Event> findAllByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
@@ -3,8 +3,10 @@ package org.cherrypic.domain.event.repository;
 import java.util.List;
 import org.cherrypic.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
-
-    List<Event> findAllByAlbumId(Long albumId);
+    @Query("select e from Event e where e.album.id = :albumId")
+    List<Event> findAllByAlbumId(@Param("albumId") Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/repository/EventRepository.java
@@ -3,15 +3,10 @@ package org.cherrypic.domain.event.repository;
 import java.util.List;
 import org.cherrypic.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
     @Query("select e from Event e where e.album.id = :albumId")
     List<Event> findAllByAlbumId(@Param("albumId") Long albumId);
-
-    @Modifying(clearAutomatically = true)
-    @Query("delete from Event e where e.album.id = :albumId")
-    void deleteAllByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/event/service/EventServiceImpl.java
@@ -21,6 +21,8 @@ import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.event.entity.Event;
 import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
@@ -31,6 +33,7 @@ import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -49,6 +52,7 @@ public class EventServiceImpl implements EventService {
 
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
+    private final SubscriptionRepository subscriptionRepository;
     private final EventRepository eventRepository;
     private final ImageRepository imageRepository;
     private final EventImageRepository eventImageRepository;
@@ -191,6 +195,13 @@ public class EventServiceImpl implements EventService {
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
     }
 
+    private Subscription getSubscriptionByAlbumId(Long albumId) {
+        return subscriptionRepository
+                .findByAlbumId(albumId)
+                .orElseThrow(
+                        () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
     private void validateParticipantAuthority(Member member, Album album) {
 
         Participant participant = getParticipantByMemberIdAndAlbumId(member.getId(), album.getId());
@@ -248,7 +259,8 @@ public class EventServiceImpl implements EventService {
     private void validateSubscriptionNotExpired(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
             throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/exception/FavoritesErrorCode.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/exception/FavoritesErrorCode.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.favorites.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cherrypic.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum FavoritesErrorCode implements BaseErrorCode {
+    FAVORITES_NOT_FOUND(404, "참가자에 대한 즐겨찾기 정보가 존재하지 않습니다."),
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.favorites.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.cherrypic.favorites.entity.Favorites;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
     Optional<Favorites> findByParticipantId(Long participantId);
 
     void deleteByParticipantId(Long participantId);
+
+    void deleteByParticipantIdIn(List<Long> participantIds);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
     Optional<Favorites> findByParticipantId(Long participantId);
+
+    void deleteByParticipantId(Long participantId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
@@ -1,6 +1,9 @@
 package org.cherrypic.domain.favorites.repository;
 
+import java.util.Optional;
 import org.cherrypic.favorites.entity.Favorites;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FavoritesRepository extends JpaRepository<Favorites, Long> {}
+public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
+    Optional<Favorites> findByParticipantId(Long participantId);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
     Optional<Favorites> findByParticipantId(Long participantId);
 
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Favorites f where f.participant.id = :participantId")
     void deleteByParticipantId(Long participantId);
 
     @Modifying(clearAutomatically = true)

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/repository/FavoritesRepository.java
@@ -3,12 +3,17 @@ package org.cherrypic.domain.favorites.repository;
 import java.util.List;
 import java.util.Optional;
 import org.cherrypic.favorites.entity.Favorites;
+import org.cherrypic.participant.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
     Optional<Favorites> findByParticipantId(Long participantId);
 
     void deleteByParticipantId(Long participantId);
 
-    void deleteByParticipantIdIn(List<Long> participantIds);
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Favorites f where f.participant in :participants")
+    void deleteAllByParticipants(List<Participant> participants);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/service/FavoritesServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/favorites/service/FavoritesServiceImpl.java
@@ -5,6 +5,8 @@ import org.cherrypic.album.entity.Album;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
 import org.cherrypic.domain.favorites.dto.response.FavoritesMarkToggleResponse;
+import org.cherrypic.domain.favorites.exception.FavoritesErrorCode;
+import org.cherrypic.domain.favorites.repository.FavoritesRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.favorites.entity.Favorites;
@@ -23,6 +25,7 @@ public class FavoritesServiceImpl implements FavoritesService {
 
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
+    private final FavoritesRepository favoritesRepository;
 
     @Override
     public FavoritesMarkToggleResponse toggleMark(Long albumId) {
@@ -30,8 +33,8 @@ public class FavoritesServiceImpl implements FavoritesService {
         final Album album = getAlbumById(albumId);
         final Participant participant =
                 getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
+        final Favorites favorites = getFavoritesByParticipantId(participant.getId());
 
-        Favorites favorites = participant.getFavorites();
         favorites.toggleMarked();
 
         return FavoritesMarkToggleResponse.from(favorites);
@@ -47,5 +50,11 @@ public class FavoritesServiceImpl implements FavoritesService {
         return participantRepository
                 .findByMemberIdAndAlbumId(memberId, albumId)
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
+    }
+
+    private Favorites getFavoritesByParticipantId(Long participantId) {
+        return favoritesRepository
+                .findByParticipantId(participantId)
+                .orElseThrow(() -> new CustomException(FavoritesErrorCode.FAVORITES_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/EventImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/EventImageRepository.java
@@ -1,6 +1,14 @@
 package org.cherrypic.domain.image.repository;
 
+import java.util.List;
+import org.cherrypic.event.entity.Event;
 import org.cherrypic.event.entity.EventImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface EventImageRepository extends JpaRepository<EventImage, Long> {}
+public interface EventImageRepository extends JpaRepository<EventImage, Long> {
+    @Modifying(clearAutomatically = true)
+    @Query("delete from EventImage ei where ei.event in :events")
+    void deleteAllByEvents(List<Event> events);
+}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepository.java
@@ -3,6 +3,8 @@ package org.cherrypic.domain.image.repository;
 import java.util.List;
 import org.cherrypic.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
     List<Image> findAllById(Iterable<Long> imageIds);
@@ -12,4 +14,8 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
     boolean existsByAlbumId(Long albumId);
 
     long countByIdInAndAlbumId(List<Long> imageIds, Long albumId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Image i where i.album.id = :albumId")
+    void deleteAllByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -17,6 +17,8 @@ import org.cherrypic.domain.image.event.ImagesDeleteEvent;
 import org.cherrypic.domain.image.exception.ImageErrorCode;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.domain.tempalbum.event.TempAlbumImagesDeleteEvent;
 import org.cherrypic.domain.tempalbum.exception.TempAlbumErrorCode;
 import org.cherrypic.domain.tempalbum.repository.TempAlbumImageRepository;
@@ -33,6 +35,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.s3.S3Util;
 import org.cherrypic.s3.enums.FileExtension;
 import org.cherrypic.s3.enums.ImageType;
+import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.cherrypic.tempalbum.entity.TempAlbum;
 import org.cherrypic.tempalbum.entity.TempAlbumImage;
@@ -53,6 +56,7 @@ public class ImageServiceImpl implements ImageService {
     private final ImageRepository imageRepository;
     private final EventRepository eventRepository;
     private final ParticipantRepository participantRepository;
+    private final SubscriptionRepository subscriptionRepository;
     private final TempAlbumRepository tempAlbumRepository;
     private final TempAlbumImageRepository tempAlbumImageRepository;
 
@@ -340,6 +344,13 @@ public class ImageServiceImpl implements ImageService {
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
     }
 
+    private Subscription getSubscriptionByAlbumId(Long albumId) {
+        return subscriptionRepository
+                .findByAlbumId(albumId)
+                .orElseThrow(
+                        () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
     private TempAlbum getTempAlbumById(Long tempAlbumId) {
         return tempAlbumRepository
                 .findById(tempAlbumId)
@@ -361,7 +372,6 @@ public class ImageServiceImpl implements ImageService {
     }
 
     private void validateAlbumCapacity(Album album, BigDecimal uploadCapacity) {
-
         BigDecimal maxCapacity = album.getType().getCapacityGb();
         BigDecimal current = album.getCapacityGb();
         BigDecimal afterUpload = current.add(uploadCapacity);
@@ -372,7 +382,6 @@ public class ImageServiceImpl implements ImageService {
     }
 
     private void validateTempAlbumCapacity(TempAlbum tempAlbum, BigDecimal uploadCapacity) {
-
         BigDecimal maxCapacity = tempAlbum.getType().getCapacityGb();
         BigDecimal current = tempAlbum.getCapacityGb();
         BigDecimal afterUpload = current.add(uploadCapacity);
@@ -433,7 +442,8 @@ public class ImageServiceImpl implements ImageService {
     private void validateSubscriptionNotExpired(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
             throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
@@ -5,7 +5,6 @@ import org.cherrypic.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -21,15 +20,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             """,
             nativeQuery = true)
     void bulkInsertAlbumDeleteNotifications(
-            @Param("albumId") Long albumId,
-            @Param("senderId") Long senderId,
-            @Param("title") String title,
-            @Param("content") String content);
+            Long albumId, Long senderId, String title, String content);
 
     @Modifying
     @Query("delete from Notification n where n.receiver.id = :receiverId and n.album.id = :albumId")
-    void deleteByReceiverIdAndAlbumId(
-            @Param("receiverId") Long receiverId, @Param("albumId") Long albumId);
+    void deleteByReceiverIdAndAlbumId(Long receiverId, Long albumId);
 
     @Modifying(clearAutomatically = true)
     @Query("delete from Notification n where n.album.id = :albumId")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package org.cherrypic.domain.notification.repository;
 
+import java.util.List;
 import org.cherrypic.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -33,4 +34,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying(clearAutomatically = true)
     @Query("delete from Notification n where n.album.id = :albumId")
     void deleteAllByAlbumId(Long albumId);
+
+    @Query("select n from Notification n where n.album.id = :albumId")
+    List<Notification> findAllByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
@@ -25,5 +25,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("title") String title,
             @Param("content") String content);
 
-    void deleteByReceiverIdAndAlbumId(Long receiverId, Long albumId);
+    @Modifying
+    @Query("delete from Notification n where n.receiver.id = :receiverId and n.album.id = :albumId")
+    void deleteByReceiverIdAndAlbumId(
+            @Param("receiverId") Long receiverId, @Param("albumId") Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/notification/repository/NotificationRepository.java
@@ -29,4 +29,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("delete from Notification n where n.receiver.id = :receiverId and n.album.id = :albumId")
     void deleteByReceiverIdAndAlbumId(
             @Param("receiverId") Long receiverId, @Param("albumId") Long albumId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Notification n where n.album.id = :albumId")
+    void deleteAllByAlbumId(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -10,7 +10,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface ParticipantRepository
         extends JpaRepository<Participant, Long>, ParticipantRepositoryCustom {
-    Optional<Participant> findByMemberIdAndAlbumId(Long memberId, Long albumId);
+
+    @Query("select p from Participant p where p.member.id = :memberId and p.album.id = :albumId")
+    Optional<Participant> findByMemberIdAndAlbumId(
+            @Param("memberId") Long memberId, @Param("albumId") Long albumId);
 
     @Modifying(clearAutomatically = true)
     @Query(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -30,6 +30,10 @@ public interface ParticipantRepository
     @Query("select p from Participant p where p.album.id = :albumId and p.role = 'HOST'")
     Optional<Participant> findHostByAlbumId(@Param("albumId") Long albumId);
 
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Participant p where p.album.id = :albumId")
+    void deleteAllByAlbumId(Long albumId);
+
     int countByAlbumId(Long albumId);
 
     long countByAlbumIdAndMemberIdNot(Long albumId, Long excludeMemberId);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -30,6 +30,9 @@ public interface ParticipantRepository
     @Query("select p from Participant p where p.album.id = :albumId and p.role = 'HOST'")
     Optional<Participant> findHostByAlbumId(@Param("albumId") Long albumId);
 
+    @Query("select p.id from Participant p where p.album.id = :albumId")
+    List<Long> findIdsByAlbumId(@Param("albumId") Long albumId);
+
     int countByAlbumId(Long albumId);
 
     long countByAlbumIdAndMemberIdNot(Long albumId, Long excludeMemberId);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -27,6 +27,10 @@ public interface ParticipantRepository
     @Query("select p from Participant p where p.album.id = :albumId and p.role = 'HOST'")
     Optional<Participant> findHostByAlbumId(Long albumId);
 
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Participant p where p.id = :participantId")
+    void deleteByParticipantId(Long participantId);
+
     int countByAlbumId(Long albumId);
 
     long countByAlbumIdAndMemberIdNot(Long albumId, Long excludeMemberId);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -30,10 +30,6 @@ public interface ParticipantRepository
     @Query("select p from Participant p where p.album.id = :albumId and p.role = 'HOST'")
     Optional<Participant> findHostByAlbumId(@Param("albumId") Long albumId);
 
-    @Modifying(clearAutomatically = true)
-    @Query("delete from Participant p where p.album.id = :albumId")
-    void deleteAllByAlbumId(Long albumId);
-
     int countByAlbumId(Long albumId);
 
     long countByAlbumIdAndMemberIdNot(Long albumId, Long excludeMemberId);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -30,9 +30,6 @@ public interface ParticipantRepository
     @Query("select p from Participant p where p.album.id = :albumId and p.role = 'HOST'")
     Optional<Participant> findHostByAlbumId(@Param("albumId") Long albumId);
 
-    @Query("select p.id from Participant p where p.album.id = :albumId")
-    List<Long> findIdsByAlbumId(@Param("albumId") Long albumId);
-
     int countByAlbumId(Long albumId);
 
     long countByAlbumIdAndMemberIdNot(Long albumId, Long excludeMemberId);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/repository/ParticipantRepository.java
@@ -6,29 +6,26 @@ import org.cherrypic.participant.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface ParticipantRepository
         extends JpaRepository<Participant, Long>, ParticipantRepositoryCustom {
 
     @Query("select p from Participant p where p.member.id = :memberId and p.album.id = :albumId")
-    Optional<Participant> findByMemberIdAndAlbumId(
-            @Param("memberId") Long memberId, @Param("albumId") Long albumId);
+    Optional<Participant> findByMemberIdAndAlbumId(Long memberId, Long albumId);
 
     @Modifying(clearAutomatically = true)
     @Query(
             value =
                     "update participant set role = 'STANDARD' where album_id = :albumId and role = 'LIMITED'",
             nativeQuery = true)
-    void bulkChangeLimitedToStandard(@Param("albumId") Long albumId);
+    void bulkChangeLimitedToStandard(Long albumId);
 
     @Query(
             "select p.member.id from Participant p where p.album.id = :albumId and p.member.id <> :memberId")
-    List<Long> findOtherParticipantMemberIds(
-            @Param("albumId") Long albumId, @Param("memberId") Long memberId);
+    List<Long> findOtherParticipantMemberIds(Long albumId, Long memberId);
 
     @Query("select p from Participant p where p.album.id = :albumId and p.role = 'HOST'")
-    Optional<Participant> findHostByAlbumId(@Param("albumId") Long albumId);
+    Optional<Participant> findHostByAlbumId(Long albumId);
 
     int countByAlbumId(Long albumId);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -7,6 +7,7 @@ import org.cherrypic.album.entity.Album;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
 import org.cherrypic.domain.album.repository.AlbumRepository;
+import org.cherrypic.domain.favorites.repository.FavoritesRepository;
 import org.cherrypic.domain.notification.repository.NotificationRepository;
 import org.cherrypic.domain.participant.dto.request.ParticipantRoleUpdateRequest;
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
@@ -33,6 +34,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
     private final ParticipantRepository participantRepository;
     private final AlbumRepository albumRepository;
+    private final FavoritesRepository favoritesRepository;
     private final NotificationRepository notificationRepository;
 
     @Override
@@ -46,6 +48,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         validateNotAlbumHost(participant);
 
         try {
+            favoritesRepository.deleteByParticipantId(participant.getId());
             participantRepository.delete(participant);
             notificationRepository.deleteByReceiverIdAndAlbumId(currentMember.getId(), albumId);
         } catch (ObjectOptimisticLockingFailureException ignored) {
@@ -65,6 +68,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         validateParticipantBelongsToAlbum(target, album);
 
         try {
+            favoritesRepository.deleteByParticipantId(target.getId());
             participantRepository.delete(target);
             notificationRepository.deleteByReceiverIdAndAlbumId(
                     target.getMember().getId(), album.getId());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -53,7 +53,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         try {
             favoritesRepository.deleteByParticipantId(participant.getId());
-            participantRepository.delete(participant);
+            participantRepository.deleteById(participant.getId());
             notificationRepository.deleteByReceiverIdAndAlbumId(currentMember.getId(), albumId);
         } catch (ObjectOptimisticLockingFailureException ignored) {
         }
@@ -73,7 +73,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         try {
             favoritesRepository.deleteByParticipantId(target.getId());
-            participantRepository.delete(target);
+            participantRepository.deleteById(target.getId());
             notificationRepository.deleteByReceiverIdAndAlbumId(
                     target.getMember().getId(), album.getId());
         } catch (ObjectOptimisticLockingFailureException ignored) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -13,12 +13,15 @@ import org.cherrypic.domain.participant.dto.request.ParticipantRoleUpdateRequest
 import org.cherrypic.domain.participant.dto.response.ParticipantListResponse;
 import org.cherrypic.domain.participant.exception.ParticipantErrorCode;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
+import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.data.domain.Slice;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -34,6 +37,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
     private final ParticipantRepository participantRepository;
     private final AlbumRepository albumRepository;
+    private final SubscriptionRepository subscriptionRepository;
     private final FavoritesRepository favoritesRepository;
     private final NotificationRepository notificationRepository;
 
@@ -164,6 +168,13 @@ public class ParticipantServiceImpl implements ParticipantService {
                 .orElseThrow(() -> new CustomException(ParticipantErrorCode.PARTICIPANT_NOT_FOUND));
     }
 
+    private Subscription getSubscriptionByAlbumId(Long albumId) {
+        return subscriptionRepository
+                .findByAlbumId(albumId)
+                .orElseThrow(
+                        () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
     private void validateNotAlbumHost(Participant participant) {
         if (participant.getRole() == ParticipantRole.HOST) {
             throw new CustomException(AlbumErrorCode.HOST_LEAVE_NOT_ALLOWED);
@@ -203,7 +214,8 @@ public class ParticipantServiceImpl implements ParticipantService {
     private void validateSubscriptionInactive(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.ACTIVE) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.ACTIVE) {
             throw new CustomException(AlbumErrorCode.SUBSCRIPTION_ACTIVE_HOST_TRANSFER_NOT_ALLOWED);
         }
     }
@@ -217,7 +229,8 @@ public class ParticipantServiceImpl implements ParticipantService {
     private void validateSubscriptionNotExpired(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
             throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/participant/service/ParticipantServiceImpl.java
@@ -53,7 +53,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         try {
             favoritesRepository.deleteByParticipantId(participant.getId());
-            participantRepository.deleteById(participant.getId());
+            participantRepository.deleteByParticipantId(participant.getId());
             notificationRepository.deleteByReceiverIdAndAlbumId(currentMember.getId(), albumId);
         } catch (ObjectOptimisticLockingFailureException ignored) {
         }
@@ -73,7 +73,7 @@ public class ParticipantServiceImpl implements ParticipantService {
 
         try {
             favoritesRepository.deleteByParticipantId(target.getId());
-            participantRepository.deleteById(target.getId());
+            participantRepository.deleteByParticipantId(target.getId());
             notificationRepository.deleteByReceiverIdAndAlbumId(
                     target.getMember().getId(), album.getId());
         } catch (ObjectOptimisticLockingFailureException ignored) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepository.java
@@ -6,7 +6,6 @@ import org.cherrypic.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long>, PaymentRepositoryCustom {
     Optional<Payment> findByMerchantUid(String merchantUid);
@@ -15,7 +14,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long>, Payment
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Payment p where p.id = :paymentId")
-    Optional<Payment> findByIdWithPessimisticLock(@Param("paymentId") Long paymentId);
+    Optional<Payment> findByIdWithPessimisticLock(Long paymentId);
 
     Optional<Payment> findTop1ByAlbumIdOrderByIdAsc(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepository.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/repository/PaymentRepository.java
@@ -16,4 +16,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long>, Payment
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Payment p where p.id = :paymentId")
     Optional<Payment> findByIdWithPessimisticLock(@Param("paymentId") Long paymentId);
+
+    Optional<Payment> findTop1ByAlbumIdOrderByIdAsc(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -24,6 +24,8 @@ import org.cherrypic.domain.payment.dto.response.PaymentUnlinkedResponse;
 import org.cherrypic.domain.payment.dto.response.PaymentVerificationResponse;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
+import org.cherrypic.domain.subscription.exception.SubscriptionErrorCode;
+import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
@@ -34,6 +36,7 @@ import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
 import org.cherrypic.payment.enums.PaymentPurpose;
 import org.cherrypic.payment.enums.PaymentStatus;
+import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
@@ -52,6 +55,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final AlbumRepository albumRepository;
     private final ParticipantRepository participantRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -219,6 +223,13 @@ public class PaymentServiceImpl implements PaymentService {
                 .orElseThrow(() -> new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
     }
 
+    private Subscription getSubscriptionByAlbumId(Long albumId) {
+        return subscriptionRepository
+                .findByAlbumId(albumId)
+                .orElseThrow(
+                        () -> new CustomException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
     private void validateAlbumHost(Long memberId, Long albumId) {
         Participant participant = getParticipantByMemberIdAndAlbumId(memberId, albumId);
 
@@ -236,7 +247,8 @@ public class PaymentServiceImpl implements PaymentService {
     private void validateSubscriptionNotExpired(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
             throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/subscription/service/SubscriptionServiceImpl.java
@@ -144,7 +144,8 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     private void validateSubscriptionNotExpired(Album album) {
         if (album.getType() == AlbumType.BASIC) return;
 
-        if (album.getSubscription().getStatus() == SubscriptionStatus.EXPIRED) {
+        Subscription subscription = getSubscriptionByAlbumId(album.getId());
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
             throw new CustomException(AlbumErrorCode.EXPIRED_SUBSCRIPTION);
         }
     }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -30,14 +30,17 @@ import org.cherrypic.domain.event.repository.EventRepository;
 import org.cherrypic.domain.favorites.repository.FavoritesRepository;
 import org.cherrypic.domain.image.event.ImageDeleteEvent;
 import org.cherrypic.domain.image.event.ImagesDeleteEvent;
+import org.cherrypic.domain.image.repository.EventImageRepository;
 import org.cherrypic.domain.image.repository.ImageRepository;
 import org.cherrypic.domain.member.repository.MemberRepository;
+import org.cherrypic.domain.notification.repository.NotificationRepository;
 import org.cherrypic.domain.participant.repository.ParticipantRepository;
 import org.cherrypic.domain.payment.exception.PaymentErrorCode;
 import org.cherrypic.domain.payment.repository.PaymentRepository;
 import org.cherrypic.domain.refundtask.repository.RefundTaskRepository;
 import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.event.entity.Event;
+import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.global.pagination.SliceResponse;
@@ -47,6 +50,8 @@ import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
+import org.cherrypic.notification.entity.Notification;
+import org.cherrypic.notification.enums.NotificationType;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.entity.Payment;
@@ -82,6 +87,8 @@ class AlbumServiceTest extends IntegrationTest {
     @Autowired private InvitationCodeRepository invitationCodeRepository;
     @Autowired private EventRepository eventRepository;
     @Autowired private ImageRepository imageRepository;
+    @Autowired private EventImageRepository eventImageRepository;
+    @Autowired private NotificationRepository notificationRepository;
 
     @MockitoBean private MemberUtil memberUtil;
 
@@ -1208,10 +1215,6 @@ class AlbumServiceTest extends IntegrationTest {
             Album album5 = Album.createAlbum("testAlbum5", "testURL5", AlbumType.PRO, false);
             albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
 
-            Image image =
-                    Image.createImage(album1, 1L, "testUrl", LocalDateTime.now(), BigDecimal.ONE);
-            imageRepository.save(image);
-
             subscriptionRepository.save(
                     Subscription.createSubscription(member1, album5, LocalDateTime.now()));
 
@@ -1228,18 +1231,40 @@ class AlbumServiceTest extends IntegrationTest {
             participantRepository.saveAll(
                     List.of(participant1, participant2, participant3, participant4, participant5));
 
-            eventRepository.save(Event.createEvent(album1, "testTitle1", "testCoverUrl1"));
+            favoritesRepository.save(Favorites.createFavorites(participant1));
+
+            Image image =
+                    Image.createImage(album1, 1L, "testUrl", LocalDateTime.now(), BigDecimal.ONE);
+            imageRepository.save(image);
+
+            Event event = Event.createEvent(album1, "testTitle1", "testCoverUrl1");
+            eventRepository.save(event);
+            eventImageRepository.save(EventImage.createEventImage(event, image));
+
+            notificationRepository.save(
+                    Notification.createNotification(
+                            member1,
+                            member2,
+                            album1,
+                            "testTitle",
+                            "testContent",
+                            NotificationType.ALBUM));
         }
 
         @Test
-        void 유효한_요청일_경우_앨범과_내부_이벤트가_모두_삭제된다() {
+        void 유효한_요청일_경우_참가자_즐겨찾기_이벤트_이미지_알림이_모두_삭제된다() {
             // when
             albumService.deleteAlbum(1L);
 
             // then
             Assertions.assertAll(
                     () -> assertThat(albumRepository.findById(1L).isPresent()).isFalse(),
-                    () -> assertThat(eventRepository.findById(1L).isPresent()).isFalse());
+                    () -> assertThat(participantRepository.findById(1L).isPresent()).isFalse(),
+                    () -> assertThat(favoritesRepository.findById(1L).isPresent()).isFalse(),
+                    () -> assertThat(eventRepository.findById(1L).isPresent()).isFalse(),
+                    () -> assertThat(eventImageRepository.findById(1L).isPresent()).isFalse(),
+                    () -> assertThat(imageRepository.findById(1L).isPresent()).isFalse(),
+                    () -> assertThat(notificationRepository.findById(1L).isPresent()).isFalse());
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -1169,6 +1169,7 @@ class AlbumServiceTest extends IntegrationTest {
         @Test
         void 앨범이_없는_경우_빈_리스트를_조회한다() {
             // given
+            favoritesRepository.deleteAll();
             albumRepository.deleteAll();
 
             // when

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -268,12 +268,10 @@ class AlbumServiceTest extends IntegrationTest {
                                 () -> {
                                     Album loadedAlbum = albumRepository.findById(2L).get();
                                     loadedAlbum.getParticipants().get(0);
-                                    loadedAlbum.getPayments().get(0);
                                     return loadedAlbum;
                                 });
                 Participant participant = album.getParticipants().get(0);
-                Payment payment = album.getPayments().get(0);
-
+                Payment payment = paymentRepository.findTop1ByAlbumIdOrderByIdAsc(2L).get();
                 Subscription subscription = subscriptionRepository.findById(1L).orElseThrow();
 
                 Assertions.assertAll(
@@ -1170,6 +1168,7 @@ class AlbumServiceTest extends IntegrationTest {
         void 앨범이_없는_경우_빈_리스트를_조회한다() {
             // given
             favoritesRepository.deleteAll();
+            participantRepository.deleteAll();
             albumRepository.deleteAll();
 
             // when

--- a/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/participant/service/ParticipantServiceTest.java
@@ -119,11 +119,11 @@ class ParticipantServiceTest extends IntegrationTest {
                             () -> {
                                 Album loadedAlbum = albumRepository.findById(1L).get();
                                 loadedAlbum.getParticipants().size();
-                                loadedAlbum.getNotifications().size();
                                 return loadedAlbum;
                             });
             List<Participant> participants = album.getParticipants();
-            List<Notification> notifications = album.getNotifications();
+            List<Notification> notifications =
+                    notificationRepository.findAllByAlbumId(album.getId());
 
             Assertions.assertAll(
                     () ->
@@ -225,11 +225,11 @@ class ParticipantServiceTest extends IntegrationTest {
                             () -> {
                                 Album loadedAlbum = albumRepository.findById(1L).get();
                                 loadedAlbum.getParticipants().size();
-                                loadedAlbum.getNotifications().size();
                                 return loadedAlbum;
                             });
             List<Participant> participants = album.getParticipants();
-            List<Notification> notifications = album.getNotifications();
+            List<Notification> notifications =
+                    notificationRepository.findAllByAlbumId(album.getId());
 
             Assertions.assertAll(
                     () ->

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -23,7 +23,6 @@ import org.cherrypic.domain.subscription.repository.SubscriptionRepository;
 import org.cherrypic.domain.subscription.service.SubscriptionService;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.util.MemberUtil;
-import org.cherrypic.global.util.TransactionUtil;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.member.entity.OauthInfo;
 import org.cherrypic.participant.entity.Participant;
@@ -43,8 +42,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class SubscriptionServiceTest extends IntegrationTest {
-
-    @Autowired private TransactionUtil transactionUtil;
 
     @Autowired private SubscriptionService subscriptionService;
     @Autowired private SubscriptionRepository subscriptionRepository;
@@ -340,14 +337,7 @@ class SubscriptionServiceTest extends IntegrationTest {
             subscriptionService.renewSubscription(1L, request);
 
             // then
-            Album album =
-                    transactionUtil.getResult(
-                            () -> {
-                                Album loadedAlbum = albumRepository.findById(1L).get();
-                                loadedAlbum.getPayments().get(0);
-                                return loadedAlbum;
-                            });
-            Payment payment = album.getPayments().get(0);
+            Payment payment = paymentRepository.findTop1ByAlbumIdOrderByIdAsc(1L).get();
             Subscription subscription = subscriptionRepository.findByAlbumId(1L).get();
 
             Assertions.assertAll(
@@ -373,8 +363,6 @@ class SubscriptionServiceTest extends IntegrationTest {
         @Test
         void 결제에_앨범이_연결되면_환불_예약_작업이_SKIP된다() {
             // given
-            Subscription canceledSubscription = subscriptionRepository.findById(1L).get();
-
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 
             // when

--- a/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/subscription/service/SubscriptionServiceTest.java
@@ -345,11 +345,10 @@ class SubscriptionServiceTest extends IntegrationTest {
                             () -> {
                                 Album loadedAlbum = albumRepository.findById(1L).get();
                                 loadedAlbum.getPayments().get(0);
-                                loadedAlbum.getSubscription();
                                 return loadedAlbum;
                             });
             Payment payment = album.getPayments().get(0);
-            Subscription subscription = album.getSubscription();
+            Subscription subscription = subscriptionRepository.findByAlbumId(1L).get();
 
             Assertions.assertAll(
                     () ->
@@ -375,8 +374,6 @@ class SubscriptionServiceTest extends IntegrationTest {
         void 결제에_앨범이_연결되면_환불_예약_작업이_SKIP된다() {
             // given
             Subscription canceledSubscription = subscriptionRepository.findById(1L).get();
-            LocalDateTime previousEndAt =
-                    canceledSubscription.getEndAt().truncatedTo(ChronoUnit.MINUTES);
 
             SubscriptionRenewRequest request = new SubscriptionRenewRequest(1L);
 
@@ -584,34 +581,25 @@ class SubscriptionServiceTest extends IntegrationTest {
             subscriptionService.getSubscriptionInfo(1L);
 
             // then
-            Album album =
-                    transactionUtil.getResult(
-                            () -> {
-                                Album loadedAlbum = albumRepository.findById(1L).get();
-                                loadedAlbum.getSubscription();
-                                return loadedAlbum;
-                            });
-            Subscription subscription = album.getSubscription();
+            Subscription subscription = subscriptionRepository.findByAlbumId(1L).get();
 
-            Assertions.assertAll(
-                    () ->
-                            assertThat(subscription)
-                                    .extracting(
-                                            "id",
-                                            "member.id",
-                                            "album.id",
-                                            "status",
-                                            "startAt",
-                                            "endAt",
-                                            "nextBillingAt")
-                                    .containsExactly(
-                                            1L,
-                                            1L,
-                                            1L,
-                                            SubscriptionStatus.ACTIVE,
-                                            LocalDateTime.of(2025, 8, 4, 0, 0),
-                                            LocalDateTime.of(2025, 9, 4, 0, 0),
-                                            LocalDateTime.of(2025, 9, 1, 0, 0)));
+            assertThat(subscription)
+                    .extracting(
+                            "id",
+                            "member.id",
+                            "album.id",
+                            "status",
+                            "startAt",
+                            "endAt",
+                            "nextBillingAt")
+                    .containsExactly(
+                            1L,
+                            1L,
+                            1L,
+                            SubscriptionStatus.ACTIVE,
+                            LocalDateTime.of(2025, 8, 4, 0, 0),
+                            LocalDateTime.of(2025, 9, 4, 0, 0),
+                            LocalDateTime.of(2025, 9, 1, 0, 0));
         }
 
         @Test

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -18,7 +18,6 @@ import org.cherrypic.image.entity.Image;
 import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;
 import org.cherrypic.payment.entity.Payment;
-import org.cherrypic.subscription.entity.Subscription;
 
 @Getter
 @Entity
@@ -52,9 +51,6 @@ public class Album extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
-
-    @OneToOne(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Subscription subscription;
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -40,7 +40,7 @@ public class Album extends BaseTimeEntity {
 
     @NotNull private BigDecimal capacityGb;
 
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "album", cascade = CascadeType.PERSIST)
     private List<Participant> participants = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -13,7 +13,6 @@ import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.exception.CustomException;
-import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;
 
 @Getter
@@ -39,9 +38,6 @@ public class Album extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.PERSIST)
     private List<Participant> participants = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Notification> notifications = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Album(

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.common.model.BaseTimeEntity;
-import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.notification.entity.Notification;
@@ -45,9 +44,6 @@ public class Album extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Event> events = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -42,6 +42,15 @@ public class Album extends BaseTimeEntity {
     @NotNull private BigDecimal capacityGb;
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Participant> participants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Event> events = new ArrayList<>();
+
+    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Payment> payments = new ArrayList<>();
 
     @OneToOne(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -49,15 +58,6 @@ public class Album extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Event> events = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Participant> participants = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Image> images = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Album(

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -16,7 +16,6 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;
-import org.cherrypic.payment.entity.Payment;
 
 @Getter
 @Entity
@@ -44,9 +43,6 @@ public class Album extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Payment> payments = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -13,7 +13,6 @@ import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.album.exception.AlbumDomainErrorCode;
 import org.cherrypic.common.model.BaseTimeEntity;
 import org.cherrypic.exception.CustomException;
-import org.cherrypic.image.entity.Image;
 import org.cherrypic.notification.entity.Notification;
 import org.cherrypic.participant.entity.Participant;
 
@@ -40,9 +39,6 @@ public class Album extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.PERSIST)
     private List<Participant> participants = new ArrayList<>();
-
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Image> images = new ArrayList<>();
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();

--- a/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/participant/entity/Participant.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cherrypic.album.entity.Album;
 import org.cherrypic.common.model.BaseTimeEntity;
-import org.cherrypic.favorites.entity.Favorites;
 import org.cherrypic.member.entity.Member;
 import org.cherrypic.participant.enums.ParticipantRole;
 
@@ -33,9 +32,6 @@ public class Participant extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ParticipantRole role;
 
-    @OneToOne(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Favorites favorites;
-
     @Builder(access = AccessLevel.PRIVATE)
     private Participant(Member member, Album album, ParticipantRole role) {
         this.member = member;
@@ -45,10 +41,6 @@ public class Participant extends BaseTimeEntity {
 
     public static Participant createParticipant(Member member, Album album, ParticipantRole role) {
         return Participant.builder().member(member).album(album).role(role).build();
-    }
-
-    public void assignFavorites() {
-        this.favorites = Favorites.createFavorites(this);
     }
 
     public void changeRole(ParticipantRole role) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #216 

---
## 📌 작업 내용 및 특이사항
* 참가자를 조회할 때 즐겨찾기 정보가 함께 로딩되는 현상을 방지하기 위해, Participant ↔ Favorite 간 1:1 양방향 연관관계를 단방향으로 변경했습니다.
* 앨범을 조회할 때 구독이 조인되는 현상을 방지하기 위해, Album ↔ Subscription 간 1:1 양방향 연관관계를 단방향으로 변경했습니다.
* Participant에 설정되어 있던 orphanRemoval = true 옵션을 제거하고, CascadeType.PERSIST만 유지했습니다. 참가자 삭제는 앨범 삭제 시 명시적으로 처리하며, 앨범 생성 시 연관된 참가자들을 함께 저장하기 위해 PERSIST 전이만 남겼습니다.
* 앨범 삭제 시 즐겨찾기, 참가자, 이벤트, 이벤트 이미지, 이미지, 알림을 각각 명시적으로 삭제하도록 수정했습니다.
  * 참가자와 이벤트는 이미 엔티티를 조회한 상태이므로 deleteAllInBatch()로 삭제하여 효율성을 높였습니다.
  * 즐겨찾기는 연관된 즐겨찾기 엔티티들을 추가로 조회해야 하므로, @Modifying JPQL 방식으로 삭제해 불필요한 조회를 피했습니다.
  * 이벤트 이미지, 이미지는 데이터 양이 많아질 수 있어, IN (...) 조건이 포함된 deleteAllInBatch()보다 JPQL 방식을 택했습니다.
  * 알림도 삭제 시 별도 조회가 필요한 구조이므로, 즐겨찾기와 같은 이유로 JPQL 방식으로 처리했습니다.
* 결제 및 구독 도메인은 데이터 보존을 고려해 앨범 삭제 시 자동 삭제되지 않도록 연관관계를 제거하고 삭제 대상에서 제외했습니다.
* 최종적으로 앨범 삭제 흐름은 서비스 단에서 모든 연관 도메인을 명시적으로 삭제한 뒤, 앨범을 삭제하는 방식으로 수정했습니다.
* JPA 사용 중 발생하던 불필요한 left join 문제를 개선하기 위해, 일부 조회 로직을 JPQL 기반으로 변경했습니다.
* 또한, deleteById 등 JPA 메서드 사용 시 내부적으로 발생하는 select 쿼리를 피하고자, 별도 조회 없이 즉시 삭제할 수 있도록 @Modifying JPQL 쿼리 방식으로 개선했습니다.

---
## 📚 참고사항
* https://alstn113.tistory.com/21
* https://00h0.tistory.com/97