### PR TITLE
refactor: 이미지 저장 단위 변경

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumInfoResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/dto/response/AlbumInfoResponse.java
@@ -4,26 +4,33 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import org.cherrypic.album.enums.AlbumType;
+import org.cherrypic.global.util.StorageUnitConverter;
 
 public record AlbumInfoResponse(
         @Schema(description = "앨범 제목", example = "맛집 탐방") String title,
         @Schema(description = "앨범 커버 사진 url", example = "https://example.jpg") String coverUrl,
         @Schema(description = "앨범 유형", example = "PRO") AlbumType type,
-        @Schema(description = "사용한 용량 (GB)", example = "2")
+        @Schema(description = "사용한 용량 (GB)", example = "2.4")
                 @JsonFormat(shape = JsonFormat.Shape.STRING)
-                BigDecimal capacityUsed,
-        @Schema(description = "총 용량 (GB)", example = "3") BigDecimal totalCapacity,
+                BigDecimal capacityUsedGb,
+        @Schema(description = "총 용량 (GB)", example = "3") BigDecimal totalCapacityGb,
         @Schema(description = "앨범 Host의 이름", example = "김OO") String hostName,
         @Schema(description = "앨범의 참여자 수", example = "6") Integer numOfParticipants) {
     public static AlbumInfoResponse of(
             String title,
             String coverUrl,
             AlbumType type,
-            BigDecimal capacityUsed,
-            BigDecimal totalCapacity,
+            BigDecimal capacityUsedMb,
+            BigDecimal totalCapacityMb,
             String hostName,
             Integer numOfParticipants) {
         return new AlbumInfoResponse(
-                title, coverUrl, type, capacityUsed, totalCapacity, hostName, numOfParticipants);
+                title,
+                coverUrl,
+                type,
+                StorageUnitConverter.mbToGb(capacityUsedMb),
+                StorageUnitConverter.mbToGb(totalCapacityMb),
+                hostName,
+                numOfParticipants);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/album/service/AlbumServiceImpl.java
@@ -207,8 +207,8 @@ public class AlbumServiceImpl implements AlbumService {
                 album.getTitle(),
                 album.getCoverUrl(),
                 album.getType(),
-                album.getCapacityGb(),
-                album.getType().getCapacityGb(),
+                album.getCapacityMb(),
+                album.getType().getCapacityMb(),
                 hostName,
                 numOfParticipants);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/AlbumImageUploadRequest.java
@@ -27,6 +27,6 @@ public record AlbumImageUploadRequest(
                     String md5Hashes,
             @Schema(description = "파일이 찍힌 시간, 정보가 없다면 null을 넣어주세요.") LocalDateTime generatedAt,
             @NotNull(message = "파일의 용량은 비워둘 수 없습니다.")
-                    @Schema(description = "업로드 하는 파일의 용량(GB)", example = "0.04")
-                    BigDecimal capacity) {}
+                    @Schema(description = "업로드 하는 파일의 용량(MB), 소수점 2자리 까지", example = "0.04")
+                    BigDecimal capacityMb) {}
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/TempAlbumImageUploadRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/request/TempAlbumImageUploadRequest.java
@@ -25,6 +25,6 @@ public record TempAlbumImageUploadRequest(
                     @Schema(description = "S3 업로드시 파일의 변형을 확인하기 위한 md5 해시")
                     String md5Hashes,
             @NotNull(message = "파일의 용량은 비워둘 수 없습니다.")
-                    @Schema(description = "업로드 하는 파일의 용량(GB)", example = "0.04")
-                    BigDecimal capacity) {}
+                    @Schema(description = "업로드 하는 파일의 용량(MB), 소수점 2자리까지", example = "0.04")
+                    BigDecimal capacityMb) {}
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -84,7 +84,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
     @Override
     public void bulkInsertImages(List<Image> images) {
         String sql =
-                "INSERT INTO image (album_id, member_id, url, capacity_gb, generated_at, created_at, updated_at) "
+                "INSERT INTO image (album_id, member_id, url, capacity_mb, generated_at, created_at, updated_at) "
                         + "VALUES (?, ?, ?, ?, ?, NOW(), NOW())";
 
         jdbcTemplate.batchUpdate(
@@ -95,7 +95,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                     ps.setLong(1, image.getAlbum().getId());
                     ps.setLong(2, image.getMemberId());
                     ps.setString(3, image.getUrl());
-                    ps.setBigDecimal(4, image.getCapacityMb()); // capacity_gb 추가
+                    ps.setBigDecimal(4, image.getCapacityMb());
                     ps.setObject(5, image.getGeneratedAt());
                 });
     }
@@ -103,7 +103,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
     @Override
     public void bulkInsertTempAlbumImages(List<TempAlbumImage> images) {
         String sql =
-                "INSERT INTO temp_album_image (temp_album_id, url, capacity_gb, created_at, updated_at) "
+                "INSERT INTO temp_album_image (temp_album_id, url, capacity_mb, created_at, updated_at) "
                         + "VALUES (?, ?, ?, NOW(), NOW())";
 
         jdbcTemplate.batchUpdate(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -95,7 +95,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                     ps.setLong(1, image.getAlbum().getId());
                     ps.setLong(2, image.getMemberId());
                     ps.setString(3, image.getUrl());
-                    ps.setBigDecimal(4, image.getCapacityGb()); // capacity_gb 추가
+                    ps.setBigDecimal(4, image.getCapacityMb()); // capacity_gb 추가
                     ps.setObject(5, image.getGeneratedAt());
                 });
     }
@@ -113,7 +113,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                 (ps, image) -> {
                     ps.setLong(1, image.getTempAlbum().getId());
                     ps.setString(2, image.getUrl());
-                    ps.setBigDecimal(3, image.getCapacityGb());
+                    ps.setBigDecimal(3, image.getCapacityMb());
                 });
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -222,7 +222,7 @@ public class ImageServiceImpl implements ImageService {
 
         album.decreaseCapacity(
                 images.stream()
-                        .map(Image::getCapacityGb)
+                        .map(Image::getCapacityMb)
                         .filter(Objects::nonNull)
                         .reduce(BigDecimal.ZERO, BigDecimal::add));
 
@@ -314,7 +314,7 @@ public class ImageServiceImpl implements ImageService {
 
         tempAlbum.decreaseCapacity(
                 tempAlbumImages.stream()
-                        .map(TempAlbumImage::getCapacityGb)
+                        .map(TempAlbumImage::getCapacityMb)
                         .filter(Objects::nonNull)
                         .reduce(BigDecimal.ZERO, BigDecimal::add));
 
@@ -376,8 +376,8 @@ public class ImageServiceImpl implements ImageService {
     }
 
     private void validateAlbumCapacity(Album album, BigDecimal uploadCapacity) {
-        BigDecimal maxCapacity = album.getType().getCapacityGb();
-        BigDecimal current = album.getCapacityGb();
+        BigDecimal maxCapacity = album.getType().getCapacityMb();
+        BigDecimal current = album.getCapacityMb();
         BigDecimal afterUpload = current.add(uploadCapacity);
 
         if (afterUpload.compareTo(maxCapacity) > 0) {
@@ -386,8 +386,8 @@ public class ImageServiceImpl implements ImageService {
     }
 
     private void validateTempAlbumCapacity(TempAlbum tempAlbum, BigDecimal uploadCapacity) {
-        BigDecimal maxCapacity = tempAlbum.getType().getCapacityGb();
-        BigDecimal current = tempAlbum.getCapacityGb();
+        BigDecimal maxCapacity = tempAlbum.getType().getCapacityMb();
+        BigDecimal current = tempAlbum.getCapacityMb();
         BigDecimal afterUpload = current.add(uploadCapacity);
 
         if (afterUpload.compareTo(maxCapacity) > 0) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -121,15 +121,15 @@ public class ImageServiceImpl implements ImageService {
         validateParticipantAuthority(currentMember.getId(), album.getId());
         validateSubscriptionNotExpired(album);
 
-        BigDecimal uploadCapacity =
+        BigDecimal uploadCapacityMb =
                 request.payloads().stream()
-                        .map(AlbumImageUploadRequest.Payload::capacity)
+                        .map(AlbumImageUploadRequest.Payload::capacityMb)
                         .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        validateAlbumCapacity(album, uploadCapacity);
+        validateAlbumCapacity(album, uploadCapacityMb);
         validateDistinctHashes(request);
 
-        album.increaseCapacity(uploadCapacity);
+        album.increaseCapacity(uploadCapacityMb);
 
         List<String> presignedUrls =
                 request.payloads().stream()
@@ -159,7 +159,7 @@ public class ImageServiceImpl implements ImageService {
                                             req.generatedAt() != null
                                                     ? req.generatedAt()
                                                     : LocalDateTime.now(),
-                                            req.capacity());
+                                            req.capacityMb());
                                 })
                         .toList();
 
@@ -242,15 +242,15 @@ public class ImageServiceImpl implements ImageService {
 
         validateTempAlbumOwner(tempAlbum, currentMember);
 
-        BigDecimal uploadCapacity =
+        BigDecimal uploadCapacityMb =
                 request.payloads().stream()
-                        .map(TempAlbumImageUploadRequest.Payload::capacity)
+                        .map(TempAlbumImageUploadRequest.Payload::capacityMb)
                         .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        validateTempAlbumCapacity(tempAlbum, uploadCapacity);
+        validateTempAlbumCapacity(tempAlbum, uploadCapacityMb);
         validateDistinctHashes(request);
 
-        tempAlbum.increaseCapacity(uploadCapacity);
+        tempAlbum.increaseCapacity(uploadCapacityMb);
 
         List<String> presignedUrls =
                 request.payloads().stream()
@@ -275,7 +275,7 @@ public class ImageServiceImpl implements ImageService {
                                             presignedUrl.substring(0, presignedUrl.indexOf("?"));
 
                                     return TempAlbumImage.createTempAlbumImage(
-                                            tempAlbum, objectUrl, req.capacity());
+                                            tempAlbum, objectUrl, req.capacityMb());
                                 })
                         .toList();
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/response/TempAlbumCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/response/TempAlbumCreateResponse.java
@@ -3,6 +3,7 @@ package org.cherrypic.domain.tempalbum.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import org.cherrypic.global.util.StorageUnitConverter;
 import org.cherrypic.tempalbum.entity.TempAlbum;
 import org.cherrypic.tempalbum.enums.TempAlbumType;
 
@@ -18,7 +19,7 @@ public record TempAlbumCreateResponse(
                 tempAlbum.getId(),
                 tempAlbum.getMember().getId(),
                 tempAlbum.getTitle(),
-                tempAlbum.getCapacityMb(),
+                StorageUnitConverter.mbToGb(tempAlbum.getCapacityMb()),
                 tempAlbum.getType(),
                 tempAlbum.getExpiredAt());
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/response/TempAlbumCreateResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/response/TempAlbumCreateResponse.java
@@ -18,7 +18,7 @@ public record TempAlbumCreateResponse(
                 tempAlbum.getId(),
                 tempAlbum.getMember().getId(),
                 tempAlbum.getTitle(),
-                tempAlbum.getCapacityGb(),
+                tempAlbum.getCapacityMb(),
                 tempAlbum.getType(),
                 tempAlbum.getExpiredAt());
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/StorageUnitConverter.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/StorageUnitConverter.java
@@ -9,7 +9,7 @@ public class StorageUnitConverter {
 
     public static BigDecimal mbToGb(BigDecimal mb) {
         if (mb == null) {
-            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+            return BigDecimal.ZERO;
         }
         return mb.divide(MB_IN_GB, 2, RoundingMode.HALF_UP);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/global/util/StorageUnitConverter.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/util/StorageUnitConverter.java
@@ -1,0 +1,16 @@
+package org.cherrypic.global.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class StorageUnitConverter {
+
+    private static final BigDecimal MB_IN_GB = BigDecimal.valueOf(1024);
+
+    public static BigDecimal mbToGb(BigDecimal mb) {
+        if (mb == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+        return mb.divide(MB_IN_GB, 2, RoundingMode.HALF_UP);
+    }
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/controller/AlbumControllerTest.java
@@ -949,7 +949,7 @@ class AlbumControllerTest {
                             "testUrl",
                             AlbumType.BASIC,
                             new BigDecimal("0.00"),
-                            new BigDecimal("3"),
+                            new BigDecimal("3.00"),
                             "testNickname",
                             1);
             given(albumService.getAlbum(1L)).willReturn(response);
@@ -963,8 +963,8 @@ class AlbumControllerTest {
                     .andExpect(jsonPath("$.data.title").value("testAlbum"))
                     .andExpect(jsonPath("$.data.coverUrl").value("testUrl"))
                     .andExpect(jsonPath("$.data.type").value("BASIC"))
-                    .andExpect(jsonPath("$.data.capacityUsed").value("0.00"))
-                    .andExpect(jsonPath("$.data.totalCapacity").value("3"))
+                    .andExpect(jsonPath("$.data.capacityUsedGb").value("0.00"))
+                    .andExpect(jsonPath("$.data.totalCapacityGb").value(3.00))
                     .andExpect(jsonPath("$.data.hostName").value("testNickname"))
                     .andExpect(jsonPath("$.data.numOfParticipants").value(1));
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/album/service/AlbumServiceTest.java
@@ -969,6 +969,7 @@ class AlbumServiceTest extends IntegrationTest {
             Album album1 = Album.createAlbum("testAlbum1", "testURL1", AlbumType.BASIC, false);
             Album album2 = Album.createAlbum("testAlbum2", "testURL2", AlbumType.BASIC, false);
             Album album3 = Album.createAlbum("testAlbum3", "testURL3", AlbumType.BASIC, false);
+            album1.increaseCapacity(new BigDecimal(1024));
             albumRepository.saveAll(List.of(album1, album2, album3));
 
             Participant participant1 =
@@ -989,16 +990,16 @@ class AlbumServiceTest extends IntegrationTest {
                             "title",
                             "coverUrl",
                             "type",
-                            "capacityUsed",
-                            "totalCapacity",
+                            "capacityUsedGb",
+                            "totalCapacityGb",
                             "hostName",
                             "numOfParticipants")
                     .containsExactly(
                             "testAlbum1",
                             "testURL1",
                             AlbumType.BASIC,
-                            new BigDecimal("0.00"),
-                            new BigDecimal("3"),
+                            new BigDecimal("1.00"),
+                            new BigDecimal("3.00"),
                             "testNickname",
                             1);
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -21,6 +21,7 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
 import org.cherrypic.s3.enums.FileExtension;
+import org.cherrypic.tempalbum.enums.TempAlbumType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1305,9 +1306,11 @@ class ImageControllerTest {
                     new TempAlbumImageUploadRequest(
                             List.of(
                                     new TempAlbumImageUploadRequest.Payload(
-                                            FileExtension.JPEG, "testMd5Hash1", BigDecimal.TEN),
+                                            FileExtension.JPEG,
+                                            "testMd5Hash1",
+                                            TempAlbumType.DEFAULT.getCapacityMb()),
                                     new TempAlbumImageUploadRequest.Payload(
-                                            FileExtension.JPEG, "testMd5Hash2", BigDecimal.TEN)));
+                                            FileExtension.JPEG, "testMd5Hash2", BigDecimal.ONE)));
 
             given(imageService.createTempAlbumImageUploadUrls(1L, request))
                     .willThrow(

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -787,7 +787,7 @@ class ImageServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(imageRepository.findAllById(List.of(1L, 2L))).isEmpty(),
                     () ->
-                            assertThat(albumRepository.findById(1L).orElseThrow().getCapacityGb())
+                            assertThat(albumRepository.findById(1L).orElseThrow().getCapacityMb())
                                     .isEqualTo(new BigDecimal("0.00")),
                     () -> assertThat(eventImageRepository.findById(1L).isPresent()).isFalse());
         }
@@ -1066,7 +1066,7 @@ class ImageServiceTest extends IntegrationTest {
                                             tempAlbumRepository
                                                     .findById(1L)
                                                     .orElseThrow()
-                                                    .getCapacityGb())
+                                                    .getCapacityMb())
                                     .isEqualTo(new BigDecimal("0.40")));
         }
 

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -46,6 +46,7 @@ import org.cherrypic.subscription.entity.Subscription;
 import org.cherrypic.subscription.enums.SubscriptionStatus;
 import org.cherrypic.tempalbum.entity.TempAlbum;
 import org.cherrypic.tempalbum.entity.TempAlbumImage;
+import org.cherrypic.tempalbum.enums.TempAlbumType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -478,12 +479,12 @@ class ImageServiceTest extends IntegrationTest {
                                             FileExtension.JPEG,
                                             "testMd5Hash1",
                                             LocalDateTime.now(),
-                                            BigDecimal.TEN),
+                                            AlbumType.BASIC.getCapacityMb()),
                                     new AlbumImageUploadRequest.Payload(
                                             FileExtension.JPEG,
                                             "testMd5Hash2",
                                             LocalDateTime.now(),
-                                            BigDecimal.TEN)));
+                                            BigDecimal.ONE)));
 
             // when & then
             assertThatThrownBy(() -> imageService.createAlbumImageUploadUrls(1L, request))
@@ -991,9 +992,11 @@ class ImageServiceTest extends IntegrationTest {
                     new TempAlbumImageUploadRequest(
                             List.of(
                                     new TempAlbumImageUploadRequest.Payload(
-                                            FileExtension.JPEG, "testMd5Hash1", BigDecimal.TEN),
+                                            FileExtension.JPEG,
+                                            "testMd5Hash1",
+                                            TempAlbumType.DEFAULT.getCapacityMb()),
                                     new TempAlbumImageUploadRequest.Payload(
-                                            FileExtension.JPEG, "testMd5Hash2", BigDecimal.TEN)));
+                                            FileExtension.JPEG, "testMd5Hash2", BigDecimal.ONE)));
 
             // when & then
             assertThatThrownBy(() -> imageService.createTempAlbumImageUploadUrls(1L, request))

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
@@ -62,7 +62,7 @@ public class TempAlbumServiceTest extends IntegrationTest {
             TempAlbum tempAlbum = tempAlbumRepository.findById(1L).orElseThrow();
 
             assertThat(tempAlbum)
-                    .extracting("member.id", "title", "capacityGb", "type", "expiredAt", "webUrl")
+                    .extracting("member.id", "title", "capacityMb", "type", "expiredAt", "webUrl")
                     .containsExactly(
                             1L,
                             "testTitle",

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -78,10 +78,13 @@ public class Album extends BaseTimeEntity {
     }
 
     public void increaseCapacity(BigDecimal decimal) {
-        if (this.capacityMb.add(decimal).compareTo(BigDecimal.valueOf(9999999.99)) > 0) {
+        BigDecimal newCapacity = this.capacityMb.add(decimal);
+
+        if (newCapacity.compareTo(this.type.getCapacityMb()) > 0) {
             throw new CustomException(AlbumDomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT);
         }
-        this.capacityMb = capacityMb.add(decimal);
+
+        this.capacityMb = newCapacity;
     }
 
     public void decreaseCapacity(BigDecimal decimal) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/entity/Album.java
@@ -34,7 +34,7 @@ public class Album extends BaseTimeEntity {
 
     @NotNull private Boolean permissionControl;
 
-    @NotNull private BigDecimal capacityGb;
+    @NotNull private BigDecimal capacityMb;
 
     @OneToMany(mappedBy = "album", cascade = CascadeType.PERSIST)
     private List<Participant> participants = new ArrayList<>();
@@ -45,12 +45,12 @@ public class Album extends BaseTimeEntity {
             String coverUrl,
             AlbumType type,
             boolean permissionControl,
-            BigDecimal capacityGb) {
+            BigDecimal capacityMb) {
         this.title = title;
         this.coverUrl = coverUrl;
         this.type = type;
         this.permissionControl = permissionControl;
-        this.capacityGb = capacityGb;
+        this.capacityMb = capacityMb;
     }
 
     public static Album createAlbum(
@@ -60,7 +60,7 @@ public class Album extends BaseTimeEntity {
                 .coverUrl(coverUrl)
                 .type(type)
                 .permissionControl(permissionControl)
-                .capacityGb(BigDecimal.ZERO)
+                .capacityMb(BigDecimal.ZERO)
                 .build();
     }
 
@@ -78,16 +78,16 @@ public class Album extends BaseTimeEntity {
     }
 
     public void increaseCapacity(BigDecimal decimal) {
-        if (this.capacityGb.add(decimal).compareTo(BigDecimal.valueOf(9999.99)) > 0) {
+        if (this.capacityMb.add(decimal).compareTo(BigDecimal.valueOf(9999999.99)) > 0) {
             throw new CustomException(AlbumDomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT);
         }
-        this.capacityGb = capacityGb.add(decimal);
+        this.capacityMb = capacityMb.add(decimal);
     }
 
     public void decreaseCapacity(BigDecimal decimal) {
-        if (this.capacityGb.subtract(decimal).compareTo(BigDecimal.ZERO) < 0) {
+        if (this.capacityMb.subtract(decimal).compareTo(BigDecimal.ZERO) < 0) {
             throw new CustomException(AlbumDomainErrorCode.ALBUM_CAPACITY_DECREASE_UNDER_ZERO);
         }
-        this.capacityGb = capacityGb.subtract(decimal);
+        this.capacityMb = capacityMb.subtract(decimal);
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumType.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/enums/AlbumType.java
@@ -6,15 +6,16 @@ import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/** BASIC : 3GB PRO : 200GB PREMIUM : 2TB */
 @Getter
 @AllArgsConstructor
 public enum AlbumType {
-    BASIC(0, new BigDecimal("3"), 10),
-    PRO(5900, new BigDecimal("200"), 50),
-    PREMIUM(12900, new BigDecimal("2048"), Integer.MAX_VALUE);
+    BASIC(0, new BigDecimal("3072"), 10),
+    PRO(5900, new BigDecimal("204800"), 50),
+    PREMIUM(12900, new BigDecimal("2097152"), Integer.MAX_VALUE);
 
     private final int price;
-    private final BigDecimal capacityGb;
+    private final BigDecimal capacityMb;
     private final int maxParticipants;
 
     @JsonCreator

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/exception/AlbumDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/exception/AlbumDomainErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum AlbumDomainErrorCode implements BaseErrorCode {
-    ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "앨범 용량은 7자리 MB 초과로 늘릴 수 없습니다"),
+    ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "앨범의 용량을 초과했습니다."),
     ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "앨범 용량은 0MB 미만으로 줄일 수 없습니다.");
 
     private final int status;

--- a/cherrypic-domain/src/main/java/org/cherrypic/album/exception/AlbumDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/album/exception/AlbumDomainErrorCode.java
@@ -7,8 +7,8 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum AlbumDomainErrorCode implements BaseErrorCode {
-    ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "앨범 용량은 9999GB 초과로 늘릴 수 없습니다"),
-    ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "앨범 용량은 0GB 미만으로 줄일 수 없습니다.");
+    ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "앨범 용량은 7자리 MB 초과로 늘릴 수 없습니다"),
+    ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "앨범 용량은 0MB 미만으로 줄일 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -28,7 +28,7 @@ public class Image extends BaseTimeEntity {
 
     @NotNull private String url;
 
-    @NotNull private BigDecimal capacityGb;
+    @NotNull private BigDecimal capacityMb;
 
     private LocalDateTime generatedAt;
 
@@ -38,12 +38,12 @@ public class Image extends BaseTimeEntity {
             Long memberId,
             String url,
             LocalDateTime generatedAt,
-            BigDecimal capacityGb) {
+            BigDecimal capacityMb) {
         this.album = album;
         this.memberId = memberId;
         this.url = url;
         this.generatedAt = generatedAt;
-        this.capacityGb = capacityGb;
+        this.capacityMb = capacityMb;
     }
 
     public static Image createImage(
@@ -51,13 +51,13 @@ public class Image extends BaseTimeEntity {
             Long memberId,
             String url,
             LocalDateTime generatedAt,
-            BigDecimal capacityGb) {
+            BigDecimal capacityMb) {
         return Image.builder()
                 .album(album)
                 .memberId(memberId)
                 .url(url)
                 .generatedAt(generatedAt)
-                .capacityGb(capacityGb)
+                .capacityMb(capacityMb)
                 .build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbum.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbum.java
@@ -64,11 +64,14 @@ public class TempAlbum extends BaseTimeEntity {
     }
 
     public void increaseCapacity(BigDecimal decimal) {
-        if (this.capacityMb.add(decimal).compareTo(BigDecimal.valueOf(9999.99)) > 0) {
+        BigDecimal newCapacity = this.capacityMb.add(decimal);
+
+        if (newCapacity.compareTo(this.type.getCapacityMb()) > 0) {
             throw new CustomException(
                     TempAlbumDomainErrorCode.TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT);
         }
-        this.capacityMb = capacityMb.add(decimal);
+
+        this.capacityMb = newCapacity;
     }
 
     public void decreaseCapacity(BigDecimal decimal) {

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbum.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbum.java
@@ -29,7 +29,7 @@ public class TempAlbum extends BaseTimeEntity {
 
     @NotNull private String title;
 
-    @NotNull private BigDecimal capacityGb;
+    @NotNull private BigDecimal capacityMb;
 
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -43,12 +43,12 @@ public class TempAlbum extends BaseTimeEntity {
     private TempAlbum(
             Member member,
             String title,
-            BigDecimal capacityGb,
+            BigDecimal capacityMb,
             TempAlbumType type,
             LocalDate expiredAt) {
         this.member = member;
         this.title = title;
-        this.capacityGb = capacityGb;
+        this.capacityMb = capacityMb;
         this.type = type;
         this.expiredAt = expiredAt;
     }
@@ -57,25 +57,25 @@ public class TempAlbum extends BaseTimeEntity {
         return TempAlbum.builder()
                 .member(member)
                 .title(title)
-                .capacityGb(BigDecimal.ZERO)
+                .capacityMb(BigDecimal.ZERO)
                 .type(TempAlbumType.DEFAULT)
                 .expiredAt(LocalDate.now().plusDays(TempAlbumType.DEFAULT.getDaysToLive()))
                 .build();
     }
 
     public void increaseCapacity(BigDecimal decimal) {
-        if (this.capacityGb.add(decimal).compareTo(BigDecimal.valueOf(9999.99)) > 0) {
+        if (this.capacityMb.add(decimal).compareTo(BigDecimal.valueOf(9999.99)) > 0) {
             throw new CustomException(
                     TempAlbumDomainErrorCode.TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT);
         }
-        this.capacityGb = capacityGb.add(decimal);
+        this.capacityMb = capacityMb.add(decimal);
     }
 
     public void decreaseCapacity(BigDecimal decimal) {
-        if (this.capacityGb.subtract(decimal).compareTo(BigDecimal.ZERO) < 0) {
+        if (this.capacityMb.subtract(decimal).compareTo(BigDecimal.ZERO) < 0) {
             throw new CustomException(
                     TempAlbumDomainErrorCode.TEMP_ALBUM_CAPACITY_DECREASE_UNDER_ZERO);
         }
-        this.capacityGb = capacityGb.subtract(decimal);
+        this.capacityMb = capacityMb.subtract(decimal);
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbumImage.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbumImage.java
@@ -24,21 +24,21 @@ public class TempAlbumImage extends BaseTimeEntity {
 
     @NotNull private String url;
 
-    @NotNull private BigDecimal capacityGb;
+    @NotNull private BigDecimal capacityMb;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private TempAlbumImage(TempAlbum tempAlbum, String url, BigDecimal capacityGb) {
+    private TempAlbumImage(TempAlbum tempAlbum, String url, BigDecimal capacityMb) {
         this.tempAlbum = tempAlbum;
         this.url = url;
-        this.capacityGb = capacityGb;
+        this.capacityMb = capacityMb;
     }
 
     public static TempAlbumImage createTempAlbumImage(
-            TempAlbum tempAlbum, String url, BigDecimal capacityGb) {
+            TempAlbum tempAlbum, String url, BigDecimal capacityMb) {
         return TempAlbumImage.builder()
                 .tempAlbum(tempAlbum)
                 .url(url)
-                .capacityGb(capacityGb)
+                .capacityMb(capacityMb)
                 .build();
     }
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/enums/TempAlbumType.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/enums/TempAlbumType.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum TempAlbumType {
-    DEFAULT(BigDecimal.ONE, 3);
+    DEFAULT(new BigDecimal(1024), 3);
 
-    private final BigDecimal capacityGb;
+    private final BigDecimal capacityMb;
     private final int daysToLive;
 }

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/exception/TempAlbumDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/exception/TempAlbumDomainErrorCode.java
@@ -7,7 +7,7 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum TempAlbumDomainErrorCode implements BaseErrorCode {
-    TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "임시 앨범 용량은 7자리 이상 MB 초과로 늘릴 수 없습니다"),
+    TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "임시 앨범의 용량을 초과했습니다."),
     TEMP_ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "임시 앨범 용량은 0MB 미만으로 줄일 수 없습니다.");
 
     private final int status;

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/exception/TempAlbumDomainErrorCode.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/exception/TempAlbumDomainErrorCode.java
@@ -7,8 +7,8 @@ import org.cherrypic.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum TempAlbumDomainErrorCode implements BaseErrorCode {
-    TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "임시 앨범 용량은 9999GB 초과로 늘릴 수 없습니다"),
-    TEMP_ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "임시 앨범 용량은 0GB 미만으로 줄일 수 없습니다.");
+    TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT(400, "임시 앨범 용량은 7자리 이상 MB 초과로 늘릴 수 없습니다"),
+    TEMP_ALBUM_CAPACITY_DECREASE_UNDER_ZERO(400, "임시 앨범 용량은 0MB 미만으로 줄일 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -19,7 +19,7 @@ CREATE TABLE album (
                        cover_url VARCHAR(255),
                        type VARCHAR(20) NOT NULL CHECK (type IN ('BASIC','PRO','PREMIUM')),
                        permission_control BOOLEAN NOT NULL,
-                       capacity_gb DECIMAL(6,2) NOT NULL,
+                       capacity_mb DECIMAL(9,2) NOT NULL,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL
 );
@@ -96,7 +96,7 @@ CREATE TABLE image (
                        album_id BIGINT NOT NULL,
                        url VARCHAR(255) NOT NULL,
                        generated_at DATETIME,
-                       capacity_gb DECIMAL(6,2) NOT NULL,
+                       capacity_mb DECIMAL(9,2) NOT NULL,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,
                        CONSTRAINT fk_image_album FOREIGN KEY (album_id) REFERENCES album (id)

--- a/cherrypic-domain/src/main/resources/db/migration/V3__create_temp_album_and_temp_album_image_table.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V3__create_temp_album_and_temp_album_image_table.sql
@@ -2,7 +2,7 @@ CREATE TABLE temp_album (
                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
                             member_id BIGINT NOT NULL,
                             title VARCHAR(20) NOT NULL,
-                            capacity_mb DECIMAL(9,2) NOT NULL,
+                            capacity_mb DECIMAL(6,2) NOT NULL,
                             type VARCHAR(20) NOT NULL CHECK (type IN ('DEFAULT')),
                             expired_at DATE NOT NULL,
                             web_url VARCHAR(255),
@@ -16,7 +16,7 @@ CREATE TABLE temp_album_image (
                                   id BIGINT AUTO_INCREMENT PRIMARY KEY,
                                   temp_album_id BIGINT NOT NULL,
                                   url VARCHAR(255) NOT NULL,
-                                  capacity_mb DECIMAL(9,2) NOT NULL,
+                                  capacity_mb DECIMAL(6,2) NOT NULL,
                                   created_at DATETIME(6) NOT NULL,
                                   updated_at DATETIME(6) NOT NULL,
                                   CONSTRAINT fk_temp_album FOREIGN KEY (temp_album_id) REFERENCES temp_album(id)

--- a/cherrypic-domain/src/main/resources/db/migration/V3__create_temp_album_and_temp_album_image_table.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V3__create_temp_album_and_temp_album_image_table.sql
@@ -2,7 +2,7 @@ CREATE TABLE temp_album (
                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
                             member_id BIGINT NOT NULL,
                             title VARCHAR(20) NOT NULL,
-                            capacity_gb DECIMAL(6,2) NOT NULL,
+                            capacity_mb DECIMAL(9,2) NOT NULL,
                             type VARCHAR(20) NOT NULL CHECK (type IN ('DEFAULT')),
                             expired_at DATE NOT NULL,
                             web_url VARCHAR(255),
@@ -16,7 +16,7 @@ CREATE TABLE temp_album_image (
                                   id BIGINT AUTO_INCREMENT PRIMARY KEY,
                                   temp_album_id BIGINT NOT NULL,
                                   url VARCHAR(255) NOT NULL,
-                                  capacity_gb DECIMAL(6,2) NOT NULL,
+                                  capacity_mb DECIMAL(9,2) NOT NULL,
                                   created_at DATETIME(6) NOT NULL,
                                   updated_at DATETIME(6) NOT NULL,
                                   CONSTRAINT fk_temp_album FOREIGN KEY (temp_album_id) REFERENCES temp_album(id)

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/album/AlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/album/AlbumTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 class AlbumTest {
 
     @Test
-    void 용량을_7자리_MB_이상으로_늘릴_경우_예외가_발생한다() {
+    void 앨범_용량을_초과해서_늘릴_경우_예외가_발생한다() {
         // given
         Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumType.BASIC, false);
 
         // when & then
-        assertThatThrownBy(() -> album.increaseCapacity(BigDecimal.valueOf(12345678)))
+        assertThatThrownBy(() -> album.increaseCapacity(BigDecimal.valueOf(3073)))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(AlbumDomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT.getMessage());
     }

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/album/AlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/album/AlbumTest.java
@@ -12,18 +12,18 @@ import org.junit.jupiter.api.Test;
 class AlbumTest {
 
     @Test
-    void 용량을_4자리_GB_이상으로_늘릴_경우_예외가_발생한다() {
+    void 용량을_7자리_MB_이상으로_늘릴_경우_예외가_발생한다() {
         // given
         Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumType.BASIC, false);
 
         // when & then
-        assertThatThrownBy(() -> album.increaseCapacity(BigDecimal.valueOf(10000)))
+        assertThatThrownBy(() -> album.increaseCapacity(BigDecimal.valueOf(12345678)))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(AlbumDomainErrorCode.ALBUM_CAPACITY_INCREASE_OVER_LIMIT.getMessage());
     }
 
     @Test
-    void 용량을_0GB_미만으로_줄일_경우_예외가_발생한다() {
+    void 용량을_0MB_미만으로_줄일_경우_예외가_발생한다() {
         // given
         Album album = Album.createAlbum("testTitle", "testCoverUrl", AlbumType.BASIC, false);
 

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/tempalbum/TempAlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/tempalbum/TempAlbumTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class TempAlbumTest {
 
     @Test
-    void 용량을_4자리_GB_이상으로_늘릴_경우_예외가_발생한다() {
+    void 용량을_7자리_MB_이상으로_늘릴_경우_예외가_발생한다() {
         // given
         Member member =
                 Member.createMember(
@@ -23,7 +23,7 @@ class TempAlbumTest {
         TempAlbum tempAlbum = TempAlbum.createTempAlbum(member, "testTitle");
 
         // when & then
-        assertThatThrownBy(() -> tempAlbum.increaseCapacity(BigDecimal.valueOf(10000)))
+        assertThatThrownBy(() -> tempAlbum.increaseCapacity(BigDecimal.valueOf(12345678)))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(
                         TempAlbumDomainErrorCode.TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT
@@ -31,7 +31,7 @@ class TempAlbumTest {
     }
 
     @Test
-    void 용량을_0GB_미만으로_줄일_경우_예외가_발생한다() {
+    void 용량을_0MB_미만으로_줄일_경우_예외가_발생한다() {
         // given
         Member member =
                 Member.createMember(

--- a/cherrypic-domain/src/test/java/org/cherrypic/album/entity/tempalbum/TempAlbumTest.java
+++ b/cherrypic-domain/src/test/java/org/cherrypic/album/entity/tempalbum/TempAlbumTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class TempAlbumTest {
 
     @Test
-    void 용량을_7자리_MB_이상으로_늘릴_경우_예외가_발생한다() {
+    void 임시_앨범_용량을_초과해서_늘릴_경우_예외가_발생한다() {
         // given
         Member member =
                 Member.createMember(
@@ -23,7 +23,7 @@ class TempAlbumTest {
         TempAlbum tempAlbum = TempAlbum.createTempAlbum(member, "testTitle");
 
         // when & then
-        assertThatThrownBy(() -> tempAlbum.increaseCapacity(BigDecimal.valueOf(12345678)))
+        assertThatThrownBy(() -> tempAlbum.increaseCapacity(BigDecimal.valueOf(1025)))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(
                         TempAlbumDomainErrorCode.TEMP_ALBUM_CAPACITY_INCREASE_OVER_LIMIT


### PR DESCRIPTION
## 🌱 관련 이슈
- close #226 

---
## 📌 작업 내용 및 특이사항
- 이미지 저장 단위를 MB 단위로 변경했습니다.
- 단, 앨범 정보를 보여주는 경우 GB를 환산하여 보여줍니다.