### PR TITLE
feat: 결제 준비 응답에 다음 결제일 필드 추가

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/dto/response/PaymentReadyResponse.java
@@ -1,6 +1,8 @@
 package org.cherrypic.domain.payment.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import org.cherrypic.album.enums.AlbumType;
 import org.cherrypic.payment.enums.PaymentPurpose;
 
@@ -10,13 +12,21 @@ public record PaymentReadyResponse(
         @Schema(description = "결제 요청 고유 ID", example = "album_20250723_pro_1_c4f1a2b3d5e6")
                 String merchantUid,
         @Schema(description = "구매자 이름", example = "최현태") String buyerName,
-        @Schema(description = "결제 목적", example = "RENEWAL") PaymentPurpose purpose) {
+        @Schema(description = "결제 목적", example = "RENEWAL") PaymentPurpose purpose,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "다음 결제일", example = "2024-09-21")
+                LocalDateTime nextBillingAt) {
     public static PaymentReadyResponse of(
             AlbumType type,
             Integer price,
             String merchantUid,
             String buyerName,
-            PaymentPurpose purpose) {
-        return new PaymentReadyResponse(type, price, merchantUid, buyerName, purpose);
+            PaymentPurpose purpose,
+            LocalDateTime nextBillingAt) {
+        return new PaymentReadyResponse(
+                type, price, merchantUid, buyerName, purpose, nextBillingAt);
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/payment/service/PaymentServiceImpl.java
@@ -6,6 +6,7 @@ import com.siot.IamportRestClient.request.CancelData;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
@@ -84,7 +85,9 @@ public class PaymentServiceImpl implements PaymentService {
         Payment payment = Payment.createPayment(currentMember, merchantUid, price, purpose, type);
         paymentRepository.save(payment);
 
-        return PaymentReadyResponse.of(type, price, merchantUid, buyerName, purpose);
+        LocalDateTime nextBillingAt = calculateNextBillingAt();
+
+        return PaymentReadyResponse.of(type, price, merchantUid, buyerName, purpose, nextBillingAt);
     }
 
     @Override
@@ -209,6 +212,18 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         throw new CustomException(PaymentErrorCode.DOWNGRADE_NOT_ALLOWED);
+    }
+
+    private LocalDateTime calculateNextBillingAt() {
+        LocalDateTime now = LocalDateTime.now();
+        boolean isAtEndOfMonth = now.getDayOfMonth() >= 28;
+
+        if (isAtEndOfMonth) {
+            YearMonth nextMonth = YearMonth.from(now.plusMonths(1));
+            return nextMonth.atEndOfMonth().atTime(now.toLocalTime());
+        }
+
+        return now.plusMonths(1);
     }
 
     private Album getAlbumById(Long albumId) {

--- a/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/payment/controller/PaymentControllerTest.java
@@ -66,7 +66,8 @@ class PaymentControllerTest {
                                 3900,
                                 "album_20250723_pro_1_a5c5dd8beaa6",
                                 "상냥한 너구리",
-                                PaymentPurpose.CREATION);
+                                PaymentPurpose.CREATION,
+                                LocalDateTime.of(2025, 9, 30, 0, 0));
 
                 given(paymentService.preparePayment(request)).willReturn(response);
 
@@ -86,7 +87,8 @@ class PaymentControllerTest {
                                 jsonPath("$.data.merchantUid")
                                         .value("album_20250723_pro_1_a5c5dd8beaa6"))
                         .andExpect(jsonPath("$.data.buyerName").value("상냥한 너구리"))
-                        .andExpect(jsonPath("$.data.purpose").value("CREATION"));
+                        .andExpect(jsonPath("$.data.purpose").value("CREATION"))
+                        .andExpect(jsonPath("$.data.nextBillingAt").value("2025-09-30"));
             }
         }
 
@@ -104,7 +106,8 @@ class PaymentControllerTest {
                                 5900,
                                 "album_20250723_pro_1_a5c5dd8beaa6",
                                 "상냥한 너구리",
-                                PaymentPurpose.RENEWAL);
+                                PaymentPurpose.RENEWAL,
+                                LocalDateTime.of(2025, 9, 30, 0, 0));
 
                 given(paymentService.preparePayment(request)).willReturn(response);
 
@@ -124,7 +127,8 @@ class PaymentControllerTest {
                                 jsonPath("$.data.merchantUid")
                                         .value("album_20250723_pro_1_a5c5dd8beaa6"))
                         .andExpect(jsonPath("$.data.buyerName").value("상냥한 너구리"))
-                        .andExpect(jsonPath("$.data.purpose").value("RENEWAL"));
+                        .andExpect(jsonPath("$.data.purpose").value("RENEWAL"))
+                        .andExpect(jsonPath("$.data.nextBillingAt").value("2025-09-30"));
             }
 
             @Test
@@ -254,7 +258,8 @@ class PaymentControllerTest {
                                 12900,
                                 "album_20250723_pro_1_a5c5dd8beaa6",
                                 "상냥한 너구리",
-                                PaymentPurpose.UPGRADE);
+                                PaymentPurpose.UPGRADE,
+                                LocalDateTime.of(2025, 9, 30, 0, 0));
 
                 given(paymentService.preparePayment(request)).willReturn(response);
 
@@ -274,7 +279,8 @@ class PaymentControllerTest {
                                 jsonPath("$.data.merchantUid")
                                         .value("album_20250723_pro_1_a5c5dd8beaa6"))
                         .andExpect(jsonPath("$.data.buyerName").value("상냥한 너구리"))
-                        .andExpect(jsonPath("$.data.purpose").value("UPGRADE"));
+                        .andExpect(jsonPath("$.data.purpose").value("UPGRADE"))
+                        .andExpect(jsonPath("$.data.nextBillingAt").value("2025-09-30"));
             }
 
             @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #227 

---
## 📌 작업 내용 및 특이사항
- 결제 준비 API 응답에 다음 결제일 필드를 추가했습니다.
- 결제 준비 시점을 기준으로 다음 결제일을 계산하며, 말일 결제의 경우 월말 보정을 적용합니다.
- 기존 구독 갱신 시점의 계산 방식과 동일한 로직을 사용합니다.