### PR TITLE
feat: 임시 앨범 수정 API 구현

### DIFF
--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.tempalbum.dto.request.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.dto.request.TempAlbumUpdateRequest;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumCreateResponse;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumListResponse;
 import org.cherrypic.domain.tempalbum.service.TempAlbumService;
@@ -32,5 +33,13 @@ public class TempAlbumController {
     @Operation(summary = "임시 앨범 목록 조회", description = "회원이 가지고 있는 임시 앨범을 조회합니다.")
     public TempAlbumListResponse tempAlbumsGet() {
         return tempAlbumService.getTempAlbums();
+    }
+
+    @PatchMapping
+    @Operation(summary = "임시 앨범 수정", description = "임시 앨범을 수정합니다.")
+    public ResponseEntity<Void> tempAlbumUpdate(
+            @Valid @RequestBody TempAlbumUpdateRequest request) {
+        tempAlbumService.updateTempAlbum(request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/controller/TempAlbumController.java
@@ -35,11 +35,11 @@ public class TempAlbumController {
         return tempAlbumService.getTempAlbums();
     }
 
-    @PatchMapping
+    @PatchMapping("/{tempAlbumId}")
     @Operation(summary = "임시 앨범 수정", description = "임시 앨범을 수정합니다.")
     public ResponseEntity<Void> tempAlbumUpdate(
-            @Valid @RequestBody TempAlbumUpdateRequest request) {
-        tempAlbumService.updateTempAlbum(request);
+            @PathVariable Long tempAlbumId, @Valid @RequestBody TempAlbumUpdateRequest request) {
+        tempAlbumService.updateTempAlbum(tempAlbumId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/request/TempAlbumUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/request/TempAlbumUpdateRequest.java
@@ -2,12 +2,9 @@ package org.cherrypic.domain.tempalbum.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record TempAlbumUpdateRequest(
-        @NotNull(message = "임시 앨범 ID는 비워둘 수 없습니다.") @Schema(description = "임시 앨범 ID", example = "1")
-                Long tempAlbumId,
         @NotBlank(message = "임시 앨범 이름은 비워둘 수 없습니다.")
                 @Schema(description = "임시 앨범 이름", example = "회사 공유용")
                 @Size(max = 20, message = "임시 앨범 이름은 최대 20자까지 가능합니다.")

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/request/TempAlbumUpdateRequest.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/dto/request/TempAlbumUpdateRequest.java
@@ -1,0 +1,15 @@
+package org.cherrypic.domain.tempalbum.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record TempAlbumUpdateRequest(
+        @NotNull(message = "임시 앨범 ID는 비워둘 수 없습니다.") @Schema(description = "임시 앨범 ID", example = "1")
+                Long tempAlbumId,
+        @NotBlank(message = "임시 앨범 이름은 비워둘 수 없습니다.")
+                @Schema(description = "임시 앨범 이름", example = "회사 공유용")
+                @Size(max = 20, message = "임시 앨범 이름은 최대 20자까지 가능합니다.")
+                String title,
+        @Schema(description = "임시 앨범 Web Url", example = "https://example.com") String webUrl) {}

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
@@ -1,6 +1,7 @@
 package org.cherrypic.domain.tempalbum.service;
 
 import org.cherrypic.domain.tempalbum.dto.request.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.dto.request.TempAlbumUpdateRequest;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumCreateResponse;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumListResponse;
 
@@ -9,4 +10,6 @@ public interface TempAlbumService {
     TempAlbumCreateResponse createTempAlbum(TempAlbumCreateRequest request);
 
     TempAlbumListResponse getTempAlbums();
+
+    void updateTempAlbum(TempAlbumUpdateRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumService.java
@@ -11,5 +11,5 @@ public interface TempAlbumService {
 
     TempAlbumListResponse getTempAlbums();
 
-    void updateTempAlbum(TempAlbumUpdateRequest request);
+    void updateTempAlbum(Long tempAlbumId, TempAlbumUpdateRequest request);
 }

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
@@ -49,9 +49,9 @@ public class TempAlbumServiceImpl implements TempAlbumService {
 
     @Override
     @Transactional
-    public void updateTempAlbum(TempAlbumUpdateRequest request) {
+    public void updateTempAlbum(Long tempAlbumId, TempAlbumUpdateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        final TempAlbum tempAlbum = getTempAlbumById(request.tempAlbumId());
+        final TempAlbum tempAlbum = getTempAlbumById(tempAlbumId);
 
         validateTempAlbumOwner(tempAlbum, currentMember.getId());
 

--- a/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
+++ b/cherrypic-api/src/main/java/org/cherrypic/domain/tempalbum/service/TempAlbumServiceImpl.java
@@ -1,8 +1,10 @@
 package org.cherrypic.domain.tempalbum.service;
 
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.cherrypic.domain.tempalbum.dto.request.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.dto.request.TempAlbumUpdateRequest;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumCreateResponse;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumListResponse;
 import org.cherrypic.domain.tempalbum.exception.TempAlbumErrorCode;
@@ -45,10 +47,33 @@ public class TempAlbumServiceImpl implements TempAlbumService {
         return TempAlbumListResponse.from(tempAlbums);
     }
 
+    @Override
+    @Transactional
+    public void updateTempAlbum(TempAlbumUpdateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final TempAlbum tempAlbum = getTempAlbumById(request.tempAlbumId());
+
+        validateTempAlbumOwner(tempAlbum, currentMember.getId());
+
+        tempAlbum.updateTempAlbum(request.title(), request.webUrl());
+    }
+
     private void validateTempAlbumCreateLimit(Member member) {
         long count = tempAlbumRepository.countByMemberId(member.getId());
         if (count >= 5) {
             throw new CustomException(TempAlbumErrorCode.CREATE_OVER_LIMIT);
         }
+    }
+
+    private void validateTempAlbumOwner(TempAlbum tempAlbum, Long memberId) {
+        if (!Objects.equals(tempAlbum.getId(), memberId)) {
+            throw new CustomException(TempAlbumErrorCode.NOT_TEMP_ALBUM_OWNER);
+        }
+    }
+
+    private TempAlbum getTempAlbumById(Long tempAlbumId) {
+        return tempAlbumRepository
+                .findById(tempAlbumId)
+                .orElseThrow(() -> new CustomException(TempAlbumErrorCode.TEMP_ALBUM_NOT_FOUND));
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/controller/TempAlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/controller/TempAlbumControllerTest.java
@@ -154,15 +154,14 @@ class TempAlbumControllerTest {
         @Test
         void 유효한_요청이면_임시_앨범을_수정한다() throws Exception {
             // given
-            TempAlbumUpdateRequest request =
-                    new TempAlbumUpdateRequest(1L, "testTitle", "testWebUrl");
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest("testTitle", "testWebUrl");
 
-            willDoNothing().given(tempAlbumService).updateTempAlbum(request);
+            willDoNothing().given(tempAlbumService).updateTempAlbum(1L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/temp-albums")
+                            patch("/temp-albums/1")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -174,17 +173,16 @@ class TempAlbumControllerTest {
         @Test
         void 임시_앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
             // given
-            TempAlbumUpdateRequest request =
-                    new TempAlbumUpdateRequest(999L, "testTitle", "testWebUrl");
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest("testTitle", "testWebUrl");
 
             willThrow(new CustomException(TempAlbumErrorCode.TEMP_ALBUM_NOT_FOUND))
                     .given(tempAlbumService)
-                    .updateTempAlbum(request);
+                    .updateTempAlbum(999L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/temp-albums")
+                            patch("/temp-albums/999")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -196,17 +194,16 @@ class TempAlbumControllerTest {
         @Test
         void 임시_앨범_생성자가_아닌_경우_예외가_발생한다() throws Exception {
             // given
-            TempAlbumUpdateRequest request =
-                    new TempAlbumUpdateRequest(2L, "testTitle", "testWebUrl");
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest("testTitle", "testWebUrl");
 
             willThrow(new CustomException(TempAlbumErrorCode.NOT_TEMP_ALBUM_OWNER))
                     .given(tempAlbumService)
-                    .updateTempAlbum(request);
+                    .updateTempAlbum(2L, request);
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/temp-albums")
+                            patch("/temp-albums/2")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -215,38 +212,18 @@ class TempAlbumControllerTest {
                     .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()));
         }
 
-        @Test
-        void 임시_앨범_ID를_비워두면_예외가_발생한다() throws Exception {
-            // given
-            TempAlbumUpdateRequest request =
-                    new TempAlbumUpdateRequest(null, "testTitle", "testUrl");
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            patch("/temp-albums")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
-                    .andExpect(jsonPath("$.data.message").value("임시 앨범 ID는 비워둘 수 없습니다."));
-        }
-
         @ParameterizedTest
         @NullSource
         @EmptySource
         @ValueSource(strings = {" "})
         void 임시_앨범_이름이_null_또는_공백이면_예외가_발생한다(String name) throws Exception {
             // given
-            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest(1L, name, "testUrl");
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest(name, "testUrl");
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            patch("/temp-albums")
+                            patch("/temp-albums/1")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/controller/TempAlbumControllerTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/controller/TempAlbumControllerTest.java
@@ -1,8 +1,7 @@
 package org.cherrypic.tempalbum.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,6 +11,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.cherrypic.domain.tempalbum.controller.TempAlbumController;
 import org.cherrypic.domain.tempalbum.dto.request.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.dto.request.TempAlbumUpdateRequest;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumCreateResponse;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumListResponse;
 import org.cherrypic.domain.tempalbum.exception.TempAlbumErrorCode;
@@ -20,6 +20,10 @@ import org.cherrypic.exception.CustomException;
 import org.cherrypic.tempalbum.enums.TempAlbumType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -141,6 +145,116 @@ class TempAlbumControllerTest {
                     .andExpect(jsonPath("$.data.content[0].tempAlbumId").value(1))
                     .andExpect(jsonPath("$.data.content[1].tempAlbumId").value(2))
                     .andExpect(jsonPath("$.data.content[2].tempAlbumId").value(3));
+        }
+    }
+
+    @Nested
+    class 임시_앨범_수정_요청_시 {
+
+        @Test
+        void 유효한_요청이면_임시_앨범을_수정한다() throws Exception {
+            // given
+            TempAlbumUpdateRequest request =
+                    new TempAlbumUpdateRequest(1L, "testTitle", "testWebUrl");
+
+            willDoNothing().given(tempAlbumService).updateTempAlbum(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/temp-albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNoContent())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()));
+        }
+
+        @Test
+        void 임시_앨범이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumUpdateRequest request =
+                    new TempAlbumUpdateRequest(999L, "testTitle", "testWebUrl");
+
+            willThrow(new CustomException(TempAlbumErrorCode.TEMP_ALBUM_NOT_FOUND))
+                    .given(tempAlbumService)
+                    .updateTempAlbum(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/temp-albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+        }
+
+        @Test
+        void 임시_앨범_생성자가_아닌_경우_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumUpdateRequest request =
+                    new TempAlbumUpdateRequest(2L, "testTitle", "testWebUrl");
+
+            willThrow(new CustomException(TempAlbumErrorCode.NOT_TEMP_ALBUM_OWNER))
+                    .given(tempAlbumService)
+                    .updateTempAlbum(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/temp-albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()));
+        }
+
+        @Test
+        void 임시_앨범_ID를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            TempAlbumUpdateRequest request =
+                    new TempAlbumUpdateRequest(null, "testTitle", "testUrl");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/temp-albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("임시 앨범 ID는 비워둘 수 없습니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 임시_앨범_이름이_null_또는_공백이면_예외가_발생한다(String name) throws Exception {
+            // given
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest(1L, name, "testUrl");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/temp-albums")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.data.code").value("MethodArgumentNotValidException"))
+                    .andExpect(jsonPath("$.data.message").value("임시 앨범 이름은 비워둘 수 없습니다."));
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
@@ -170,6 +170,18 @@ public class TempAlbumServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 임시_앨범이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            TempAlbumUpdateRequest request =
+                    new TempAlbumUpdateRequest(999L, "changedTitle", "testUrl");
+
+            // when & then
+            assertThatThrownBy(() -> tempAlbumService.updateTempAlbum(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(TempAlbumErrorCode.TEMP_ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
         void 임시_앨범_생성자가_아닌_경우_예외가_발생한다() {
             // given
             TempAlbumUpdateRequest request =

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
@@ -2,6 +2,7 @@ package org.cherrypic.tempalbum.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.cherrypic.member.entity.QMember.member;
 import static org.mockito.BDDMockito.given;
 
 import java.math.BigDecimal;
@@ -10,6 +11,7 @@ import java.util.List;
 import org.cherrypic.IntegrationTest;
 import org.cherrypic.domain.member.repository.MemberRepository;
 import org.cherrypic.domain.tempalbum.dto.request.TempAlbumCreateRequest;
+import org.cherrypic.domain.tempalbum.dto.request.TempAlbumUpdateRequest;
 import org.cherrypic.domain.tempalbum.dto.response.TempAlbumListResponse;
 import org.cherrypic.domain.tempalbum.exception.TempAlbumErrorCode;
 import org.cherrypic.domain.tempalbum.repository.TempAlbumRepository;
@@ -125,6 +127,58 @@ public class TempAlbumServiceTest extends IntegrationTest {
                     () -> assertThat(response.content().get(1).title()).isEqualTo("testTitle2"),
                     () -> assertThat(response.content().get(2).tempAlbumId()).isEqualTo(1L),
                     () -> assertThat(response.content().get(2).title()).isEqualTo("testTitle1"));
+        }
+    }
+
+    @Nested
+    class 임시_앨범을_수정할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname1",
+                            "testProfileImageUrl1");
+            Member member2 =
+                    Member.createMember(
+                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                            "testNickname2",
+                            "testProfileImageUrl2");
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            TempAlbum tempAlbum1 = TempAlbum.createTempAlbum(member1, "testTitle1");
+            TempAlbum tempAlbum2 = TempAlbum.createTempAlbum(member2, "testTitle2");
+            tempAlbumRepository.saveAll(List.of(tempAlbum1, tempAlbum2));
+        }
+
+        @Test
+        void 유효한_요청이면_앨범_정보를_수정한다() {
+            // given
+            TempAlbumUpdateRequest request =
+                    new TempAlbumUpdateRequest(1L, "changedTitle", "testUrl");
+
+            // when
+            tempAlbumService.updateTempAlbum(request);
+
+            // then
+            TempAlbum tempAlbum = tempAlbumRepository.findById(1L).orElseThrow();
+            assertThat(tempAlbum)
+                    .extracting("title", "webUrl")
+                    .containsExactly("changedTitle", "testUrl");
+        }
+
+        @Test
+        void 임시_앨범_생성자가_아닌_경우_예외가_발생한다() {
+            // given
+            TempAlbumUpdateRequest request =
+                    new TempAlbumUpdateRequest(2L, "changedTitle", "testUrl");
+
+            // when & then
+            assertThatThrownBy(() -> tempAlbumService.updateTempAlbum(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(TempAlbumErrorCode.NOT_TEMP_ALBUM_OWNER.getMessage());
         }
     }
 }

--- a/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
+++ b/cherrypic-api/src/test/java/org/cherrypic/tempalbum/service/TempAlbumServiceTest.java
@@ -156,11 +156,10 @@ public class TempAlbumServiceTest extends IntegrationTest {
         @Test
         void 유효한_요청이면_앨범_정보를_수정한다() {
             // given
-            TempAlbumUpdateRequest request =
-                    new TempAlbumUpdateRequest(1L, "changedTitle", "testUrl");
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest("changedTitle", "testUrl");
 
             // when
-            tempAlbumService.updateTempAlbum(request);
+            tempAlbumService.updateTempAlbum(1L, request);
 
             // then
             TempAlbum tempAlbum = tempAlbumRepository.findById(1L).orElseThrow();
@@ -172,11 +171,10 @@ public class TempAlbumServiceTest extends IntegrationTest {
         @Test
         void 임시_앨범이_존재하지_않는_경우_예외가_발생한다() {
             // given
-            TempAlbumUpdateRequest request =
-                    new TempAlbumUpdateRequest(999L, "changedTitle", "testUrl");
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest("changedTitle", "testUrl");
 
             // when & then
-            assertThatThrownBy(() -> tempAlbumService.updateTempAlbum(request))
+            assertThatThrownBy(() -> tempAlbumService.updateTempAlbum(999L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(TempAlbumErrorCode.TEMP_ALBUM_NOT_FOUND.getMessage());
         }
@@ -184,11 +182,10 @@ public class TempAlbumServiceTest extends IntegrationTest {
         @Test
         void 임시_앨범_생성자가_아닌_경우_예외가_발생한다() {
             // given
-            TempAlbumUpdateRequest request =
-                    new TempAlbumUpdateRequest(2L, "changedTitle", "testUrl");
+            TempAlbumUpdateRequest request = new TempAlbumUpdateRequest("changedTitle", "testUrl");
 
             // when & then
-            assertThatThrownBy(() -> tempAlbumService.updateTempAlbum(request))
+            assertThatThrownBy(() -> tempAlbumService.updateTempAlbum(2L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(TempAlbumErrorCode.NOT_TEMP_ALBUM_OWNER.getMessage());
         }

--- a/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbum.java
+++ b/cherrypic-domain/src/main/java/org/cherrypic/tempalbum/entity/TempAlbum.java
@@ -81,4 +81,9 @@ public class TempAlbum extends BaseTimeEntity {
         }
         this.capacityMb = capacityMb.subtract(decimal);
     }
+
+    public void updateTempAlbum(String title, String webUrl) {
+        this.title = title;
+        this.webUrl = webUrl;
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #233 

---
## 📌 작업 내용 및 특이사항
- 임시 앨범 수정 API를 구현했습니다
- 이름과 webUrl을 수정할 수 있고, webUrl을 수정하는 것은 강제가 아닙니다.
- 사진이 없는 임시 앨범일 경우 아직 webUrl을 가지지 않을 수도 있다고 가정했습니다.