### PR TITLE
feat: 앨범 목록 조회 API에 구독 상태 필터링 기능 추가

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/controller/AlbumController.java
@@ -13,6 +13,7 @@ import org.cherrypic.domain.album.service.AlbumService;
 import org.cherrypic.global.annotation.PageSize;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -80,6 +81,9 @@ public class AlbumController {
             @Parameter(description = "앨범 유형 (BASIC, PRO, PREMIUM). 생략 시 전체 조회")
                     @RequestParam(required = false)
                     AlbumType type,
+            @Parameter(description = "구독 상태 (ACTIVE, CANCELED, EXPIRED). 생략 시 전체 조회")
+                    @RequestParam(required = false)
+                    SubscriptionStatus status,
             @Parameter(description = "검색 키워드 (앨범 제목에 포함된 단어). 생략 시 전체 조회")
                     @RequestParam(required = false)
                     String keyword,
@@ -91,7 +95,7 @@ public class AlbumController {
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
         return albumService.getParticipatingAlbumsByCondition(
-                type, keyword, lastAlbumId, size, direction);
+                type, status, keyword, lastAlbumId, size, direction);
     }
 
     @DeleteMapping("/{albumId}")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumListResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import org.cherrypic.album.enums.AlbumType;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 
 public record AlbumListResponse(
         @Schema(description = "앨범 ID", example = "1") Long albumId,
@@ -11,6 +12,7 @@ public record AlbumListResponse(
         @Schema(description = "앨범 커버 URL", example = "https://example.jpg") String coverUrl,
         @Schema(description = "앨범 유형", example = "BASIC") AlbumType type,
         @Schema(description = "앨범 구독 가격", example = "5900") Integer price,
+        @Schema(description = "구독 상태", example = "ACTIVE") SubscriptionStatus status,
         @JsonFormat(
                         shape = JsonFormat.Shape.STRING,
                         pattern = "yyyy-MM-dd",
@@ -23,9 +25,10 @@ public record AlbumListResponse(
             String title,
             String coverUrl,
             AlbumType type,
+            SubscriptionStatus status,
             LocalDateTime createdAt,
             Boolean marked) {
         return new AlbumListResponse(
-                albumId, title, coverUrl, type, type.getPrice(), createdAt, marked);
+                albumId, title, coverUrl, type, type.getPrice(), status, createdAt, marked);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryCustom.java
@@ -3,12 +3,14 @@ package org.cherrypic.domain.album.repository;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.data.domain.Slice;
 
 public interface AlbumRepositoryCustom {
-    Slice<AlbumListResponse> findAllByMemberIdAndTypeAndKeyword(
+    Slice<AlbumListResponse> findAllByMemberIdWithCondition(
             Long memberId,
             AlbumType type,
+            SubscriptionStatus status,
             String keyword,
             Long lastAlbumId,
             int size,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.cherrypic.domain.album.repository;
 import static org.cherrypic.album.entity.QAlbum.album;
 import static org.cherrypic.favorites.entity.QFavorites.favorites;
 import static org.cherrypic.participant.entity.QParticipant.participant;
+import static org.cherrypic.subscription.entity.QSubscription.subscription;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.domain.album.dto.response.AlbumListResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -25,9 +27,10 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<AlbumListResponse> findAllByMemberIdAndTypeAndKeyword(
+    public Slice<AlbumListResponse> findAllByMemberIdWithCondition(
             Long memberId,
             AlbumType type,
+            SubscriptionStatus status,
             String keyword,
             Long lastAlbumId,
             int size,
@@ -39,15 +42,19 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                                 album.title,
                                 album.coverUrl,
                                 album.type,
+                                subscription.status,
                                 album.createdAt,
                                 favorites.marked)
                         .from(participant)
                         .join(participant.album, album)
+                        .leftJoin(subscription)
+                        .on(subscription.album.eq(album))
                         .leftJoin(favorites)
                         .on(favorites.participant.eq(participant))
                         .where(
                                 participant.member.id.eq(memberId),
                                 type != null ? album.type.eq(type) : null,
+                                status != null ? subscription.status.eq(status) : null,
                                 keyword != null ? album.title.containsIgnoreCase(keyword) : null,
                                 lastAlbumIdCondition(lastAlbumId, direction))
                         .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())
@@ -63,6 +70,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                                                 tuple.get(album.title),
                                                 tuple.get(album.coverUrl),
                                                 tuple.get(album.type),
+                                                tuple.get(subscription.status),
                                                 tuple.get(album.createdAt),
                                                 tuple.get(favorites.marked)))
                         .collect(Collectors.toList());

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/repository/AlbumRepositoryImpl.java
@@ -54,7 +54,7 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
                         .where(
                                 participant.member.id.eq(memberId),
                                 type != null ? album.type.eq(type) : null,
-                                status != null ? subscription.status.eq(status) : null,
+                                statusCondition(status),
                                 keyword != null ? album.title.containsIgnoreCase(keyword) : null,
                                 lastAlbumIdCondition(lastAlbumId, direction))
                         .orderBy(direction == SortDirection.DESC ? album.id.desc() : album.id.asc())
@@ -84,6 +84,21 @@ public class AlbumRepositoryImpl implements AlbumRepositoryCustom {
         }
 
         return direction == SortDirection.DESC ? album.id.lt(albumId) : album.id.gt(albumId);
+    }
+
+    private BooleanExpression statusCondition(SubscriptionStatus status) {
+        if (status == null) {
+            return null;
+        }
+
+        if (status == SubscriptionStatus.ACTIVE) {
+            return subscription
+                    .status
+                    .eq(SubscriptionStatus.ACTIVE)
+                    .or(subscription.isNull().and(album.type.eq(AlbumType.BASIC)));
+        }
+
+        return subscription.status.eq(status);
     }
 
     private Slice<AlbumListResponse> checkLastPage(int pageSize, List<AlbumListResponse> results) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumService.java
@@ -6,6 +6,7 @@ import org.cherrypic.domain.album.dto.request.AlbumUpdateRequest;
 import org.cherrypic.domain.album.dto.response.*;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 
 public interface AlbumService {
     AlbumCreateResponse createAlbum(AlbumCreateRequest request);
@@ -21,7 +22,12 @@ public interface AlbumService {
     AlbumInfoResponse getAlbum(Long albumId);
 
     SliceResponse<AlbumListResponse> getParticipatingAlbumsByCondition(
-            AlbumType type, String keyword, Long lastAlbumId, int size, SortDirection direction);
+            AlbumType type,
+            SubscriptionStatus status,
+            String keyword,
+            Long lastAlbumId,
+            int size,
+            SortDirection direction);
 
     void deleteAlbum(Long albumId);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -215,12 +215,17 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<AlbumListResponse> getParticipatingAlbumsByCondition(
-            AlbumType type, String keyword, Long lastAlbumId, int size, SortDirection direction) {
+            AlbumType type,
+            SubscriptionStatus status,
+            String keyword,
+            Long lastAlbumId,
+            int size,
+            SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
 
         Slice<AlbumListResponse> results =
-                albumRepository.findAllByMemberIdAndTypeAndKeyword(
-                        currentMember.getId(), type, keyword, lastAlbumId, size, direction);
+                albumRepository.findAllByMemberIdWithCondition(
+                        currentMember.getId(), type, status, keyword, lastAlbumId, size, direction);
 
         return SliceResponse.from(results);
     }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -22,6 +22,7 @@ import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.participant.enums.ParticipantRole;
 import org.cherrypic.payment.exception.PaymentDomainErrorCode;
+import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1034,6 +1035,7 @@ class AlbumControllerTest {
                                     "testCoverUrl2",
                                     AlbumType.PRO,
                                     AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.ACTIVE,
                                     LocalDateTime.now(),
                                     true),
                             new AlbumListResponse(
@@ -1042,12 +1044,13 @@ class AlbumControllerTest {
                                     "testCoverUrl1",
                                     AlbumType.PRO,
                                     AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.ACTIVE,
                                     LocalDateTime.now(),
                                     false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    AlbumType.PRO, null, null, 2, SortDirection.DESC))
+                                    AlbumType.PRO, null, null, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -1073,6 +1076,7 @@ class AlbumControllerTest {
                                     "testCoverUrl2",
                                     AlbumType.BASIC,
                                     AlbumType.BASIC.getPrice(),
+                                    null,
                                     LocalDateTime.now(),
                                     true),
                             new AlbumListResponse(
@@ -1081,12 +1085,13 @@ class AlbumControllerTest {
                                     "testCoverUrl1",
                                     AlbumType.BASIC,
                                     AlbumType.BASIC.getPrice(),
+                                    null,
                                     LocalDateTime.now(),
                                     false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    null, "testTitle", null, 2, SortDirection.DESC))
+                                    null, null, "testTitle", null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -1103,7 +1108,7 @@ class AlbumControllerTest {
         }
 
         @Test
-        void PRO_유형과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_응답한다() throws Exception {
+        void ACTIVE_구독_상태로_필터링하면_BASIC_앨범과_구독_중인_유료_앨범만_응답한다() throws Exception {
             // given
             List<AlbumListResponse> albums =
                     List.of(
@@ -1113,35 +1118,118 @@ class AlbumControllerTest {
                                     "testCoverUrl2",
                                     AlbumType.PRO,
                                     AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.ACTIVE,
                                     LocalDateTime.now(),
                                     true),
                             new AlbumListResponse(
                                     1L,
                                     "testTitle1",
                                     "testCoverUrl1",
-                                    AlbumType.PRO,
-                                    AlbumType.PRO.getPrice(),
+                                    AlbumType.BASIC,
+                                    AlbumType.BASIC.getPrice(),
+                                    null,
                                     LocalDateTime.now(),
                                     false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    AlbumType.PRO, "testTitle", null, 2, SortDirection.DESC))
+                                    null,
+                                    SubscriptionStatus.ACTIVE,
+                                    null,
+                                    null,
+                                    2,
+                                    SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
             ResultActions perform =
-                    mockMvc.perform(
-                            get("/albums")
-                                    .param("type", "PRO")
-                                    .param("keyword", "testTitle")
-                                    .param("size", "2"));
+                    mockMvc.perform(get("/albums").param("status", "ACTIVE").param("size", "2"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-                    .andExpect(jsonPath("$.data.content[0].title").value("testTitle2"))
-                    .andExpect(jsonPath("$.data.content[1].title").value("testTitle1"))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(2))
+                    .andExpect(jsonPath("$.data.content[0].type").value("PRO"))
+                    .andExpect(jsonPath("$.data.content[0].status").value("ACTIVE"))
+                    .andExpect(jsonPath("$.data.content[1].albumId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].type").value("BASIC"))
+                    .andExpect(jsonPath("$.data.content[1].status").doesNotExist())
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void CANCELED_구독_상태로_필터링하면_해지되었지만_구독_중인_유료_앨범만_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.CANCELED,
+                                    LocalDateTime.now(),
+                                    false));
+
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null,
+                                    SubscriptionStatus.CANCELED,
+                                    null,
+                                    null,
+                                    1,
+                                    SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("status", "CANCELED").param("size", "1"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(1))
+                    .andExpect(jsonPath("$.data.content[0].type").value("PRO"))
+                    .andExpect(jsonPath("$.data.content[0].status").value("CANCELED"))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void EXPIRED_구독_상태로_필터링하면_구독이_만료된_유료_앨범만_응답한다() throws Exception {
+            // given
+            List<AlbumListResponse> albums =
+                    List.of(
+                            new AlbumListResponse(
+                                    1L,
+                                    "testTitle1",
+                                    "testCoverUrl1",
+                                    AlbumType.PRO,
+                                    AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.EXPIRED,
+                                    LocalDateTime.now(),
+                                    false));
+
+            given(
+                            albumService.getParticipatingAlbumsByCondition(
+                                    null,
+                                    SubscriptionStatus.EXPIRED,
+                                    null,
+                                    null,
+                                    1,
+                                    SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(albums, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(get("/albums").param("status", "EXPIRED").param("size", "1"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].albumId").value(1))
+                    .andExpect(jsonPath("$.data.content[0].type").value("PRO"))
+                    .andExpect(jsonPath("$.data.content[0].status").value("EXPIRED"))
                     .andExpect(jsonPath("$.data.isLast").value(true));
         }
 
@@ -1156,6 +1244,7 @@ class AlbumControllerTest {
                                     "testCoverUrl1",
                                     AlbumType.BASIC,
                                     AlbumType.BASIC.getPrice(),
+                                    null,
                                     LocalDateTime.now(),
                                     false),
                             new AlbumListResponse(
@@ -1164,12 +1253,13 @@ class AlbumControllerTest {
                                     "testCoverUrl2",
                                     AlbumType.PRO,
                                     AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.ACTIVE,
                                     LocalDateTime.now(),
                                     true));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    null, null, null, 2, SortDirection.ASC))
+                                    null, null, null, null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -1195,6 +1285,7 @@ class AlbumControllerTest {
                                     "testCoverUrl2",
                                     AlbumType.PRO,
                                     AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.ACTIVE,
                                     LocalDateTime.now(),
                                     true),
                             new AlbumListResponse(
@@ -1203,12 +1294,13 @@ class AlbumControllerTest {
                                     "testCoverUrl1",
                                     AlbumType.BASIC,
                                     AlbumType.BASIC.getPrice(),
+                                    null,
                                     LocalDateTime.now(),
                                     false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    null, null, null, 2, SortDirection.DESC))
+                                    null, null, null, null, 2, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -1234,12 +1326,13 @@ class AlbumControllerTest {
                                     "testCoverUrl1",
                                     AlbumType.BASIC,
                                     AlbumType.BASIC.getPrice(),
+                                    null,
                                     LocalDateTime.now(),
                                     false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    null, null, null, 1, SortDirection.DESC))
+                                    null, null, null, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then
@@ -1264,6 +1357,7 @@ class AlbumControllerTest {
                                     "testCoverUrl2",
                                     AlbumType.PRO,
                                     AlbumType.PRO.getPrice(),
+                                    SubscriptionStatus.ACTIVE,
                                     LocalDateTime.now(),
                                     true),
                             new AlbumListResponse(
@@ -1272,12 +1366,13 @@ class AlbumControllerTest {
                                     "testCoverUrl1",
                                     AlbumType.BASIC,
                                     AlbumType.BASIC.getPrice(),
+                                    null,
                                     LocalDateTime.now(),
                                     false));
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    null, null, null, 1, SortDirection.DESC))
+                                    null, null, null, null, 1, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, false));
 
             // when & then
@@ -1298,7 +1393,7 @@ class AlbumControllerTest {
 
             given(
                             albumService.getParticipatingAlbumsByCondition(
-                                    null, null, null, 10, SortDirection.DESC))
+                                    null, null, null, null, 10, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(albums, true));
 
             // when & then

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -1134,19 +1134,12 @@ class AlbumServiceTest extends IntegrationTest {
                             null, SubscriptionStatus.ACTIVE, null, null, 3, SortDirection.DESC);
 
             // when & then
-            Assertions.assertAll(
-                    () -> assertThat(response.content().getFirst().albumId()).isEqualTo(3),
-                    () -> assertThat(response.content().getFirst().type()).isEqualTo(AlbumType.PRO),
-                    () ->
-                            assertThat(response.content().getFirst().status())
-                                    .isEqualTo(SubscriptionStatus.ACTIVE),
-                    () -> assertThat(response.content().get(1).albumId()).isEqualTo(2),
-                    () -> assertThat(response.content().get(1).type()).isEqualTo(AlbumType.BASIC),
-                    () -> assertThat(response.content().get(1).status()).isEqualTo(null),
-                    () -> assertThat(response.content().get(2).albumId()).isEqualTo(1),
-                    () -> assertThat(response.content().get(2).type()).isEqualTo(AlbumType.BASIC),
-                    () -> assertThat(response.content().get(2).status()).isEqualTo(null),
-                    () -> assertThat(response.isLast()).isTrue());
+            assertThat(response.content())
+                    .extracting("albumId", "type", "status")
+                    .containsExactly(
+                            tuple(3L, AlbumType.PRO, SubscriptionStatus.ACTIVE),
+                            tuple(2L, AlbumType.BASIC, null),
+                            tuple(1L, AlbumType.BASIC, null));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -1044,7 +1044,11 @@ class AlbumServiceTest extends IntegrationTest {
             Album album1 = Album.createAlbum("testTitle1", "testCoverUrl1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testTitle2", "testCoverUrl2", AlbumType.BASIC, false);
             Album album3 = Album.createAlbum("testTitle3", "testCoverUrl3", AlbumType.PRO, false);
-            albumRepository.saveAll(List.of(album1, album2, album3));
+            Album album4 =
+                    Album.createAlbum("testTitle4", "testCoverUrl4", AlbumType.PREMIUM, false);
+            Album album5 =
+                    Album.createAlbum("testTitle5", "testCoverUrl5", AlbumType.PREMIUM, false);
+            albumRepository.saveAll(List.of(album1, album2, album3, album4, album5));
 
             Participant participant1 =
                     Participant.createParticipant(member, album1, ParticipantRole.HOST);
@@ -1052,12 +1056,36 @@ class AlbumServiceTest extends IntegrationTest {
                     Participant.createParticipant(member, album2, ParticipantRole.HOST);
             Participant participant3 =
                     Participant.createParticipant(member, album3, ParticipantRole.HOST);
-            participantRepository.saveAll(List.of(participant1, participant2, participant3));
+            Participant participant4 =
+                    Participant.createParticipant(member, album4, ParticipantRole.HOST);
+            Participant participant5 =
+                    Participant.createParticipant(member, album5, ParticipantRole.HOST);
+            participantRepository.saveAll(
+                    List.of(participant1, participant2, participant3, participant4, participant5));
+
+            // 15일 전에 시작되어 구독 중
+            Subscription subscription1 =
+                    Subscription.createSubscription(
+                            member, album3, LocalDateTime.now().minusDays(15));
+            // 15일 전에 시작되어 해지된 구독
+            Subscription subscription2 =
+                    Subscription.createSubscription(
+                            member, album4, LocalDateTime.now().minusDays(15));
+            subscription2.cancel();
+            // 만료된 구독
+            Subscription subscription3 =
+                    Subscription.createSubscription(
+                            member, album5, LocalDateTime.of(2025, 9, 1, 0, 0));
+            ReflectionTestUtils.setField(subscription3, "status", SubscriptionStatus.EXPIRED);
+            subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
 
             Favorites favorites1 = Favorites.createFavorites(participant1);
             Favorites favorites2 = Favorites.createFavorites(participant2);
             Favorites favorites3 = Favorites.createFavorites(participant3);
-            favoritesRepository.saveAll(List.of(favorites1, favorites2, favorites3));
+            Favorites favorites4 = Favorites.createFavorites(participant4);
+            Favorites favorites5 = Favorites.createFavorites(participant5);
+            favoritesRepository.saveAll(
+                    List.of(favorites1, favorites2, favorites3, favorites4, favorites5));
         }
 
         @Test
@@ -1065,19 +1093,19 @@ class AlbumServiceTest extends IntegrationTest {
             // given
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            AlbumType.PRO, null, null, 1, SortDirection.DESC);
+                            AlbumType.PRO, null, null, null, 1, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(
-                    () -> assertThat(response.content().get(0).albumId()).isEqualTo(3),
-                    () -> assertThat(response.content().get(0).type()).isEqualTo(AlbumType.PRO),
+                    () -> assertThat(response.content().getFirst().albumId()).isEqualTo(3),
+                    () -> assertThat(response.content().getFirst().type()).isEqualTo(AlbumType.PRO),
                     () ->
-                            assertThat(response.content().get(0).price())
+                            assertThat(response.content().getFirst().price())
                                     .isEqualTo(AlbumType.PRO.getPrice()),
                     () ->
                             assertThat(
                                             response.content()
-                                                    .get(0)
+                                                    .getFirst()
                                                     .createdAt()
                                                     .truncatedTo(ChronoUnit.MINUTES))
                                     .isEqualTo(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)),
@@ -1089,27 +1117,73 @@ class AlbumServiceTest extends IntegrationTest {
             // given
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            null, "title2", null, 1, SortDirection.DESC);
+                            null, null, "title2", null, 1, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(
-                    () -> assertThat(response.content().get(0).albumId()).isEqualTo(2),
-                    () -> assertThat(response.content().get(0).title()).isEqualTo("testTitle2"),
+                    () -> assertThat(response.content().getFirst().albumId()).isEqualTo(2),
+                    () -> assertThat(response.content().getFirst().title()).isEqualTo("testTitle2"),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
         @Test
-        void PRO_유형과_앨범_이름으로_필터링하면_조건을_모두_만족하는_앨범만_조회한다() {
+        void ACTIVE_구독_상태로_필터링하면_BASIC_앨범과_구독_중인_유료_앨범만_조회한다() {
             // given
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            AlbumType.PRO, "title3", null, 1, SortDirection.DESC);
+                            null, SubscriptionStatus.ACTIVE, null, null, 3, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(
-                    () -> assertThat(response.content().get(0).albumId()).isEqualTo(3),
-                    () -> assertThat(response.content().get(0).title()).isEqualTo("testTitle3"),
-                    () -> assertThat(response.content().get(0).type()).isEqualTo(AlbumType.PRO),
+                    () -> assertThat(response.content().getFirst().albumId()).isEqualTo(3),
+                    () -> assertThat(response.content().getFirst().type()).isEqualTo(AlbumType.PRO),
+                    () ->
+                            assertThat(response.content().getFirst().status())
+                                    .isEqualTo(SubscriptionStatus.ACTIVE),
+                    () -> assertThat(response.content().get(1).albumId()).isEqualTo(2),
+                    () -> assertThat(response.content().get(1).type()).isEqualTo(AlbumType.BASIC),
+                    () -> assertThat(response.content().get(1).status()).isEqualTo(null),
+                    () -> assertThat(response.content().get(2).albumId()).isEqualTo(1),
+                    () -> assertThat(response.content().get(2).type()).isEqualTo(AlbumType.BASIC),
+                    () -> assertThat(response.content().get(2).status()).isEqualTo(null),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void CANCELED_구독_상태로_필터링하면_해지되었지만_구독_중인_유료_앨범만_조회한다() {
+            // given
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, SubscriptionStatus.CANCELED, null, null, 3, SortDirection.DESC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().getFirst().albumId()).isEqualTo(4),
+                    () ->
+                            assertThat(response.content().getFirst().type())
+                                    .isEqualTo(AlbumType.PREMIUM),
+                    () ->
+                            assertThat(response.content().getFirst().status())
+                                    .isEqualTo(SubscriptionStatus.CANCELED),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void EXPIRED_구독_상태로_필터링하면_구독이_만료된_유료_앨범만_조회한다() {
+            // given
+            SliceResponse<AlbumListResponse> response =
+                    albumService.getParticipatingAlbumsByCondition(
+                            null, SubscriptionStatus.EXPIRED, null, null, 3, SortDirection.DESC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().getFirst().albumId()).isEqualTo(5),
+                    () ->
+                            assertThat(response.content().getFirst().type())
+                                    .isEqualTo(AlbumType.PREMIUM),
+                    () ->
+                            assertThat(response.content().getFirst().status())
+                                    .isEqualTo(SubscriptionStatus.EXPIRED),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -1118,14 +1192,14 @@ class AlbumServiceTest extends IntegrationTest {
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            null, null, null, 3, SortDirection.ASC);
+                            null, null, null, null, 5, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
                     () ->
                             assertThat(response.content())
                                     .extracting("albumId")
-                                    .containsExactly(1L, 2L, 3L),
+                                    .containsExactly(1L, 2L, 3L, 4L, 5L),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -1134,14 +1208,14 @@ class AlbumServiceTest extends IntegrationTest {
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            null, null, null, 3, SortDirection.DESC);
+                            null, null, null, null, 5, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
                     () ->
                             assertThat(response.content())
                                     .extracting("albumId")
-                                    .containsExactly(3L, 2L, 1L),
+                                    .containsExactly(5L, 4L, 3L, 2L, 1L),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -1150,11 +1224,11 @@ class AlbumServiceTest extends IntegrationTest {
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            null, null, null, 3, SortDirection.DESC);
+                            null, null, null, null, 5, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(response.content().size()).isEqualTo(3),
+                    () -> assertThat(response.content().size()).isEqualTo(5),
                     () -> assertThat(response.isLast()).isTrue());
         }
 
@@ -1163,7 +1237,7 @@ class AlbumServiceTest extends IntegrationTest {
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            null, null, null, 1, SortDirection.DESC);
+                            null, null, null, null, 1, SortDirection.DESC);
 
             // then
             Assertions.assertAll(
@@ -1176,12 +1250,13 @@ class AlbumServiceTest extends IntegrationTest {
             // given
             favoritesRepository.deleteAll();
             participantRepository.deleteAll();
+            subscriptionRepository.deleteAll();
             albumRepository.deleteAll();
 
             // when
             SliceResponse<AlbumListResponse> response =
                     albumService.getParticipatingAlbumsByCondition(
-                            null, null, null, 10, SortDirection.DESC);
+                            null, null, null, null, 10, SortDirection.DESC);
 
             // when & then
             Assertions.assertAll(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #218 

---
## 📌 작업 내용 및 특이사항
* 마이페이지의 앨범 관리에서 구독 상태(ACTIVE, CANCELED, EXPIRED)별로 앨범을 조회할 수 있는 기능을 추가했습니다.
* 기존 앨범 목록 조회 API의 필터링 조건과 구조가 유사하여, 해당 API 내부에 구독 상태 필터링 조건을 추가했습니다.
  * ACTIVE 상태는 BASIC 앨범과 구독 중인 유료 앨범을 모두 포함합니다.
  * CANCELED 상태는 해지되었지만 아직 이용 중인 유료 앨범만 조회됩니다. (플랜 필터링 없이 상태 기준으로만 조회)
  * EXPIRED 상태는 구독이 만료된 유료 앨범만 조회되며, 플랜별 필터링이 가능합니다.

---
## 📚 참고사항
* 현재는 앨범 유형과 관계없이 삭제 요청 시 모두 hard delete되고 있습니다.
* 다만, PRO, PREMIUM 앨범은 결제 내역 보존 필요로 인해 추후 하위 리소스만 제거하고 앨범 자체는 상태만 변경하는 soft delete 방식으로 전환하려고 합니다.
* 이에 따라 BASIC 앨범도 soft delete 방식으로 일괄 전환하는 것이 맞을지, 혹은 BASIC만 hard delete 방식으로 유지해도 괜찮을지에 대한 의견 부탁드립니다.
* 또한, 만료(EXPIRED) 상태 앨범 목록에 BASIC을 포함시키는 것이 적절한지도 함께 검토 부탁드립니다. (BASIC은 구독 개념이 없어 만료와는 무관한 상태이기 때문입니다.)
