### PR TITLE
refactor: 촬영일 순 기반 필터링 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ sonarqube {
                 '**/*Dto*.java, **/*Request*.java, **/*Response*.java, **/*Exception*.java, **/*ErrorCode*.java, **/*Validator*.java,' +
                 '**/*FcmService*.java, **/EventImage.java, **/Notification.java, **/Favorites.java ,**/ImageEventListener.java,' +
                 '**/TempAlbum.java, **/TempAlbumImage.java, **/TempAlbumType.java, **/TempAlbumType.java, **/FileExtension.java,' +
-                '**/RefundTask.java, **/RefundTaskStatus.java, cherrypic-batch/**'
+                '**/RefundTask.java, **/RefundTaskStatus.java, cherrypic-batch/**, **/StorageUnitConverter.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ sonarqube {
                 '**/*Dto*.java, **/*Request*.java, **/*Response*.java, **/*Exception*.java, **/*ErrorCode*.java, **/*Validator*.java,' +
                 '**/*FcmService*.java, **/EventImage.java, **/Notification.java, **/Favorites.java ,**/ImageEventListener.java,' +
                 '**/TempAlbum.java, **/TempAlbumImage.java, **/TempAlbumType.java, **/TempAlbumType.java, **/FileExtension.java,' +
-                '**/RefundTask.java, **/RefundTaskStatus.java, cherrypic-batch/**, **/StorageUnitConverter.java, **/ImageRepositoryImpl'
+                '**/RefundTask.java, **/RefundTaskStatus.java, cherrypic-batch/**, **/StorageUnitConverter.java, **/ImageRepositoryImpl.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ sonarqube {
                 '**/*Dto*.java, **/*Request*.java, **/*Response*.java, **/*Exception*.java, **/*ErrorCode*.java, **/*Validator*.java,' +
                 '**/*FcmService*.java, **/EventImage.java, **/Notification.java, **/Favorites.java ,**/ImageEventListener.java,' +
                 '**/TempAlbum.java, **/TempAlbumImage.java, **/TempAlbumType.java, **/TempAlbumType.java, **/FileExtension.java,' +
-                '**/RefundTask.java, **/RefundTaskStatus.java, cherrypic-batch/**, **/StorageUnitConverter.java'
+                '**/RefundTask.java, **/RefundTaskStatus.java, cherrypic-batch/**, **/StorageUnitConverter.java, **/ImageRepositoryImpl'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -11,6 +11,7 @@ import org.cherrypic.domain.image.service.ImageService;
 import org.cherrypic.global.annotation.PageSize;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.global.pagination.SortParameter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -67,10 +68,13 @@ public class ImageController {
                     @RequestParam(required = false)
                     Long lastImageId,
             @Parameter(description = "페이지당 조회할 이미지의 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 파라미터 (UPLOAD: 업로드순, GENERATED: 촬용일순)")
+                    @RequestParam(defaultValue = "UPLOAD")
+                    SortParameter parameter,
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
-        return imageService.getAlbumImages(albumId, lastImageId, size, direction);
+        return imageService.getAlbumImages(albumId, lastImageId, size, parameter, direction);
     }
 
     @GetMapping("/events/{eventId}/images")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -68,7 +68,7 @@ public class ImageController {
                     @RequestParam(required = false)
                     Long lastImageId,
             @Parameter(description = "페이지당 조회할 이미지의 수") @RequestParam @PageSize Integer size,
-            @Parameter(description = "정렬 파라미터 (UPLOAD: 업로드순, GENERATED: 촬용일순)")
+            @Parameter(description = "정렬 파라미터 (UPLOAD: 업로드순, GENERATED: 촬영일순)")
                     @RequestParam(defaultValue = "UPLOAD")
                     SortParameter parameter,
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
@@ -85,7 +85,7 @@ public class ImageController {
                     @RequestParam(required = false)
                     Long lastEventImageId,
             @Parameter(description = "페이지당 조회할 이미지의 수") @RequestParam @PageSize Integer size,
-            @Parameter(description = "정렬 파라미터 (UPLOAD: 업로드순, GENERATED: 촬용일순)")
+            @Parameter(description = "정렬 파라미터 (UPLOAD: 업로드순, GENERATED: 촬영일순)")
                     @RequestParam(defaultValue = "UPLOAD")
                     SortParameter parameter,
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/controller/ImageController.java
@@ -85,10 +85,13 @@ public class ImageController {
                     @RequestParam(required = false)
                     Long lastEventImageId,
             @Parameter(description = "페이지당 조회할 이미지의 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 파라미터 (UPLOAD: 업로드순, GENERATED: 촬용일순)")
+                    @RequestParam(defaultValue = "UPLOAD")
+                    SortParameter parameter,
             @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
                     @RequestParam(defaultValue = "DESC")
                     SortDirection direction) {
-        return imageService.getEventImages(eventId, lastEventImageId, size, direction);
+        return imageService.getEventImages(eventId, lastEventImageId, size, parameter, direction);
     }
 
     @DeleteMapping("albums/{albumId}/images")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/AlbumImageListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/AlbumImageListResponse.java
@@ -1,9 +1,15 @@
 package org.cherrypic.domain.image.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record AlbumImageListResponse(
         @Schema(description = "이미지 ID", example = "1") Long imageId,
         @Schema(description = "이미지 url", example = "https://example.jpg") String imageUrl,
-        @Schema(description = "필터링 기준 날짜", example = "2025-10-01") LocalDate date) {}
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "필터링 기준 날짜", example = "2025-10-01")
+                LocalDateTime date) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/AlbumImageListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/AlbumImageListResponse.java
@@ -1,7 +1,9 @@
 package org.cherrypic.domain.image.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 
 public record AlbumImageListResponse(
         @Schema(description = "이미지 ID", example = "1") Long imageId,
-        @Schema(description = "이미지 url", example = "https://example.jpg") String imageUrl) {}
+        @Schema(description = "이미지 url", example = "https://example.jpg") String imageUrl,
+        @Schema(description = "필터링 기준 날짜", example = "2025-10-01") LocalDate date) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/EventImageListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/EventImageListResponse.java
@@ -1,9 +1,15 @@
 package org.cherrypic.domain.image.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record EventImageListResponse(
         @Schema(description = "이벤트 이미지 ID", example = "1") Long eventImageId,
         @Schema(description = "이벤트 이미지 url", example = "https://example.jpg") String imageUrl,
-        @Schema(description = "필터링 기준 날짜", example = "2025-10-01") LocalDate date) {}
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "필터링 기준 날짜", example = "2025-10-01")
+                LocalDateTime date) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/EventImageListResponse.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/dto/response/EventImageListResponse.java
@@ -1,7 +1,9 @@
 package org.cherrypic.domain.image.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 
 public record EventImageListResponse(
         @Schema(description = "이벤트 이미지 ID", example = "1") Long eventImageId,
-        @Schema(description = "이벤트 이미지 url", example = "https://example.jpg") String imageUrl) {}
+        @Schema(description = "이벤트 이미지 url", example = "https://example.jpg") String imageUrl,
+        @Schema(description = "필터링 기준 날짜", example = "2025-10-01") LocalDate date) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
@@ -11,7 +11,11 @@ import org.springframework.data.domain.Slice;
 
 public interface ImageRepositoryCustom {
     Slice<EventImageListResponse> findAllByEventId(
-            Long eventId, Long lastImageId, int size, SortDirection direction);
+            Long eventId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction);
 
     Slice<AlbumImageListResponse> findAllByAlbumId(
             Long albumId,

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryCustom.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.global.pagination.SortParameter;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.tempalbum.entity.TempAlbumImage;
 import org.springframework.data.domain.Slice;
@@ -13,7 +14,11 @@ public interface ImageRepositoryCustom {
             Long eventId, Long lastImageId, int size, SortDirection direction);
 
     Slice<AlbumImageListResponse> findAllByAlbumId(
-            Long albumId, Long lastImageId, int size, SortDirection direction);
+            Long albumId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction);
 
     List<Image> findAllUnmappedToEvent(Long eventId, List<Long> imageIds);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -53,7 +53,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                                 eventImage.event.id.eq(eventId),
                                 lastImageIdCondition(lastImageId, direction, parameter))
                         .orderBy(getOrderByExpression(parameter, direction))
-                        .limit(size + 1)
+                        .limit((long) size + 1)
                         .fetch()
                         .stream()
                         .map(
@@ -91,7 +91,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                                 image.album.id.eq(albumId),
                                 lastImageIdCondition(lastImageId, direction, parameter))
                         .orderBy(getOrderByExpression(parameter, direction))
-                        .limit(size + 1)
+                        .limit((long) size + 1)
                         .fetch()
                         .stream()
                         .map(
@@ -195,14 +195,6 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                 .where(image.url.in(urls))
                 .orderBy(orderExpr.asc())
                 .fetch();
-    }
-
-    private BooleanExpression lastImageIdCondition(Long imageId, SortDirection direction) {
-        if (imageId == null) {
-            return null;
-        }
-
-        return direction == SortDirection.DESC ? image.id.lt(imageId) : image.id.gt(imageId);
     }
 
     private BooleanExpression lastImageIdCondition(

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -4,12 +4,13 @@ import static org.cherrypic.event.entity.QEventImage.eventImage;
 import static org.cherrypic.image.entity.QImage.image;
 import static org.cherrypic.tempalbum.entity.QTempAlbumImage.tempAlbumImage;
 
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
@@ -39,14 +40,17 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
             SortParameter parameter,
             SortDirection direction) {
 
+        Expression<LocalDateTime> sortedField =
+                parameter == SortParameter.UPLOAD ? image.createdAt : image.generatedAt;
+
         List<EventImageListResponse> results =
                 queryFactory
                         .select(
-                                eventImage.id,
-                                image.url,
-                                parameter == SortParameter.UPLOAD
-                                        ? image.createdAt
-                                        : image.generatedAt)
+                                Projections.constructor(
+                                        EventImageListResponse.class,
+                                        eventImage.id,
+                                        image.url,
+                                        sortedField))
                         .from(eventImage)
                         .join(eventImage.image, image)
                         .where(
@@ -54,18 +58,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                                 lastImageIdCondition(lastImageId, direction, parameter))
                         .orderBy(getOrderByExpression(parameter, direction))
                         .limit((long) size + 1)
-                        .fetch()
-                        .stream()
-                        .map(
-                                tuple ->
-                                        new EventImageListResponse(
-                                                tuple.get(eventImage.id),
-                                                tuple.get(image.url),
-                                                parameter == SortParameter.UPLOAD
-                                                        ? tuple.get(image.createdAt).toLocalDate()
-                                                        : tuple.get(image.generatedAt)
-                                                                .toLocalDate()))
-                        .toList();
+                        .fetch();
 
         return checkLastPage(size, results);
     }
@@ -78,32 +71,24 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
             SortParameter parameter,
             SortDirection direction) {
 
+        Expression<LocalDateTime> sortedField =
+                parameter == SortParameter.UPLOAD ? image.createdAt : image.generatedAt;
+
         List<AlbumImageListResponse> results =
                 queryFactory
                         .select(
-                                image.id,
-                                image.url,
-                                parameter == SortParameter.UPLOAD
-                                        ? image.createdAt
-                                        : image.generatedAt)
+                                Projections.constructor(
+                                        AlbumImageListResponse.class,
+                                        image.id,
+                                        image.url,
+                                        sortedField))
                         .from(image)
                         .where(
                                 image.album.id.eq(albumId),
                                 lastImageIdCondition(lastImageId, direction, parameter))
                         .orderBy(getOrderByExpression(parameter, direction))
                         .limit((long) size + 1)
-                        .fetch()
-                        .stream()
-                        .map(
-                                tuple ->
-                                        new AlbumImageListResponse(
-                                                tuple.get(image.id),
-                                                tuple.get(image.url),
-                                                parameter == SortParameter.UPLOAD
-                                                        ? tuple.get(image.createdAt).toLocalDate()
-                                                        : tuple.get(image.generatedAt)
-                                                                .toLocalDate()))
-                        .toList();
+                        .fetch();
 
         return checkLastPage(size, results);
     }
@@ -206,13 +191,20 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
         if (parameter == SortParameter.UPLOAD) {
             return direction == SortDirection.DESC ? image.id.lt(imageId) : image.id.gt(imageId);
         } else { // GENERATED
-            LocalDate lastGeneratedDate = getLastGeneratedDate(imageId);
-            return direction == SortDirection.DESC
-                    ? Expressions.dateTimeTemplate(LocalDate.class, "DATE({0})", image.generatedAt)
-                            .lt(lastGeneratedDate)
-                    : Expressions.dateTimeTemplate(LocalDate.class, "DATE({0})", image.generatedAt)
-                            .gt(lastGeneratedDate);
+            LocalDateTime lastGeneratedAt = getLastGeneratedAt(imageId);
+            return lastGeneratedAtCondition(lastGeneratedAt, direction, parameter);
         }
+    }
+
+    private BooleanExpression lastGeneratedAtCondition(
+            LocalDateTime lastGeneratedAt, SortDirection direction, SortParameter parameter) {
+        if (lastGeneratedAt == null) {
+            return null;
+        }
+
+        return direction == SortDirection.DESC
+                ? image.generatedAt.lt(lastGeneratedAt)
+                : image.generatedAt.gt(lastGeneratedAt);
     }
 
     private com.querydsl.core.types.OrderSpecifier<?> getOrderByExpression(
@@ -226,11 +218,9 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
         }
     }
 
-    private LocalDate getLastGeneratedDate(Long imageId) {
+    private LocalDateTime getLastGeneratedAt(Long imageId) {
         return queryFactory
-                .select(
-                        Expressions.dateTimeTemplate(
-                                LocalDate.class, "DATE({0})", image.generatedAt))
+                .select(image.generatedAt)
                 .from(image)
                 .where(image.id.eq(imageId))
                 .fetchOne();

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -4,7 +4,6 @@ import static org.cherrypic.event.entity.QEventImage.eventImage;
 import static org.cherrypic.image.entity.QImage.image;
 import static org.cherrypic.tempalbum.entity.QTempAlbumImage.tempAlbumImage;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
@@ -34,21 +33,39 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
 
     @Override
     public Slice<EventImageListResponse> findAllByEventId(
-            Long eventId, Long lastImageId, int size, SortDirection direction) {
+            Long eventId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction) {
 
         List<EventImageListResponse> results =
                 queryFactory
                         .select(
-                                Projections.constructor(
-                                        EventImageListResponse.class, eventImage.id, image.url))
+                                eventImage.id,
+                                image.url,
+                                parameter == SortParameter.UPLOAD
+                                        ? image.createdAt
+                                        : image.generatedAt)
                         .from(eventImage)
                         .join(eventImage.image, image)
                         .where(
                                 eventImage.event.id.eq(eventId),
-                                lastImageIdCondition(lastImageId, direction))
-                        .orderBy(direction == SortDirection.DESC ? image.id.desc() : image.id.asc())
+                                lastImageIdCondition(lastImageId, direction, parameter))
+                        .orderBy(getOrderByExpression(parameter, direction))
                         .limit(size + 1)
-                        .fetch();
+                        .fetch()
+                        .stream()
+                        .map(
+                                tuple ->
+                                        new EventImageListResponse(
+                                                tuple.get(eventImage.id),
+                                                tuple.get(image.url),
+                                                parameter == SortParameter.UPLOAD
+                                                        ? tuple.get(image.createdAt).toLocalDate()
+                                                        : tuple.get(image.generatedAt)
+                                                                .toLocalDate()))
+                        .toList();
 
         return checkLastPage(size, results);
     }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -7,13 +7,16 @@ import static org.cherrypic.tempalbum.entity.QTempAlbumImage.tempAlbumImage;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.image.dto.response.AlbumImageListResponse;
 import org.cherrypic.domain.image.dto.response.EventImageListResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.global.pagination.SortParameter;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.tempalbum.entity.TempAlbumImage;
 import org.springframework.data.domain.PageRequest;
@@ -52,20 +55,38 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
 
     @Override
     public Slice<AlbumImageListResponse> findAllByAlbumId(
-            Long albumId, Long lastImageId, int size, SortDirection direction) {
+            Long albumId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction) {
 
         List<AlbumImageListResponse> results =
                 queryFactory
                         .select(
-                                Projections.constructor(
-                                        AlbumImageListResponse.class, image.id, image.url))
+                                image.id,
+                                image.url,
+                                parameter == SortParameter.UPLOAD
+                                        ? image.createdAt
+                                        : image.generatedAt)
                         .from(image)
                         .where(
                                 image.album.id.eq(albumId),
-                                lastImageIdCondition(lastImageId, direction))
-                        .orderBy(direction == SortDirection.DESC ? image.id.desc() : image.id.asc())
+                                lastImageIdCondition(lastImageId, direction, parameter))
+                        .orderBy(getOrderByExpression(parameter, direction))
                         .limit(size + 1)
-                        .fetch();
+                        .fetch()
+                        .stream()
+                        .map(
+                                tuple ->
+                                        new AlbumImageListResponse(
+                                                tuple.get(image.id),
+                                                tuple.get(image.url),
+                                                parameter == SortParameter.UPLOAD
+                                                        ? tuple.get(image.createdAt).toLocalDate()
+                                                        : tuple.get(image.generatedAt)
+                                                                .toLocalDate()))
+                        .toList();
 
         return checkLastPage(size, results);
     }
@@ -165,6 +186,45 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
         }
 
         return direction == SortDirection.DESC ? image.id.lt(imageId) : image.id.gt(imageId);
+    }
+
+    private BooleanExpression lastImageIdCondition(
+            Long imageId, SortDirection direction, SortParameter parameter) {
+        if (imageId == null) {
+            return null;
+        }
+
+        if (parameter == SortParameter.UPLOAD) {
+            return direction == SortDirection.DESC ? image.id.lt(imageId) : image.id.gt(imageId);
+        } else { // GENERATED
+            LocalDate lastGeneratedDate = getLastGeneratedDate(imageId);
+            return direction == SortDirection.DESC
+                    ? Expressions.dateTimeTemplate(LocalDate.class, "DATE({0})", image.generatedAt)
+                            .lt(lastGeneratedDate)
+                    : Expressions.dateTimeTemplate(LocalDate.class, "DATE({0})", image.generatedAt)
+                            .gt(lastGeneratedDate);
+        }
+    }
+
+    private com.querydsl.core.types.OrderSpecifier<?> getOrderByExpression(
+            SortParameter parameter, SortDirection direction) {
+        if (parameter == SortParameter.UPLOAD) {
+            return direction == SortDirection.DESC ? image.id.desc() : image.id.asc();
+        } else { // GENERATED
+            return direction == SortDirection.DESC
+                    ? image.generatedAt.desc()
+                    : image.generatedAt.asc();
+        }
+    }
+
+    private LocalDate getLastGeneratedDate(Long imageId) {
+        return queryFactory
+                .select(
+                        Expressions.dateTimeTemplate(
+                                LocalDate.class, "DATE({0})", image.generatedAt))
+                .from(image)
+                .where(image.id.eq(imageId))
+                .fetchOne();
     }
 
     private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -55,12 +55,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                         .join(eventImage.image, image)
                         .where(
                                 eventImage.event.id.eq(eventId),
-                                parameter == SortParameter.UPLOAD
-                                        ? lastImageIdCondition(lastImageId, direction)
-                                        : lastImageId != null
-                                                ? lastGeneratedAtCondition(
-                                                        getLastGeneratedAt(lastImageId), direction)
-                                                : null)
+                                lastCondition(lastImageId, direction, parameter))
                         .orderBy(getOrderByExpression(parameter, direction))
                         .limit((long) size + 1)
                         .fetch();
@@ -90,12 +85,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                         .from(image)
                         .where(
                                 image.album.id.eq(albumId),
-                                parameter == SortParameter.UPLOAD
-                                        ? lastImageIdCondition(lastImageId, direction)
-                                        : lastImageId != null
-                                                ? lastGeneratedAtCondition(
-                                                        getLastGeneratedAt(lastImageId), direction)
-                                                : null)
+                                lastCondition(lastImageId, direction, parameter))
                         .orderBy(getOrderByExpression(parameter, direction))
                         .limit((long) size + 1)
                         .fetch();
@@ -190,6 +180,17 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                 .where(image.url.in(urls))
                 .orderBy(orderExpr.asc())
                 .fetch();
+    }
+
+    private BooleanExpression lastCondition(
+            Long lastImageId, SortDirection direction, SortParameter parameter) {
+        if (parameter == SortParameter.UPLOAD) {
+            return lastImageIdCondition(lastImageId, direction);
+        } else {
+            return lastImageId != null
+                    ? lastGeneratedAtCondition(getLastGeneratedAt(lastImageId), direction)
+                    : null;
+        }
     }
 
     private BooleanExpression lastImageIdCondition(Long imageId, SortDirection direction) {

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/repository/ImageRepositoryImpl.java
@@ -55,7 +55,12 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                         .join(eventImage.image, image)
                         .where(
                                 eventImage.event.id.eq(eventId),
-                                lastImageIdCondition(lastImageId, direction, parameter))
+                                parameter == SortParameter.UPLOAD
+                                        ? lastImageIdCondition(lastImageId, direction)
+                                        : lastImageId != null
+                                                ? lastGeneratedAtCondition(
+                                                        getLastGeneratedAt(lastImageId), direction)
+                                                : null)
                         .orderBy(getOrderByExpression(parameter, direction))
                         .limit((long) size + 1)
                         .fetch();
@@ -85,7 +90,12 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                         .from(image)
                         .where(
                                 image.album.id.eq(albumId),
-                                lastImageIdCondition(lastImageId, direction, parameter))
+                                parameter == SortParameter.UPLOAD
+                                        ? lastImageIdCondition(lastImageId, direction)
+                                        : lastImageId != null
+                                                ? lastGeneratedAtCondition(
+                                                        getLastGeneratedAt(lastImageId), direction)
+                                                : null)
                         .orderBy(getOrderByExpression(parameter, direction))
                         .limit((long) size + 1)
                         .fetch();
@@ -182,22 +192,16 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
                 .fetch();
     }
 
-    private BooleanExpression lastImageIdCondition(
-            Long imageId, SortDirection direction, SortParameter parameter) {
+    private BooleanExpression lastImageIdCondition(Long imageId, SortDirection direction) {
         if (imageId == null) {
             return null;
         }
 
-        if (parameter == SortParameter.UPLOAD) {
-            return direction == SortDirection.DESC ? image.id.lt(imageId) : image.id.gt(imageId);
-        } else { // GENERATED
-            LocalDateTime lastGeneratedAt = getLastGeneratedAt(imageId);
-            return lastGeneratedAtCondition(lastGeneratedAt, direction, parameter);
-        }
+        return direction == SortDirection.DESC ? image.id.lt(imageId) : image.id.gt(imageId);
     }
 
     private BooleanExpression lastGeneratedAtCondition(
-            LocalDateTime lastGeneratedAt, SortDirection direction, SortParameter parameter) {
+            LocalDateTime lastGeneratedAt, SortDirection direction) {
         if (lastGeneratedAt == null) {
             return null;
         }
@@ -211,7 +215,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
             SortParameter parameter, SortDirection direction) {
         if (parameter == SortParameter.UPLOAD) {
             return direction == SortDirection.DESC ? image.id.desc() : image.id.asc();
-        } else { // GENERATED
+        } else { // GENERATE
             return direction == SortDirection.DESC
                     ? image.generatedAt.desc()
                     : image.generatedAt.asc();

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -24,7 +24,11 @@ public interface ImageService {
             SortDirection direction);
 
     SliceResponse<EventImageListResponse> getEventImages(
-            Long eventId, Long lastImageId, int size, SortDirection direction);
+            Long eventId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction);
 
     void deleteAlbumImage(Long albumId, AlbumImageDeleteRequest request);
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageService.java
@@ -4,6 +4,7 @@ import org.cherrypic.domain.image.dto.request.*;
 import org.cherrypic.domain.image.dto.response.*;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.global.pagination.SortParameter;
 
 public interface ImageService {
     PresignedUrlResponse createMemberProfileImageUploadUrl(ImageUploadRequest request);
@@ -16,7 +17,11 @@ public interface ImageService {
             Long albumId, AlbumImageUploadRequest request);
 
     SliceResponse<AlbumImageListResponse> getAlbumImages(
-            Long albumId, Long lastImageId, int size, SortDirection direction);
+            Long albumId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction);
 
     SliceResponse<EventImageListResponse> getEventImages(
             Long eventId, Long lastImageId, int size, SortDirection direction);

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -202,13 +202,17 @@ public class ImageServiceImpl implements ImageService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<EventImageListResponse> getEventImages(
-            Long eventId, Long lastImageId, int size, SortDirection direction) {
+            Long eventId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Event event = getEventById(eventId);
         getParticipantByMemberIdAndAlbumId(currentMember.getId(), event.getAlbum().getId());
 
         Slice<EventImageListResponse> result =
-                imageRepository.findAllByEventId(eventId, lastImageId, size, direction);
+                imageRepository.findAllByEventId(eventId, lastImageId, size, parameter, direction);
         return SliceResponse.from(result);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/image/service/ImageServiceImpl.java
@@ -28,6 +28,7 @@ import org.cherrypic.event.entity.Event;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.global.pagination.SortParameter;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
@@ -183,14 +184,18 @@ public class ImageServiceImpl implements ImageService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<AlbumImageListResponse> getAlbumImages(
-            Long albumId, Long lastImageId, int size, SortDirection direction) {
+            Long albumId,
+            Long lastImageId,
+            int size,
+            SortParameter parameter,
+            SortDirection direction) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Album album = getAlbumById(albumId);
 
         getParticipantByMemberIdAndAlbumId(currentMember.getId(), album.getId());
 
         Slice<AlbumImageListResponse> result =
-                imageRepository.findAllByAlbumId(albumId, lastImageId, size, direction);
+                imageRepository.findAllByAlbumId(albumId, lastImageId, size, parameter, direction);
         return SliceResponse.from(result);
     }
 

--- a/cherrypic-api/src/main/java/org/cherrypic/global/pagination/SortParameter.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/global/pagination/SortParameter.java
@@ -1,0 +1,6 @@
+package org.cherrypic.global.pagination;
+
+public enum SortParameter {
+    UPLOAD,
+    GENERATE
+}

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -975,20 +975,56 @@ class ImageControllerTest {
     class 이벤트_이미지_목록_조회_요청시 {
 
         @Test
-        void 정렬_조건이_ASC이면_eventImageId를_오름차순으로_응답한다() throws Exception {
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_ASC이면_eventImageId를_오름차순으로_응답한다() throws Exception {
             // given
             List<EventImageListResponse> eventImages =
                     List.of(
-                            new EventImageListResponse(1L, "testImageUrl1"),
-                            new EventImageListResponse(2L, "testImageUrl2"));
+                            new EventImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                            new EventImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
 
-            given(imageService.getEventImages(1L, null, 2, SortDirection.ASC))
+            given(imageService.getEventImages(1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(eventImages, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/1/images").param("size", "2").param("direction", "ASC"));
+                            get("/events/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].eventImageId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].eventImageId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_파라미터가_GENERATE이고_정렬_조건이_ASC이면_generatedAt을_오름차순으로_응답한다() throws Exception {
+            // given
+            List<EventImageListResponse> eventImages =
+                    List.of(
+                            new EventImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                            new EventImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
+
+            given(
+                            imageService.getEventImages(
+                                    1L, null, 2, SortParameter.GENERATE, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(eventImages, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/events/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "GENERATE")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -1000,20 +1036,58 @@ class ImageControllerTest {
         }
 
         @Test
-        void 정렬_조건이_DESC이면_eventImageId를_내림차순으로_응답한다() throws Exception {
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_DESC면_eventImageId를_내림차순으로_응답한다() throws Exception {
             // given
             List<EventImageListResponse> eventImages =
                     List.of(
-                            new EventImageListResponse(2L, "testImageUrl2"),
-                            new EventImageListResponse(1L, "testImageUrl1"));
+                            new EventImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                            new EventImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
 
-            given(imageService.getEventImages(1L, null, 2, SortDirection.DESC))
+            given(
+                            imageService.getEventImages(
+                                    1L, null, 2, SortParameter.UPLOAD, SortDirection.DESC))
                     .willReturn(new SliceResponse<>(eventImages, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/1/images").param("size", "2").param("direction", "DESC"));
+                            get("/events/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].eventImageId").value(2))
+                    .andExpect(jsonPath("$.data.content[1].eventImageId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_파라미터가_GENERATE이고_정렬_조건이_DESC면_generatedAt를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<EventImageListResponse> eventImages =
+                    List.of(
+                            new EventImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                            new EventImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+
+            given(
+                            imageService.getEventImages(
+                                    1L, null, 2, SortParameter.GENERATE, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(eventImages, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/events/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "GENERATE")
+                                    .param("direction", "DESC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -1027,15 +1101,20 @@ class ImageControllerTest {
         void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
             // given
             List<EventImageListResponse> eventImages =
-                    List.of(new EventImageListResponse(1L, "testImageUrl1"));
+                    List.of(
+                            new EventImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
 
-            given(imageService.getEventImages(1L, null, 1, SortDirection.ASC))
+            given(imageService.getEventImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(eventImages, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/1/images").param("size", "1").param("direction", "ASC"));
+                            get("/events/1/images")
+                                    .param("size", "1")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -1049,16 +1128,21 @@ class ImageControllerTest {
             // given
             List<EventImageListResponse> eventImages =
                     List.of(
-                            new EventImageListResponse(1L, "testImageUrl1"),
-                            new EventImageListResponse(2L, "testImageUrl2"));
+                            new EventImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                            new EventImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
 
-            given(imageService.getEventImages(1L, null, 1, SortDirection.ASC))
+            given(imageService.getEventImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(eventImages, false));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/1/images").param("size", "1").param("direction", "ASC"));
+                            get("/events/1/images")
+                                    .param("size", "1")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -1073,13 +1157,16 @@ class ImageControllerTest {
             // given
             List<EventImageListResponse> eventImages = List.of();
 
-            given(imageService.getEventImages(1L, null, 1, SortDirection.ASC))
+            given(imageService.getEventImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(eventImages, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/1/images").param("size", "1").param("direction", "ASC"));
+                            get("/events/1/images")
+                                    .param("size", "1")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -1091,13 +1178,16 @@ class ImageControllerTest {
         @Test
         void 이벤트가_존재하지_않을_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getEventImages(1L, null, 2, SortDirection.ASC))
+            given(imageService.getEventImages(1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willThrow(new CustomException(EventErrorCode.EVENT_NOT_FOUND));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/1/images").param("size", "2").param("direction", "ASC"));
+                            get("/events/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
@@ -1109,13 +1199,16 @@ class ImageControllerTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getEventImages(1L, null, 2, SortDirection.ASC))
+            given(imageService.getEventImages(1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/events/1/images").param("size", "2").param("direction", "ASC"));
+                            get("/events/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -20,6 +21,7 @@ import org.cherrypic.domain.tempalbum.exception.TempAlbumErrorCode;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.global.pagination.SortParameter;
 import org.cherrypic.s3.enums.FileExtension;
 import org.cherrypic.tempalbum.enums.TempAlbumType;
 import org.junit.jupiter.api.Nested;
@@ -693,20 +695,25 @@ class ImageControllerTest {
     class 앨범_이미지_목록_조회_요청시 {
 
         @Test
-        void 정렬_조건이_ASC이면_imageId를_오름차순으로_응답한다() throws Exception {
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_ASC이면_imageId를_오름차순으로_응답한다() throws Exception {
             // given
             List<AlbumImageListResponse> images =
                     List.of(
-                            new AlbumImageListResponse(1L, "testImageUrl1"),
-                            new AlbumImageListResponse(2L, "testImageUrl2"));
+                            new AlbumImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                            new AlbumImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
 
-            given(imageService.getAlbumImages(1L, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/1/images").param("size", "2").param("direction", "ASC"));
+                            get("/albums/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -717,20 +724,89 @@ class ImageControllerTest {
         }
 
         @Test
-        void 정렬_조건이_DESC이면_imageId를_내림차순으로_응답한다() throws Exception {
+        void 정렬_파라미터가_GENERATE이고_정렬_조건이_ASC이면_generatedAt을_오름차순으로_응답한다() throws Exception {
             // given
             List<AlbumImageListResponse> images =
                     List.of(
-                            new AlbumImageListResponse(2L, "testImageUrl2"),
-                            new AlbumImageListResponse(1L, "testImageUrl1"));
+                            new AlbumImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                            new AlbumImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
 
-            given(imageService.getAlbumImages(1L, null, 2, SortDirection.DESC))
+            given(
+                            imageService.getAlbumImages(
+                                    1L, null, 2, SortParameter.GENERATE, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/1/images").param("size", "2").param("direction", "DESC"));
+                            get("/albums/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "GENERATE")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].imageId").value(1))
+                    .andExpect(jsonPath("$.data.content[1].imageId").value(2))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_DESC면_imageId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<AlbumImageListResponse> images =
+                    List.of(
+                            new AlbumImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                            new AlbumImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+
+            given(
+                            imageService.getAlbumImages(
+                                    1L, null, 2, SortParameter.UPLOAD, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(images, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.content[0].imageId").value(2))
+                    .andExpect(jsonPath("$.data.content[1].imageId").value(1))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_파라미터가_GENERATE이고_정렬_조건이_DESC면_imageId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<AlbumImageListResponse> images =
+                    List.of(
+                            new AlbumImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                            new AlbumImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+
+            given(
+                            imageService.getAlbumImages(
+                                    1L, null, 2, SortParameter.GENERATE, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(images, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/albums/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "GENERATE")
+                                    .param("direction", "DESC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -744,15 +820,20 @@ class ImageControllerTest {
         void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
             // given
             List<AlbumImageListResponse> images =
-                    List.of(new AlbumImageListResponse(1L, "testImageUrl1"));
+                    List.of(
+                            new AlbumImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
 
-            given(imageService.getAlbumImages(1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/1/images").param("size", "1").param("direction", "ASC"));
+                            get("/albums/1/images")
+                                    .param("size", "1")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -766,16 +847,21 @@ class ImageControllerTest {
             // given
             List<AlbumImageListResponse> images =
                     List.of(
-                            new AlbumImageListResponse(1L, "testImageUrl1"),
-                            new AlbumImageListResponse(2L, "testImageUrl2"));
+                            new AlbumImageListResponse(
+                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                            new AlbumImageListResponse(
+                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
 
-            given(imageService.getAlbumImages(1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, false));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/1/images").param("size", "1").param("direction", "ASC"));
+                            get("/albums/1/images")
+                                    .param("size", "1")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -790,13 +876,16 @@ class ImageControllerTest {
             // given
             List<AlbumImageListResponse> images = List.of();
 
-            given(imageService.getAlbumImages(1L, null, 1, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/1/images").param("size", "1").param("direction", "ASC"));
+                            get("/albums/1/images")
+                                    .param("size", "1")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -808,13 +897,18 @@ class ImageControllerTest {
         @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getAlbumImages(999L, null, 2, SortDirection.ASC))
+            given(
+                            imageService.getAlbumImages(
+                                    999L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willThrow(new CustomException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/999/images").param("size", "2").param("direction", "ASC"));
+                            get("/albums/999/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
@@ -826,13 +920,16 @@ class ImageControllerTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            given(imageService.getAlbumImages(1L, null, 2, SortDirection.ASC))
+            given(imageService.getAlbumImages(1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willThrow(new CustomException(AlbumErrorCode.NOT_ALBUM_PARTICIPANT));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            get("/albums/1/images").param("size", "2").param("direction", "ASC"));
+                            get("/albums/1/images")
+                                    .param("size", "2")
+                                    .param("parameter", "UPLOAD")
+                                    .param("direction", "ASC"));
 
             perform.andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false))

--- a/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/controller/ImageControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.cherrypic.domain.album.exception.AlbumErrorCode;
@@ -700,9 +699,9 @@ class ImageControllerTest {
             List<AlbumImageListResponse> images =
                     List.of(
                             new AlbumImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)),
                             new AlbumImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)));
 
             given(imageService.getAlbumImages(1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
@@ -729,9 +728,9 @@ class ImageControllerTest {
             List<AlbumImageListResponse> images =
                     List.of(
                             new AlbumImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)),
                             new AlbumImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)));
 
             given(
                             imageService.getAlbumImages(
@@ -760,9 +759,9 @@ class ImageControllerTest {
             List<AlbumImageListResponse> images =
                     List.of(
                             new AlbumImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)),
                             new AlbumImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)));
 
             given(
                             imageService.getAlbumImages(
@@ -791,9 +790,9 @@ class ImageControllerTest {
             List<AlbumImageListResponse> images =
                     List.of(
                             new AlbumImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)),
                             new AlbumImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)));
 
             given(
                             imageService.getAlbumImages(
@@ -822,7 +821,7 @@ class ImageControllerTest {
             List<AlbumImageListResponse> images =
                     List.of(
                             new AlbumImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)));
 
             given(imageService.getAlbumImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, true));
@@ -848,9 +847,9 @@ class ImageControllerTest {
             List<AlbumImageListResponse> images =
                     List.of(
                             new AlbumImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)),
                             new AlbumImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)));
 
             given(imageService.getAlbumImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(images, false));
@@ -980,9 +979,9 @@ class ImageControllerTest {
             List<EventImageListResponse> eventImages =
                     List.of(
                             new EventImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)),
                             new EventImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)));
 
             given(imageService.getEventImages(1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(eventImages, true));
@@ -1009,9 +1008,9 @@ class ImageControllerTest {
             List<EventImageListResponse> eventImages =
                     List.of(
                             new EventImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)),
                             new EventImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)));
 
             given(
                             imageService.getEventImages(
@@ -1041,9 +1040,9 @@ class ImageControllerTest {
             List<EventImageListResponse> eventImages =
                     List.of(
                             new EventImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)),
                             new EventImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)));
 
             given(
                             imageService.getEventImages(
@@ -1072,9 +1071,9 @@ class ImageControllerTest {
             List<EventImageListResponse> eventImages =
                     List.of(
                             new EventImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)),
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)),
                             new EventImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)));
 
             given(
                             imageService.getEventImages(
@@ -1103,7 +1102,7 @@ class ImageControllerTest {
             List<EventImageListResponse> eventImages =
                     List.of(
                             new EventImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)));
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)));
 
             given(imageService.getEventImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(eventImages, true));
@@ -1129,9 +1128,9 @@ class ImageControllerTest {
             List<EventImageListResponse> eventImages =
                     List.of(
                             new EventImageListResponse(
-                                    1L, "testImageUrl1", LocalDate.of(2025, 1, 1)),
+                                    1L, "testImageUrl1", LocalDateTime.of(2025, 1, 1, 0, 0)),
                             new EventImageListResponse(
-                                    2L, "testImageUrl2", LocalDate.of(2025, 1, 2)));
+                                    2L, "testImageUrl2", LocalDateTime.of(2025, 1, 2, 0, 0)));
 
             given(imageService.getEventImages(1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(eventImages, false));

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -33,6 +33,7 @@ import org.cherrypic.event.entity.EventImage;
 import org.cherrypic.exception.CustomException;
 import org.cherrypic.global.pagination.SliceResponse;
 import org.cherrypic.global.pagination.SortDirection;
+import org.cherrypic.global.pagination.SortParameter;
 import org.cherrypic.global.util.MemberUtil;
 import org.cherrypic.image.entity.Image;
 import org.cherrypic.member.entity.Member;
@@ -543,11 +544,26 @@ class ImageServiceTest extends IntegrationTest {
             eventRepository.save(event);
 
             Image image1 =
-                    Image.createImage(album1, 1L, "testUrl", LocalDateTime.now(), BigDecimal.ZERO);
+                    Image.createImage(
+                            album1,
+                            1L,
+                            "testUrl",
+                            LocalDateTime.of(2025, 1, 3, 0, 0),
+                            BigDecimal.ZERO);
             Image image2 =
-                    Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now(), BigDecimal.ZERO);
+                    Image.createImage(
+                            album1,
+                            1L,
+                            "testUrl2",
+                            LocalDateTime.of(2025, 1, 2, 0, 0),
+                            BigDecimal.ZERO);
             Image image3 =
-                    Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now(), BigDecimal.ZERO);
+                    Image.createImage(
+                            album1,
+                            1L,
+                            "testUrl2",
+                            LocalDateTime.of(2025, 1, 1, 0, 0),
+                            BigDecimal.ZERO);
             imageRepository.saveAll(List.of(image1, image2, image3));
 
             EventImage eventImage = EventImage.createEventImage(event, image1);
@@ -555,30 +571,54 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 정렬_조건이_ASC이면_imageId를_오름차순으로_조회한다() {
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_ASC이면_imageId를_오름차순으로_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, null, 3, SortDirection.ASC);
+                    imageService.getAlbumImages(
+                            1L, null, 3, SortParameter.UPLOAD, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(1L, 2L, 3L);
         }
 
         @Test
-        void 정렬_조건이_DESC면_imageId를_내림차순으로_조회한다() {
+        void 정렬_파라미터가_GENERATE고_정렬_조건이_ASC이면_generatedAt을_오름차순으로_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, null, 3, SortDirection.DESC);
+                    imageService.getAlbumImages(
+                            1L, null, 3, SortParameter.GENERATE, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(3L, 2L, 1L);
         }
 
         @Test
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_DESC면_imageId를_내림차순으로_조회한다() {
+            // when
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(
+                            1L, null, 3, SortParameter.UPLOAD, SortDirection.DESC);
+
+            // then
+            assertThat(response.content()).extracting("imageId").containsExactly(3L, 2L, 1L);
+        }
+
+        @Test
+        void 정렬_파라미터가_GENERATE고_정렬_조건이_DESC면_generatedAt을_내림차순으로_조회한다() {
+            // when
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(
+                            1L, null, 3, SortParameter.GENERATE, SortDirection.DESC);
+
+            // then
+            assertThat(response.content()).extracting("imageId").containsExactly(1L, 2L, 3L);
+        }
+
+        @Test
         void imageId를_입력하면_다음_Image_부터_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, 1L, 2, SortDirection.ASC);
+                    imageService.getAlbumImages(1L, 1L, 2, SortParameter.UPLOAD, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("imageId").containsExactly(2L, 3L);
@@ -588,7 +628,8 @@ class ImageServiceTest extends IntegrationTest {
         void 앨범에_이미지가_없는_경우_빈_리스트를_조회한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(2L, null, 3, SortDirection.ASC);
+                    imageService.getAlbumImages(
+                            2L, null, 3, SortParameter.UPLOAD, SortDirection.ASC);
 
             // when & then
             Assertions.assertAll(
@@ -600,7 +641,8 @@ class ImageServiceTest extends IntegrationTest {
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
             SliceResponse<AlbumImageListResponse> response =
-                    imageService.getAlbumImages(1L, null, 3, SortDirection.ASC);
+                    imageService.getAlbumImages(
+                            1L, null, 3, SortParameter.UPLOAD, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
@@ -611,7 +653,10 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getAlbumImages(999L, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () ->
+                                    imageService.getAlbumImages(
+                                            999L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.ALBUM_NOT_FOUND.getMessage());
         }
@@ -619,7 +664,10 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getAlbumImages(3L, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () ->
+                                    imageService.getAlbumImages(
+                                            3L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -589,7 +589,12 @@ class ImageServiceTest extends IntegrationTest {
                             1L, null, 3, SortParameter.GENERATE, SortDirection.ASC);
 
             // then
-            assertThat(response.content()).extracting("imageId").containsExactly(3L, 2L, 1L);
+            assertThat(response.content())
+                    .extracting("date")
+                    .containsExactly(
+                            LocalDateTime.of(2025, 1, 1, 0, 0),
+                            LocalDateTime.of(2025, 1, 2, 0, 0),
+                            LocalDateTime.of(2025, 1, 3, 0, 0));
         }
 
         @Test
@@ -611,7 +616,12 @@ class ImageServiceTest extends IntegrationTest {
                             1L, null, 3, SortParameter.GENERATE, SortDirection.DESC);
 
             // then
-            assertThat(response.content()).extracting("imageId").containsExactly(1L, 2L, 3L);
+            assertThat(response.content())
+                    .extracting("date")
+                    .containsExactly(
+                            LocalDateTime.of(2025, 1, 3, 0, 0),
+                            LocalDateTime.of(2025, 1, 2, 0, 0),
+                            LocalDateTime.of(2025, 1, 1, 0, 0));
         }
 
         @Test
@@ -739,7 +749,10 @@ class ImageServiceTest extends IntegrationTest {
                             1L, null, 2, SortParameter.GENERATE, SortDirection.ASC);
 
             // then
-            assertThat(response.content()).extracting("eventImageId").containsExactly(2L, 1L);
+            assertThat(response.content())
+                    .extracting("date")
+                    .containsExactly(
+                            LocalDateTime.of(2025, 1, 1, 0, 0), LocalDateTime.of(2025, 1, 2, 0, 0));
         }
 
         @Test
@@ -761,7 +774,10 @@ class ImageServiceTest extends IntegrationTest {
                             1L, null, 2, SortParameter.GENERATE, SortDirection.DESC);
 
             // then
-            assertThat(response.content()).extracting("eventImageId").containsExactly(1L, 2L);
+            assertThat(response.content())
+                    .extracting("date")
+                    .containsExactly(
+                            LocalDateTime.of(2025, 1, 2, 0, 0), LocalDateTime.of(2025, 1, 1, 0, 0));
         }
 
         @Test

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -700,9 +700,19 @@ class ImageServiceTest extends IntegrationTest {
             eventRepository.saveAll(List.of(event1, event2, event3));
 
             Image image1 =
-                    Image.createImage(album1, 1L, "testUrl", LocalDateTime.now(), BigDecimal.ZERO);
+                    Image.createImage(
+                            album1,
+                            1L,
+                            "testUrl",
+                            LocalDateTime.of(2025, 1, 2, 0, 0),
+                            BigDecimal.ZERO);
             Image image2 =
-                    Image.createImage(album1, 1L, "testUrl2", LocalDateTime.now(), BigDecimal.ZERO);
+                    Image.createImage(
+                            album1,
+                            1L,
+                            "testUrl2",
+                            LocalDateTime.of(2025, 1, 1, 0, 0),
+                            BigDecimal.ZERO);
             imageRepository.saveAll(List.of(image1, image2));
 
             EventImage eventImage1 = EventImage.createEventImage(event1, image1);
@@ -711,30 +721,54 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 정렬_조건이_ASC이면_eventImageId를_오름차순으로_조회한다() {
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_ASC이면_eventImageId를_오름차순으로_조회한다() {
             // when
             SliceResponse<EventImageListResponse> response =
-                    imageService.getEventImages(1L, null, 2, SortDirection.ASC);
+                    imageService.getEventImages(
+                            1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("eventImageId").containsExactly(1L, 2L);
         }
 
         @Test
-        void 정렬_조건이_DESC면_eventImageId를_내림차순으로_조회한다() {
+        void 정렬_파라미터가_GENERATE이고_정렬_조건이_ASC이면_genaratedAt를_오름차순으로_조회한다() {
             // when
             SliceResponse<EventImageListResponse> response =
-                    imageService.getEventImages(1L, null, 2, SortDirection.DESC);
+                    imageService.getEventImages(
+                            1L, null, 2, SortParameter.GENERATE, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("eventImageId").containsExactly(2L, 1L);
         }
 
         @Test
+        void 정렬_파라미터가_UPLOAD이고_정렬_조건이_DESC면_eventImageId를_내림차순으로_조회한다() {
+            // when
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(
+                            1L, null, 2, SortParameter.UPLOAD, SortDirection.DESC);
+
+            // then
+            assertThat(response.content()).extracting("eventImageId").containsExactly(2L, 1L);
+        }
+
+        @Test
+        void 정렬_파라미터가_GENERATE이고_정렬_조건이_DESC면_generatedAt를_내림차순으로_조회한다() {
+            // when
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(
+                            1L, null, 2, SortParameter.GENERATE, SortDirection.DESC);
+
+            // then
+            assertThat(response.content()).extracting("eventImageId").containsExactly(1L, 2L);
+        }
+
+        @Test
         void imageId를_입력하면_다음_eventImage_부터_조회한다() {
             // when
             SliceResponse<EventImageListResponse> response =
-                    imageService.getEventImages(1L, 1L, 1, SortDirection.ASC);
+                    imageService.getEventImages(1L, 1L, 1, SortParameter.UPLOAD, SortDirection.ASC);
 
             // then
             assertThat(response.content()).extracting("eventImageId").containsExactly(2L);
@@ -744,7 +778,8 @@ class ImageServiceTest extends IntegrationTest {
         void 이벤트에_이미지가_없는_경우_빈_리스트를_조회한다() {
             // when
             SliceResponse<EventImageListResponse> response =
-                    imageService.getEventImages(2L, null, 2, SortDirection.ASC);
+                    imageService.getEventImages(
+                            2L, null, 2, SortParameter.UPLOAD, SortDirection.ASC);
 
             // when & then
             Assertions.assertAll(
@@ -756,7 +791,8 @@ class ImageServiceTest extends IntegrationTest {
         void 마지막_페이지인_경우_isLast를_true로_반환한다() {
             // when
             SliceResponse<EventImageListResponse> response =
-                    imageService.getEventImages(1L, null, 2, SortDirection.ASC);
+                    imageService.getEventImages(
+                            1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC);
 
             // then
             Assertions.assertAll(
@@ -767,7 +803,10 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 앨범_참가자가_아닌_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getEventImages(3L, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () ->
+                                    imageService.getEventImages(
+                                            3L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(AlbumErrorCode.NOT_ALBUM_PARTICIPANT.getMessage());
         }
@@ -775,7 +814,10 @@ class ImageServiceTest extends IntegrationTest {
         @Test
         void 이벤트가_존재하지_않을_경우_예외가_발생한다() {
             // when & then
-            assertThatThrownBy(() -> imageService.getEventImages(999L, null, 2, SortDirection.ASC))
+            assertThatThrownBy(
+                            () ->
+                                    imageService.getEventImages(
+                                            999L, null, 2, SortParameter.UPLOAD, SortDirection.ASC))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(EventErrorCode.EVENT_NOT_FOUND.getMessage());
         }

--- a/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/image/service/ImageServiceTest.java
@@ -661,6 +661,19 @@ class ImageServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
+            // when
+            SliceResponse<AlbumImageListResponse> response =
+                    imageService.getAlbumImages(
+                            1L, null, 2, SortParameter.UPLOAD, SortDirection.ASC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(2),
+                    () -> assertThat(response.isLast()).isFalse());
+        }
+
+        @Test
         void 앨범이_존재하지_않을_경우_예외가_발생한다() {
             // when & then
             assertThatThrownBy(
@@ -814,6 +827,19 @@ class ImageServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(response.content().size()).isEqualTo(2),
                     () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
+            // when
+            SliceResponse<EventImageListResponse> response =
+                    imageService.getEventImages(
+                            1L, null, 1, SortParameter.UPLOAD, SortDirection.ASC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(1),
+                    () -> assertThat(response.isLast()).isFalse());
         }
 
         @Test

--- a/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/image/entity/Image.java
@@ -30,7 +30,7 @@ public class Image extends BaseTimeEntity {
 
     @NotNull private BigDecimal capacityMb;
 
-    private LocalDateTime generatedAt;
+    @NotNull private LocalDateTime generatedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Image(

--- a/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
+++ b/cherrypic-domain/src/main/resources/db/migration/V1__init.sql
@@ -95,7 +95,7 @@ CREATE TABLE image (
                        member_id BIGINT NOT NULL,
                        album_id BIGINT NOT NULL,
                        url VARCHAR(255) NOT NULL,
-                       generated_at DATETIME,
+                       generated_at DATETIME(6) NOT NULL,
                        capacity_mb DECIMAL(9,2) NOT NULL,
                        created_at DATETIME(6) NOT NULL,
                        updated_at DATETIME(6) NOT NULL,


### PR DESCRIPTION
## 🌱 관련 이슈
- close #228 

---
## 📌 작업 내용 및 특이사항
- 앨범 이미지 목록 조회 & 이벤트 이미지 목록 조회에 생성일 기반 필터를 추가했습니다.
- 추가적으로, 유관 날짜를 함께 반환합니다.

---
## 📚 참고사항
- 유관 피그마
<img width="211" height="561" alt="스크린샷 2025-10-02 오전 5 33 17" src="https://github.com/user-attachments/assets/26bc8a3d-b645-4d05-a0bc-f5b83a7e0258" />
